### PR TITLE
Fix missing shutil import in assets service

### DIFF
--- a/app/services/assets.py
+++ b/app/services/assets.py
@@ -1,4 +1,4 @@
-import os, io, re, pathlib
+import os, io, re, pathlib, shutil
 from typing import Optional
 from PIL import Image
 from fastapi import UploadFile, HTTPException


### PR DESCRIPTION
## Summary
- import shutil in the assets service so poster cleanup can remove directories without crashing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de98ce2dd48330a29425752e2ea69f