### PR TITLE
Add logging configuration helper and instrument asset/import flows

### DIFF
--- a/app/logging_config.py
+++ b/app/logging_config.py
@@ -1,0 +1,34 @@
+"""Logging configuration helper for KAM."""
+import logging
+import os
+import sys
+from typing import Optional
+
+DEFAULT_LEVEL = "INFO"
+ENV_LEVEL = "KAM_LOG_LEVEL"
+
+
+def _resolve_level(name: Optional[str]) -> int:
+    """Return a logging level from an environment-provided name."""
+    if not name:
+        return logging.getLevelName(DEFAULT_LEVEL)
+    normalized = name.strip().upper()
+    level = logging.getLevelName(normalized)
+    if isinstance(level, int):
+        return level
+    return logging.getLevelName(DEFAULT_LEVEL)
+
+
+def configure_logging() -> None:
+    """Configure application-wide logging based on environment variables."""
+    level = _resolve_level(os.getenv(ENV_LEVEL))
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+        handlers=[logging.StreamHandler(sys.stdout)],
+        force=True,
+    )
+
+
+__all__ = ["configure_logging"]

--- a/app/main.py
+++ b/app/main.py
@@ -1,8 +1,15 @@
 # app/main.py
+import logging
+import os
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
-import os
+
+from .logging_config import configure_logging
+
+configure_logging()
+logger = logging.getLogger(__name__)
 
 app = FastAPI(title="KAM")
 
@@ -37,7 +44,7 @@ if ASSETS_ROOT and os.path.isdir(ASSETS_ROOT):
     # Serve files at the URL path /assets (matches your .env paths)
     app.mount("/assets", StaticFiles(directory=ASSETS_ROOT), name="assets")
 else:
-    print(f"[KAM] Skipping /assets mount. Not found in container: {ASSETS_ROOT!r}")
+    logger.warning("Skipping /assets mount. Not found in container: %r", ASSETS_ROOT)
 
 # ---- Static Web UI ----
 app.mount("/", StaticFiles(directory="app/web", html=True), name="web")

--- a/app/routers/imports.py
+++ b/app/routers/imports.py
@@ -1,9 +1,11 @@
 # app/routers/imports.py
-from fastapi import APIRouter, Form, Query, HTTPException
-from typing import Optional, Dict, Any, List
+import logging
 import os
-import requests
 import xml.etree.ElementTree as ET
+from typing import Any, Dict, List, Optional
+
+import requests
+from fastapi import APIRouter, Form, HTTPException, Query
 
 from ..services.resolve import resolve_existing_dir_or_422
 
@@ -14,42 +16,108 @@ PLEX_TOKEN      = os.environ.get("PLEX_TOKEN", "")
 # Allow opting out for self-signed Plex certs: export PLEX_VERIFY_SSL=false
 PLEX_VERIFY_SSL = os.environ.get("PLEX_VERIFY_SSL", "true").lower() != "false"
 
+logger = logging.getLogger(__name__)
+TOKEN_MASK = "***"
+
+
+def _mask_token(value: Optional[str]) -> Optional[str]:
+    if not value or not PLEX_TOKEN:
+        return value
+    return value.replace(PLEX_TOKEN, TOKEN_MASK)
+
+
+def _safe_url(url: Optional[str]) -> Optional[str]:
+    if url is None:
+        return None
+    return _mask_token(url)
+
+
+def _safe_params(params: Optional[dict]) -> Optional[dict]:
+    if not params:
+        return params
+    safe = dict(params)
+    token_key = "X-Plex-Token"
+    if token_key in safe and safe[token_key]:
+        safe[token_key] = TOKEN_MASK
+    return safe
+
+
+def _safe_headers(headers: Optional[dict]) -> Optional[dict]:
+    if not headers:
+        return headers
+    safe = dict(headers)
+    token_key = "X-Plex-Token"
+    if token_key in safe and safe[token_key]:
+        safe[token_key] = TOKEN_MASK
+    return safe
+
 def _require_plex():
     if not PLEX_URL or not PLEX_TOKEN:
+        logger.error("Plex configuration missing (PLEX_URL or PLEX_TOKEN)")
         raise HTTPException(status_code=500, detail="PLEX_URL or PLEX_TOKEN not set")
 
 def _dest_dir_or_422(library: str, folderName: str) -> str:
     try:
+        logger.debug(
+            "Resolving destination directory for library=%s folderName=%s",
+            library,
+            folderName,
+        )
         return resolve_existing_dir_or_422(library, folderName)
     except FileNotFoundError as e:
+        logger.warning(
+            "Destination directory not found for library=%s folderName=%s: %s",
+            library,
+            folderName,
+            e,
+        )
         raise HTTPException(status_code=422, detail=str(e))
 
 # ---------------- Plex helpers ----------------
 
 def _get(url: str, params: Optional[dict] = None, headers: Optional[dict] = None) -> requests.Response:
     try:
+        logger.debug(
+            "GET %s params=%s headers=%s",
+            _safe_url(url),
+            _safe_params(params),
+            _safe_headers(headers),
+        )
         r = requests.get(url, params=params, headers=headers, timeout=30, verify=PLEX_VERIFY_SSL)
         r.raise_for_status()
         return r
     except requests.HTTPError as e:
         status = e.response.status_code if e.response is not None else 502
         detail = f"Plex request failed [{status}] for {url}"
+        logger.warning(
+            "Plex HTTP error [%s] for %s: %s",
+            status,
+            _safe_url(url),
+            e,
+        )
         raise HTTPException(status_code=502, detail=detail)
     except Exception as e:
+        logger.warning("Plex request error for %s: %s", _safe_url(url), e)
         raise HTTPException(status_code=502, detail=f"Plex request error for {url}: {e}")
 
 def _download_to(path: str, url: str):
     try:
+        logger.debug("Downloading %s to %s", _safe_url(url), path)
         with requests.get(url, timeout=60, stream=True, verify=PLEX_VERIFY_SSL) as r:
             r.raise_for_status()
             with open(path, "wb") as f:
                 for chunk in r.iter_content(chunk_size=1024 * 64):
                     if chunk:
                         f.write(chunk)
+        logger.debug("Download complete for %s", path)
     except requests.HTTPError as e:
         status = e.response.status_code if e.response is not None else 502
+        logger.warning(
+            "Download failed [%s] for %s: %s", status, _safe_url(url), e
+        )
         raise HTTPException(status_code=502, detail=f"Download failed [{status}] for {url}")
     except Exception as e:
+        logger.warning("Download error for %s: %s", _safe_url(url), e)
         raise HTTPException(status_code=502, detail=f"Download error for {url}: {e}")
 
 def _json_or_xml(path: str) -> Dict[str, Any] | str:
@@ -59,10 +127,13 @@ def _json_or_xml(path: str) -> Dict[str, Any] | str:
     _require_plex()
     url = f"{PLEX_URL}{path}"
     headers = {"Accept": "application/json", "X-Plex-Token": PLEX_TOKEN}
+    logger.debug("Requesting Plex metadata from %s", _safe_url(url))
     r = _get(url, params={"X-Plex-Token": PLEX_TOKEN}, headers=headers)
     ctype = (r.headers.get("Content-Type") or "").lower()
     if "application/json" in ctype:
+        logger.debug("Received JSON metadata for %s", path)
         return r.json()
+    logger.debug("Received XML metadata for %s", path)
     return r.text  # XML
 
 def _resolve_thumb_path_from_metadata(rating_key: str) -> Optional[str]:
@@ -105,11 +176,18 @@ def _poster_url_for_rating_key(rating_key: str) -> str:
     _require_plex()
     direct = f"{PLEX_URL}/library/metadata/{rating_key}/thumb?X-Plex-Token={PLEX_TOKEN}"
     try:
+        logger.debug(
+            "Attempting direct poster URL for ratingKey=%s: %s",
+            rating_key,
+            _safe_url(direct),
+        )
         _get(direct)
         return direct
     except HTTPException:
+        logger.debug("Falling back to metadata poster lookup for ratingKey=%s", rating_key)
         thumb_path = _resolve_thumb_path_from_metadata(rating_key)
         if not thumb_path:
+            logger.warning("Poster path resolution failed for ratingKey=%s", rating_key)
             raise HTTPException(status_code=502, detail=f"Could not resolve poster path for ratingKey={rating_key}")
         return f"{PLEX_URL}{thumb_path}?X-Plex-Token={PLEX_TOKEN}"
 
@@ -117,15 +195,23 @@ def _art_url_for_rating_key(rating_key: str) -> str:
     _require_plex()
     direct = f"{PLEX_URL}/library/metadata/{rating_key}/art?X-Plex-Token={PLEX_TOKEN}"
     try:
+        logger.debug(
+            "Attempting direct background URL for ratingKey=%s: %s",
+            rating_key,
+            _safe_url(direct),
+        )
         _get(direct)
         return direct
     except HTTPException:
+        logger.debug("Falling back to metadata background lookup for ratingKey=%s", rating_key)
         art_path = _resolve_art_path_from_metadata(rating_key)
         if not art_path:
+            logger.warning("Background path resolution failed for ratingKey=%s", rating_key)
             raise HTTPException(status_code=502, detail=f"Could not resolve background path for ratingKey={rating_key}")
         return f"{PLEX_URL}{art_path}?X-Plex-Token={PLEX_TOKEN}"
 
 def _children_for_show(rating_key: str) -> List[Dict[str, Any]]:
+    logger.debug("Fetching seasons for show ratingKey=%s", rating_key)
     data = _json_or_xml(f"/library/metadata/{rating_key}/children")
     out: List[Dict[str, Any]] = []
     if isinstance(data, dict):
@@ -159,8 +245,8 @@ def _children_for_show(rating_key: str) -> List[Dict[str, Any]]:
                     "ratingKey": node.attrib.get("ratingKey"),
                     "thumb": node.attrib.get("thumb"),
                 })
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning("Failed to parse season metadata for ratingKey=%s: %s", rating_key, e)
     return out
 
 def _season_poster_url(show_rating_key: str, season_index: int) -> str:
@@ -171,9 +257,17 @@ def _season_poster_url(show_rating_key: str, season_index: int) -> str:
             if int(str(s.get("index"))) == int(season_index):
                 target = s
                 break
-        except Exception:
+        except Exception as e:
+            logger.warning(
+                "Invalid season index encountered for show %s: %s", show_rating_key, e
+            )
             continue
     if not target:
+        logger.warning(
+            "Season %s not found in Plex metadata for show %s",
+            season_index,
+            show_rating_key,
+        )
         raise HTTPException(status_code=404, detail=f"Season {season_index} not found in Plex")
     thumb = target.get("thumb")
     rk    = target.get("ratingKey")
@@ -181,6 +275,9 @@ def _season_poster_url(show_rating_key: str, season_index: int) -> str:
         return f"{PLEX_URL}{thumb}?X-Plex-Token={PLEX_TOKEN}"
     if rk:
         return f"{PLEX_URL}/library/metadata/{rk}/thumb?X-Plex-Token={PLEX_TOKEN}"
+    logger.warning(
+        "Season poster URL unavailable for show %s season %s", show_rating_key, season_index
+    )
     raise HTTPException(status_code=502, detail="Season poster URL unavailable from Plex")
 
 # ---------------- Endpoints ----------------
@@ -192,9 +289,22 @@ def import_poster_post(
     ratingKey: str = Form(...),
     url: Optional[str] = Form(None),
 ):
+    logger.debug(
+        "Import poster POST library=%s folder=%s ratingKey=%s url=%s",
+        library,
+        folderName,
+        ratingKey,
+        _safe_url(url),
+    )
     dest_dir = _dest_dir_or_422(library, folderName)
     path = os.path.join(dest_dir, "poster.jpg")
     src = url or _poster_url_for_rating_key(ratingKey)
+    logger.debug(
+        "Poster source resolved for library=%s folder=%s: %s",
+        library,
+        folderName,
+        _safe_url(src),
+    )
     _download_to(path, src)
     return {"ok": True, "path": path, "src": src}
 
@@ -214,9 +324,22 @@ def import_background_post(
     ratingKey: str = Form(...),
     url: Optional[str] = Form(None),
 ):
+    logger.debug(
+        "Import background POST library=%s folder=%s ratingKey=%s url=%s",
+        library,
+        folderName,
+        ratingKey,
+        _safe_url(url),
+    )
     dest_dir = _dest_dir_or_422(library, folderName)
     path = os.path.join(dest_dir, "background.jpg")
     src = url or _art_url_for_rating_key(ratingKey)
+    logger.debug(
+        "Background source resolved for library=%s folder=%s: %s",
+        library,
+        folderName,
+        _safe_url(src),
+    )
     _download_to(path, src)
     return {"ok": True, "path": path, "src": src}
 
@@ -237,6 +360,14 @@ def import_season_post(
     ratingKey: Optional[str] = Form(None),  # show ratingKey; required if url not supplied
     url: Optional[str] = Form(None),
 ):
+    logger.debug(
+        "Import season POST library=%s folder=%s season=%s ratingKey=%s url=%s",
+        library,
+        folderName,
+        season,
+        ratingKey,
+        _safe_url(url),
+    )
     try:
         idx = int(str(season).strip())
     except Exception:
@@ -252,6 +383,13 @@ def import_season_post(
             raise HTTPException(status_code=422, detail="ratingKey is required when url is not provided")
         src = _season_poster_url(ratingKey, idx)
 
+    logger.debug(
+        "Season source resolved for library=%s folder=%s season=%s: %s",
+        library,
+        folderName,
+        idx,
+        _safe_url(src),
+    )
     _download_to(path, src)
     return {"ok": True, "path": path, "src": src}
 
@@ -282,6 +420,14 @@ def import_movie_both(
     posterUrl: Optional[str] = Form(None),
     backgroundUrl: Optional[str] = Form(None),
 ):
+    logger.debug(
+        "Import movie POST library=%s folder=%s ratingKey=%s includePoster=%s includeBackground=%s",
+        library,
+        folderName,
+        ratingKey,
+        includePoster,
+        includeBackground,
+    )
     dest_dir = _dest_dir_or_422(library, folderName)
 
     results = {
@@ -293,22 +439,58 @@ def import_movie_both(
         try:
             p_path = os.path.join(dest_dir, "poster.jpg")
             p_src = posterUrl or _poster_url_for_rating_key(ratingKey)
+            logger.debug(
+                "Movie poster source resolved for library=%s folder=%s: %s",
+                library,
+                folderName,
+                _safe_url(p_src),
+            )
             _download_to(p_path, p_src)
             results["poster"] = {"ok": True, "path": p_path, "src": p_src, "error": None}
         except HTTPException as e:
+            logger.warning(
+                "Movie poster import failed for library=%s folder=%s: %s",
+                library,
+                folderName,
+                e.detail,
+            )
             results["poster"]["error"] = e.detail
         except Exception as e:
+            logger.warning(
+                "Movie poster import error for library=%s folder=%s: %s",
+                library,
+                folderName,
+                e,
+            )
             results["poster"]["error"] = str(e)
 
     if includeBackground:
         try:
             b_path = os.path.join(dest_dir, "background.jpg")
             b_src = backgroundUrl or _art_url_for_rating_key(ratingKey)
+            logger.debug(
+                "Movie background source resolved for library=%s folder=%s: %s",
+                library,
+                folderName,
+                _safe_url(b_src),
+            )
             _download_to(b_path, b_src)
             results["background"] = {"ok": True, "path": b_path, "src": b_src, "error": None}
         except HTTPException as e:
+            logger.warning(
+                "Movie background import failed for library=%s folder=%s: %s",
+                library,
+                folderName,
+                e.detail,
+            )
             results["background"]["error"] = e.detail
         except Exception as e:
+            logger.warning(
+                "Movie background import error for library=%s folder=%s: %s",
+                library,
+                folderName,
+                e,
+            )
             results["background"]["error"] = str(e)
 
     return {"ok": results["poster"]["ok"] or results["background"]["ok"], "results": results}
@@ -326,6 +508,15 @@ def import_show_all(
     """
     Import a show's poster, background, and all season posters in one call.
     """
+    logger.debug(
+        "Import show POST library=%s folder=%s ratingKey=%s includePoster=%s includeBackground=%s includeSeasons=%s",
+        library,
+        folderName,
+        ratingKey,
+        includePoster,
+        includeBackground,
+        includeSeasons,
+    )
     dest_dir = _dest_dir_or_422(library, folderName)
     results: Dict[str, Any] = {
         "poster": {"ok": False, "path": None, "src": None, "error": None},
@@ -338,11 +529,29 @@ def import_show_all(
         try:
             p_path = os.path.join(dest_dir, "poster.jpg")
             p_src = _poster_url_for_rating_key(ratingKey)
+            logger.debug(
+                "Show poster source resolved for library=%s folder=%s: %s",
+                library,
+                folderName,
+                _safe_url(p_src),
+            )
             _download_to(p_path, p_src)
             results["poster"] = {"ok": True, "path": p_path, "src": p_src, "error": None}
         except HTTPException as e:
+            logger.warning(
+                "Show poster import failed for library=%s folder=%s: %s",
+                library,
+                folderName,
+                e.detail,
+            )
             results["poster"]["error"] = e.detail
         except Exception as e:
+            logger.warning(
+                "Show poster import error for library=%s folder=%s: %s",
+                library,
+                folderName,
+                e,
+            )
             results["poster"]["error"] = str(e)
 
     # Series background
@@ -350,11 +559,29 @@ def import_show_all(
         try:
             b_path = os.path.join(dest_dir, "background.jpg")
             b_src = _art_url_for_rating_key(ratingKey)
+            logger.debug(
+                "Show background source resolved for library=%s folder=%s: %s",
+                library,
+                folderName,
+                _safe_url(b_src),
+            )
             _download_to(b_path, b_src)
             results["background"] = {"ok": True, "path": b_path, "src": b_src, "error": None}
         except HTTPException as e:
+            logger.warning(
+                "Show background import failed for library=%s folder=%s: %s",
+                library,
+                folderName,
+                e.detail,
+            )
             results["background"]["error"] = e.detail
         except Exception as e:
+            logger.warning(
+                "Show background import error for library=%s folder=%s: %s",
+                library,
+                folderName,
+                e,
+            )
             results["background"]["error"] = str(e)
 
     # Seasons
@@ -373,14 +600,42 @@ def import_show_all(
                 try:
                     sea_path = os.path.join(dest_dir, f"Season{idx:02d}.jpg")
                     sea_src = _season_poster_url(ratingKey, idx)
+                    logger.debug(
+                        "Show season source resolved for library=%s folder=%s season=%s: %s",
+                        library,
+                        folderName,
+                        idx,
+                        _safe_url(sea_src),
+                    )
                     _download_to(sea_path, sea_src)
                     ok_entry.update({"ok": True, "path": sea_path, "src": sea_src})
                 except HTTPException as e:
+                    logger.warning(
+                        "Season import failed for library=%s folder=%s season=%s: %s",
+                        library,
+                        folderName,
+                        idx,
+                        e.detail,
+                    )
                     ok_entry["error"] = e.detail
                 except Exception as e:
+                    logger.warning(
+                        "Season import error for library=%s folder=%s season=%s: %s",
+                        library,
+                        folderName,
+                        idx,
+                        e,
+                    )
                     ok_entry["error"] = str(e)
                 results["seasons"].append(ok_entry)
         except Exception as e:
+            logger.warning(
+                "Failed to enumerate seasons for library=%s folder=%s ratingKey=%s: %s",
+                library,
+                folderName,
+                ratingKey,
+                e,
+            )
             results["seasons"].append({"ok": False, "error": f"Failed to enumerate seasons: {e}"})
 
     results["ok"] = (
@@ -402,6 +657,14 @@ def import_collection_both(
     """
     Import a collection's poster and background from Plex into the Kometa asset folder.
     """
+    logger.debug(
+        "Import collection POST library=%s folder=%s ratingKey=%s includePoster=%s includeBackground=%s",
+        library,
+        folderName,
+        ratingKey,
+        includePoster,
+        includeBackground,
+    )
     dest_dir = _dest_dir_or_422(library, folderName)
 
     results: Dict[str, Any] = {
@@ -413,18 +676,61 @@ def import_collection_both(
         try:
             p_path = os.path.join(dest_dir, "poster.jpg")
             p_src = _poster_url_for_rating_key(ratingKey)
+            logger.debug(
+                "Collection poster source resolved for library=%s folder=%s: %s",
+                library,
+                folderName,
+                _safe_url(p_src),
+            )
             _download_to(p_path, p_src)
             results["poster"] = {"ok": True, "path": p_path, "src": p_src, "error": None}
         except HTTPException as e:
+            logger.warning(
+                "Collection poster import failed for library=%s folder=%s: %s",
+                library,
+                folderName,
+                e.detail,
+            )
             results["poster"]["error"] = e.detail
         except Exception as e:
+            logger.warning(
+                "Collection poster import error for library=%s folder=%s: %s",
+                library,
+                folderName,
+                e,
+            )
             results["poster"]["error"] = str(e)
 
     if includeBackground:
         try:
             b_path = os.path.join(dest_dir, "background.jpg")
             b_src = _art_url_for_rating_key(ratingKey)
+            logger.debug(
+                "Collection background source resolved for library=%s folder=%s: %s",
+                library,
+                folderName,
+                _safe_url(b_src),
+            )
             _download_to(b_path, b_src)
             results["background"] = {"ok": True, "path": b_path, "src": b_src, "error": None}
         except HTTPException as e:
-            results
+            logger.warning(
+                "Collection background import failed for library=%s folder=%s: %s",
+                library,
+                folderName,
+                e.detail,
+            )
+            results["background"]["error"] = e.detail
+        except Exception as e:
+            logger.warning(
+                "Collection background import error for library=%s folder=%s: %s",
+                library,
+                folderName,
+                e,
+            )
+            results["background"]["error"] = str(e)
+
+    return {
+        "ok": results["poster"]["ok"] or results["background"]["ok"],
+        "results": results,
+    }

--- a/app/services/assets.py
+++ b/app/services/assets.py
@@ -1,4 +1,9 @@
-import os, io, re, pathlib, shutil
+import io
+import logging
+import os
+import pathlib
+import re
+import shutil
 from typing import Optional
 from PIL import Image
 from fastapi import UploadFile, HTTPException
@@ -6,22 +11,32 @@ from fastapi import UploadFile, HTTPException
 SAFE = re.compile(r"[^A-Za-z0-9\-\s\.\(\)_]")
 MULTI = re.compile(r"\s+")
 
+logger = logging.getLogger(__name__)
+
 def ensure_dir(p: str):
     pathlib.Path(p).mkdir(parents=True, exist_ok=True)
+    logger.debug("Ensured directory exists: %s", p)
 
 def sanitize_name(name: str) -> str:
     s = (name or "")
     # Always preserve real titles. Only neutralize path separators and nulls.
     s = s.replace("\\", "⧵").replace("/", "⁄").replace("\x00", "")
     s = s.strip()
-    return MULTI.sub(" ", s)
+    sanitized = MULTI.sub(" ", s)
+    logger.debug("Sanitized asset name: %r -> %r", name, sanitized)
+    return sanitized
 
 def folder_name_for(title: str, year: Optional[int]) -> str:
-    title = title or "Untitled"
-    title = sanitize_name(title)
+    original = title or "Untitled"
+    sanitized = sanitize_name(original)
     if year:
-        return f"{title} ({int(year)})"
-    return title
+        folder = f"{sanitized} ({int(year)})"
+        logger.debug(
+            "Resolved asset folder for title=%r year=%r -> %s", original, year, folder
+        )
+        return folder
+    logger.debug("Resolved asset folder for title=%r -> %s", original, sanitized)
+    return sanitized
 
 def save_as_poster_jpg(upload: UploadFile, dest_folder: str) -> str:
     ensure_dir(dest_folder)
@@ -31,8 +46,8 @@ def save_as_poster_jpg(upload: UploadFile, dest_folder: str) -> str:
         if os.path.exists(f):
             try:
                 os.remove(f)
-            except Exception:
-                pass
+            except Exception as e:
+                logger.warning("Failed to remove existing poster variant %s: %s", f, e)
     dest = os.path.join(dest_folder, "poster.jpg")
     # if an incorrect directory exists at dest, remove it
     if os.path.isdir(dest):
@@ -41,6 +56,7 @@ def save_as_poster_jpg(upload: UploadFile, dest_folder: str) -> str:
     try:
         im = Image.open(io.BytesIO(raw))
     except Exception as e:
+        logger.warning("Unable to open uploaded poster for %s: %s", dest, e)
         raise HTTPException(400, f"Invalid image: {e}")
     if im.mode != "RGB":
         im = im.convert("RGB")
@@ -55,8 +71,8 @@ def _delete_existing_variants(dest_folder: str, base_no_ext: str):
             p = base + ext
             if os.path.isfile(p):
                 os.remove(p)
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning("Failed to remove asset variant %s: %s", p, e)
 
 def save_as_named_jpg(upload: UploadFile, dest_folder: str, base_no_ext: str) -> str:
     """Save an uploaded image to dest_folder/<base_no_ext>.jpg, converting to JPEG,
@@ -68,6 +84,9 @@ def save_as_named_jpg(upload: UploadFile, dest_folder: str, base_no_ext: str) ->
     try:
         im = Image.open(io.BytesIO(raw))
     except Exception as e:
+        logger.warning(
+            "Unable to open uploaded image for %s/%s: %s", dest_folder, base_no_ext, e
+        )
         raise HTTPException(400, f"Invalid image: {e}")
     if im.mode != "RGB":
         im = im.convert("RGB")
@@ -85,9 +104,16 @@ def save_bytes_as_poster_jpg(data: bytes, dest_folder: str) -> str:
             img = img.convert("RGB")
         out_path = os.path.join(dest_folder, "poster.jpg")
         img.save(out_path, format="JPEG", quality=92, optimize=True)
+        logger.debug("Saved converted poster image to %s", out_path)
         return out_path
-    except Exception:
+    except Exception as e:
+        logger.warning(
+            "Falling back to raw bytes for poster in %s due to conversion error: %s",
+            dest_folder,
+            e,
+        )
         out_path = os.path.join(dest_folder, "poster.jpg")
         with open(out_path, "wb") as f:
             f.write(data)
+        logger.debug("Saved raw poster bytes to %s", out_path)
         return out_path


### PR DESCRIPTION
## Summary
- add a central logging configuration helper that supports env-level overrides
- initialize application logging at startup and replace ad-hoc prints with logger usage
- instrument asset management and import routes with debug/warning logs for troubleshooting

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de9ca705e483308bd52655b4172f8e