### PR TITLE
Improve logging level resolution

### DIFF
--- a/app/logging_config.py
+++ b/app/logging_config.py
@@ -4,19 +4,26 @@ import os
 import sys
 from typing import Optional
 
-DEFAULT_LEVEL = "INFO"
+DEFAULT_LEVEL = logging.INFO
 ENV_LEVEL = "KAM_LOG_LEVEL"
 
 
 def _resolve_level(name: Optional[str]) -> int:
     """Return a logging level from an environment-provided name."""
-    if not name:
-        return logging.getLevelName(DEFAULT_LEVEL)
+    if not name or not name.strip():
+        return DEFAULT_LEVEL
+
     normalized = name.strip().upper()
-    level = logging.getLevelName(normalized)
+    level = logging._nameToLevel.get(normalized)
     if isinstance(level, int):
         return level
-    return logging.getLevelName(DEFAULT_LEVEL)
+
+    try:
+        candidate = logging._checkLevel(normalized)
+    except (ValueError, TypeError):
+        return DEFAULT_LEVEL
+
+    return candidate if isinstance(candidate, int) else DEFAULT_LEVEL
 
 
 def configure_logging() -> None:


### PR DESCRIPTION
## Summary
- ensure the logging level helper resolves known names to numeric values and falls back to INFO when unknown

## Testing
- KAM_LOG_LEVEL=DEBUG uvicorn app.main:app --host 0.0.0.0 --port 8000 (manual verification via /api/import/poster request)
- uvicorn app.main:app --host 0.0.0.0 --port 8000 (manual verification via /api/import/poster request)


------
https://chatgpt.com/codex/tasks/task_e_68dea133eb9c83308bd1d76a44fb25f1