### PR TITLE
Improve resolver normalization for stopwords and year suffixes

### DIFF
--- a/app/services/resolve.py
+++ b/app/services/resolve.py
@@ -1,7 +1,7 @@
 # app/services/resolve.py
 import os
-import unicodedata
 import re
+import unicodedata
 from difflib import SequenceMatcher
 from typing import Optional
 
@@ -9,19 +9,36 @@ ASSETS_ROOT = os.environ.get("KAM_ASSETS_ROOT", "/assets")
 
 _ILLEGAL_CTRL = re.compile(r"[\u0000-\u001F]")
 
+_STOPWORDS = {"the", "a", "an", "movie", "film"}
+
+
+def _tokenize_title(s: str) -> list[str]:
+    """Normalize *s* into lowercase word tokens without punctuation."""
+    if not s:
+        return []
+
+    normalized = unicodedata.normalize("NFKC", str(s))
+    normalized = _ILLEGAL_CTRL.sub("", normalized)
+    normalized = normalized.casefold()
+
+    tokens = [tok for tok in re.split(r"[^0-9a-z]+", normalized) if tok]
+    tokens = [tok for tok in tokens if tok not in _STOPWORDS]
+
+    # Drop trailing year tokens such as "(2023)" so alternate title suffixes
+    # compare on the meaningful words only.
+    while tokens and re.fullmatch(r"\d{4}", tokens[-1]):
+        tokens.pop()
+
+    return tokens
+
+
 def _normalize(s: str) -> str:
     """
     Build a comparison key that ignores punctuation/spacing/case differences,
-    so 'Batman: The Caped Crusader' == 'Batman The Caped Crusader'.
+    and common stop-words/year suffixes so
+    'Batman: The Caped Crusader (2023)' == 'Batman Caped Crusader'.
     """
-    if not s:
-        return ""
-    s = unicodedata.normalize("NFKC", str(s))
-    s = _ILLEGAL_CTRL.sub("", s)
-    s = s.casefold()
-    # drop all non-alphanumeric chars
-    s = "".join(ch for ch in s if ch.isalnum())
-    return s
+    return "".join(_tokenize_title(s))
 
 def _best_match(candidates, want: str) -> Optional[str]:
     """Return the candidate whose normalized name equals the normalized target."""

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -36,6 +36,24 @@ def test_resolve_accepts_high_similarity_variant(tmp_path, monkeypatch):
     assert os.path.basename(resolved) == existing
 
 
+def test_resolve_matches_stopword_and_year_variants(tmp_path, monkeypatch):
+    assets_root = tmp_path / "assets"
+    library = "Movies"
+    target = "The Super Mario Bros. Movie"
+    existing = "Super Mario Bros. (2023)"
+
+    library_path = assets_root / library
+    library_path.mkdir(parents=True)
+    (library_path / existing).mkdir()
+
+    monkeypatch.setenv("KAM_ASSETS_ROOT", str(assets_root))
+
+    resolve_module = _reload_with_assets_root(str(assets_root))
+
+    resolved = resolve_module.resolve_existing_dir_or_422(library, target)
+    assert os.path.basename(resolved) == existing
+
+
 def test_resolve_rejects_low_similarity_titles(tmp_path, monkeypatch):
     assets_root = tmp_path / "assets"
     library = "Movies"


### PR DESCRIPTION
## Summary
- update resolver normalization to tokenize titles, drop common stopwords, and strip trailing years
- keep existing matching flow so normalized comparisons run before fuzzy fallbacks
- add resolver unit test to cover Kometa vs Plex naming variants and retain the negative match case

## Testing
- pytest tests/test_resolve.py

------
https://chatgpt.com/codex/tasks/task_e_68dead13eea883309e9d0381161df3b5