### PR TITLE
Use config library mappings in resolver

### DIFF
--- a/app/services/resolve.py
+++ b/app/services/resolve.py
@@ -5,6 +5,8 @@ import unicodedata
 from difflib import SequenceMatcher
 from typing import Optional
 
+from app import config
+
 ASSETS_ROOT = os.environ.get("KAM_ASSETS_ROOT", "/assets")
 
 _ILLEGAL_CTRL = re.compile(r"[\u0000-\u001F]")
@@ -102,7 +104,14 @@ def resolve_existing_dir_or_422(library: str, folder_name: str) -> str:
     """
     if not library:
         raise FileNotFoundError("Missing library")
-    base = os.path.join(ASSETS_ROOT, library)
+
+    mapped_base: Optional[str]
+    if library == "Collections":
+        mapped_base = config.COLLECTIONS_ROOT
+    else:
+        mapped_base = config.LIBRARY_MAPPINGS.get(library)
+
+    base = os.fspath(mapped_base) if mapped_base else os.path.join(ASSETS_ROOT, library)
     if not os.path.isdir(base):
         raise FileNotFoundError(f"Assets library not found: {base}")
 

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -18,6 +18,31 @@ def _reload_with_assets_root(path):
     return module
 
 
+def test_resolve_prefers_config_mapping(tmp_path, monkeypatch):
+    assets_root = tmp_path / "assets"
+    library = "Movies"
+    target = "Avatar"
+
+    mapped_library_path = tmp_path / "custom_movies"
+    mapped_library_path.mkdir(parents=True)
+    (mapped_library_path / target).mkdir()
+
+    monkeypatch.setenv("KAM_ASSETS_ROOT", str(assets_root))
+
+    config_module = importlib.import_module("app.config")
+    monkeypatch.setattr(
+        config_module,
+        "LIBRARY_MAPPINGS",
+        {library: str(mapped_library_path)},
+        raising=False,
+    )
+
+    resolve_module = _reload_with_assets_root(str(assets_root))
+
+    resolved = resolve_module.resolve_existing_dir_or_422(library, target)
+    assert resolved == os.path.join(str(mapped_library_path), target)
+
+
 def test_resolve_accepts_high_similarity_variant(tmp_path, monkeypatch):
     assets_root = tmp_path / "assets"
     library = "Movies"


### PR DESCRIPTION
## Summary
- prefer configured library or collections roots when resolving asset directories
- add coverage ensuring resolution works when only library mappings are provided

## Testing
- pytest tests/test_resolve.py

------
https://chatgpt.com/codex/tasks/task_e_68df135e02ac8330afaab9fb40d35441