### PR TITLE
Expose collection asset readiness metadata

### DIFF
--- a/app/routers/collections.py
+++ b/app/routers/collections.py
@@ -47,48 +47,61 @@ def _first_existing_poster(dir_path: Path) -> Path | None:
             return p
     return None
 
-def _local_poster_for_title(title: str) -> Tuple[Path | None, str | None, str]:
+def _local_poster_for_title(title: str) -> Tuple[Path | None, str | None, str, bool]:
     """
     Find a local poster for this collection title.
 
-    Returns: (path_on_disk, public_url_or_None, folder_used)
+    Returns: (path_on_disk, public_url_or_None, folder_used, folder_exists)
     """
     if not title or not COLLECTIONS_ROOT:
-        return None, None, ""
+        return None, None, "", False
 
     base = Path(COLLECTIONS_ROOT)
     raw_folder = title
     sani_folder = sanitize_name(title)
+    found_folder = ""
+    found_exists = False
 
     # 1) exact raw
     d1 = base / raw_folder
     if d1.is_dir():
+        found_folder = d1.name
+        found_exists = True
         p = _first_existing_poster(d1)
         if p:
-            return p, _url_for_local(raw_folder, p), raw_folder
+            return p, _url_for_local(d1.name, p), d1.name, True
 
     # 2) exact sanitized
     d2 = base / sani_folder
     if d2.is_dir():
+        found_folder = d2.name
+        found_exists = True
         p = _first_existing_poster(d2)
         if p:
-            return p, _url_for_local(sani_folder, p), sani_folder
+            return p, _url_for_local(d2.name, p), d2.name, True
 
     # 3) case-insensitive match (raw)
     d3 = _case_insensitive_dir(base, raw_folder)
     if d3:
+        found_folder = d3.name
+        found_exists = True
         p = _first_existing_poster(d3)
         if p:
-            return p, _url_for_local(d3.name, p), d3.name
+            return p, _url_for_local(d3.name, p), d3.name, True
 
     # 4) case-insensitive match (sanitized)
     d4 = _case_insensitive_dir(base, sani_folder)
     if d4:
+        found_folder = d4.name
+        found_exists = True
         p = _first_existing_poster(d4)
         if p:
-            return p, _url_for_local(d4.name, p), d4.name
+            return p, _url_for_local(d4.name, p), d4.name, True
 
-    return None, None, ""
+    if found_exists:
+        return None, None, found_folder, True
+
+    return None, None, "", False
 
 def _url_for_local(folder_name: str, file_path: Path) -> str:
     """
@@ -126,13 +139,14 @@ def collections(
                 poster_plex = f"{config.PLEX_URL}/library/metadata/{rk}/thumb?X-Plex-Token={config.PLEX_TOKEN}"
 
                 # Local art look-up
-                poster_path, poster_local, folder_used = _local_poster_for_title(title)
+                _poster_path, poster_local, folder_used, folder_exists = _local_poster_for_title(title)
 
                 item = {
                     "ratingKey": rk,
                     "title": title,
                     "year": None,
-                    "folderName": sanitize_name(title) if title else "",
+                    "folderName": folder_used or (sanitize_name(title) if title else ""),
+                    "assetReady": folder_exists,
                     # ✅ prefer local for the primary image
                     "posterUrl": poster_local or poster_plex,
                     # also expose both explicitly
@@ -147,6 +161,7 @@ def collections(
                         "collections_root": COLLECTIONS_ROOT,
                         "tried_titles": [title, sanitize_name(title)],
                         "folder_used": folder_used,
+                        "asset_ready": folder_exists,
                         "assets_root": ASSETS_ROOT,
                     }
 

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -672,7 +672,10 @@
 
         for (const it of importable) {
           const title = it?.title || it?.name || "(Untitled)";
-          const folderName = it?.folderName || it?.folder || it?.name || it?.title || "";
+          let folderName = it?.folderName || "";
+          if (!folderName && it?.assetReady !== false) {
+            folderName = it?.folder || it?.name || it?.title || "";
+          }
           const ratingKey = it?.ratingKey || it?.key || it?.id;
           const context = { library: lib, title, folder: folderName };
 

--- a/tests/test_collections_route.py
+++ b/tests/test_collections_route.py
@@ -1,0 +1,91 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+class _DummyCollection:
+    def __init__(self, title: str, rating_key: int):
+        self.title = title
+        self.ratingKey = rating_key
+
+
+class _DummySection:
+    def __init__(self, collections):
+        self._collections = collections
+
+    def collections(self):
+        return self._collections
+
+
+class _DummyLibrary:
+    def __init__(self, sections):
+        self._sections = sections
+
+    def sections(self):
+        return self._sections
+
+
+class _DummyPlex:
+    def __init__(self, sections):
+        self.library = _DummyLibrary(sections)
+
+
+@pytest.fixture
+def collections_call(tmp_path, monkeypatch):
+    assets_root = tmp_path / "assets"
+    collections_root = assets_root / "Collections"
+    ready_folder = collections_root / "my cool collection"
+    ready_folder.mkdir(parents=True)
+
+    from app import config
+    from app.routers import collections as collections_router
+
+    monkeypatch.setattr(config, "PLEX_URL", "http://plex.test")
+    monkeypatch.setattr(config, "PLEX_TOKEN", "token")
+    monkeypatch.setattr(config, "CONFIG_ERRORS", [])
+
+    monkeypatch.setenv("KAM_ASSETS_ROOT", str(assets_root))
+    monkeypatch.setenv("COLLECTIONS_ROOT", str(collections_root))
+
+    collections_router.ASSETS_ROOT = str(assets_root)
+    collections_router.COLLECTIONS_ROOT = str(collections_root)
+
+    sections = [_DummySection([
+        _DummyCollection("My Cool Collection", 1),
+        _DummyCollection("Missing Assets", 2),
+    ])]
+
+    monkeypatch.setattr(collections_router, "get_plex", lambda: _DummyPlex(sections))
+
+    def _call(**kwargs):
+        params = {"query": None, "page": 1, "page_size": 60}
+        params.update(kwargs)
+        return collections_router.collections(**params)
+
+    return _call
+
+
+def test_collections_route_marks_asset_readiness(collections_call):
+    data = collections_call()
+    items = {it["title"]: it for it in data["items"]}
+
+    ready = items["My Cool Collection"]
+    # Folder detected despite casing difference and missing poster
+    assert ready["folderName"] == "my cool collection"
+    assert ready["assetReady"] is True
+
+    missing = items["Missing Assets"]
+    assert missing["assetReady"] is False
+    assert missing["folderName"] == "Missing Assets"
+
+
+def test_index_html_consumes_asset_ready_flag():
+    html = (ROOT / "app" / "web" / "index.html").read_text(encoding="utf-8")
+    assert "filter(it => it?.assetReady !== false)" in html
+    assert "let folderName = it?.folderName || \"\"" in html


### PR DESCRIPTION
## Summary
- return the resolved asset folder and readiness flag from the collections endpoint
- update the web UI importer to use the resolved folder and skip not-ready entries
- add regression coverage for the collections route and UI readiness handling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df1364a8ec83309561291f9a7e730f