### PR TITLE
Add folder override persistence and routing

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -21,7 +21,17 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-from .routers import libraries, items, collections, upload, tv, fileproxy, movie, imports
+from .routers import (
+    assets,
+    collections,
+    fileproxy,
+    imports,
+    items,
+    libraries,
+    movie,
+    tv,
+    upload,
+)
 
 app.include_router(libraries.router)
 app.include_router(items.router)
@@ -31,6 +41,7 @@ app.include_router(tv.router)
 app.include_router(movie.router)
 app.include_router(imports.router)
 app.include_router(fileproxy.router)
+app.include_router(assets.router)
 
 # ---- SAFE assets mount (env-driven) ----
 # Prefer explicit envs if you set them; otherwise infer from COLLECTIONS_ROOT.

--- a/app/routers/assets.py
+++ b/app/routers/assets.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import List
+
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel
+
+from .. import config
+from ..services import folder_overrides
+from ..services.resolve import ASSETS_ROOT, resolve_existing_dir_or_422
+
+router = APIRouter()
+
+
+class AssignFolderPayload(BaseModel):
+    library: str
+    ratingKey: str
+    folderName: str
+
+
+def _library_root(library: str) -> Path:
+    if not library:
+        raise HTTPException(status_code=422, detail="Missing library")
+    if library == "Collections":
+        base = config.COLLECTIONS_ROOT
+    else:
+        base = config.LIBRARY_MAPPINGS.get(library)
+        if not base and ASSETS_ROOT:
+            base = os.path.join(ASSETS_ROOT, library)
+    if not base:
+        raise HTTPException(status_code=404, detail=f"No assets mapping for library '{library}'")
+    root = Path(base)
+    if not root.is_dir():
+        raise HTTPException(status_code=404, detail=f"Assets library not found: {base}")
+    return root
+
+
+def _ensure_within_root(root: Path, target: Path) -> Path:
+    try:
+        target.relative_to(root)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid parent path")
+    return target
+
+
+@router.get("/api/asset-folders")
+def list_asset_folders(
+    library: str = Query(...),
+    parent: str | None = Query(None),
+    search: str | None = Query(None),
+):
+    parent_value = parent if isinstance(parent, str) else None
+    search_value = search if isinstance(search, str) else None
+
+    root = _library_root(library)
+    current = root
+    if parent_value:
+        rel = Path(parent_value)
+        if rel.is_absolute():
+            raise HTTPException(status_code=400, detail="Invalid parent path")
+        current = _ensure_within_root(root, (root / rel).resolve())
+        if not current.exists() or not current.is_dir():
+            raise HTTPException(status_code=404, detail="Parent directory not found")
+
+    term = (search_value or "").strip().lower()
+    items: List[dict] = []
+    try:
+        if term:
+            matches: List[Path] = []
+            for child in current.rglob("*"):
+                try:
+                    name_lower = child.name.lower()
+                    is_valid = child.is_file() or child.is_dir()
+                except PermissionError:
+                    continue
+                if term not in name_lower or not is_valid:
+                    continue
+                matches.append(child)
+            matches.sort(key=lambda p: (not p.is_dir(), str(p.relative_to(root)).lower()))
+            for child in matches:
+                rel_path = "" if child == root else str(child.relative_to(root))
+                items.append({
+                    "name": child.name,
+                    "isDir": child.is_dir(),
+                    "path": rel_path,
+                })
+        else:
+            for child in sorted(current.iterdir(), key=lambda p: (not p.is_dir(), p.name.lower())):
+                rel_path = "" if child == root else str(child.relative_to(root))
+                items.append({
+                    "name": child.name,
+                    "isDir": child.is_dir(),
+                    "path": rel_path,
+                })
+    except PermissionError:
+        raise HTTPException(status_code=403, detail="Permission denied")
+
+    parent_rel = "" if current == root else str(current.relative_to(root))
+
+    return {
+        "library": library,
+        "parent": parent_rel,
+        "items": items,
+    }
+
+
+@router.post("/api/items/assign-folder")
+def assign_folder(payload: AssignFolderPayload):
+    canonical_path = resolve_existing_dir_or_422(payload.library, payload.folderName)
+    canonical_folder = os.path.basename(os.path.normpath(canonical_path))
+    folder_overrides.set_override(payload.library, payload.ratingKey, canonical_folder)
+
+    folder_dir = Path(canonical_path)
+    poster_exists = (folder_dir / "poster.jpg").is_file()
+    background_exists = (folder_dir / "background.jpg").is_file()
+
+    return {
+        "library": payload.library,
+        "ratingKey": payload.ratingKey,
+        "folderName": canonical_folder,
+        "folderExists": True,
+        "assetReady": True,
+        "posterExists": poster_exists,
+        "backgroundExists": background_exists,
+    }

--- a/app/routers/collections.py
+++ b/app/routers/collections.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Query
 from math import ceil
 from typing import Optional, List, Dict, Any, Tuple
 from ..services.plex import get_plex
+from ..services import folder_overrides
 from ..services.assets import sanitize_name
 from .. import config
 
@@ -138,15 +139,32 @@ def collections(
                 # Plex art
                 poster_plex = f"{config.PLEX_URL}/library/metadata/{rk}/thumb?X-Plex-Token={config.PLEX_TOKEN}"
 
-                # Local art look-up
-                _poster_path, poster_local, folder_used, folder_exists = _local_poster_for_title(title)
+                override_folder = folder_overrides.get_override("Collections", str(rk)) if rk else None
+
+                poster_local = None
+                folder_used = sanitize_name(title) if title else ""
+                asset_ready = False
+                folder_exists = False
+
+                if override_folder:
+                    folder_used = override_folder
+                    asset_ready = True
+                    folder_exists = True
+                    if COLLECTIONS_ROOT:
+                        override_path = Path(COLLECTIONS_ROOT) / override_folder
+                        poster_path = _first_existing_poster(override_path) if override_path.is_dir() else None
+                        if poster_path:
+                            poster_local = _url_for_local(override_folder, poster_path)
+                else:
+                    _poster_path, poster_local, folder_used, folder_exists = _local_poster_for_title(title)
+                    asset_ready = folder_exists
 
                 item = {
                     "ratingKey": rk,
                     "title": title,
                     "year": None,
                     "folderName": folder_used or (sanitize_name(title) if title else ""),
-                    "assetReady": folder_exists,
+                    "assetReady": asset_ready,
                     # ✅ prefer local for the primary image
                     "posterUrl": poster_local or poster_plex,
                     # also expose both explicitly

--- a/app/routers/items.py
+++ b/app/routers/items.py
@@ -6,6 +6,7 @@ import requests
 import xml.etree.ElementTree as ET
 from urllib.parse import quote
 
+from ..services import folder_overrides
 from ..services.resolve import resolve_existing_dir_or_422
 
 router = APIRouter()
@@ -163,8 +164,9 @@ def list_items(
 
     out: List[Dict[str, Any]] = []
     for it in page_rows:
-        folder = _try_existing_asset_folder(library, it["title"], it["year"])
-        asset_ready = bool(folder)
+        override = folder_overrides.get_override(library, it["ratingKey"])
+        folder = override or _try_existing_asset_folder(library, it["title"], it["year"])
+        asset_ready = True if override else bool(folder)
         if folder and _local_poster_exists(library, folder):
             poster = _fileproxy_poster_url(library, folder)   # <-- /fileproxy now
         else:

--- a/app/routers/movie.py
+++ b/app/routers/movie.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, HTTPException, Query
 import os
 from typing import Optional
 
+from ..services import folder_overrides
 from ..services.plex import get_plex
 from ..services.assets import folder_name_for
 from ..services.resolve import resolve_existing_dir_or_422
@@ -57,8 +58,11 @@ def movie(library: str = Query(...), ratingKey: int = Query(...)):
     title = getattr(item, "title", None) or "Untitled"
     year = getattr(item, "year", None)
     folder = folder_name_for(title, year)
+    override_folder = folder_overrides.get_override(library, str(ratingKey))
     resolved_folder = _resolve_existing_folder_basename(library, title, year)
-    if resolved_folder:
+    if override_folder:
+        folder = override_folder
+    elif resolved_folder:
         folder = resolved_folder
 
     # Map to asset root for this library
@@ -67,11 +71,12 @@ def movie(library: str = Query(...), ratingKey: int = Query(...)):
     background_exists = False
     poster_url_local = None
     background_url_local = None
-    folder_exists = False
+    folder_exists = bool(override_folder)
 
     if base:
         movie_folder = os.path.join(base, folder)
-        folder_exists = os.path.isdir(movie_folder)
+        actual_exists = os.path.isdir(movie_folder)
+        folder_exists = folder_exists or actual_exists
         # poster
         p = _first_existing(os.path.join(movie_folder, "poster"))
         if p:

--- a/app/routers/tv.py
+++ b/app/routers/tv.py
@@ -6,6 +6,7 @@ import requests
 import xml.etree.ElementTree as ET
 from urllib.parse import quote
 
+from ..services import folder_overrides
 from ..services.resolve import resolve_existing_dir_or_422
 from ..services.sanitize import kometa_sanitize_folder
 
@@ -143,10 +144,16 @@ def get_show(library: str = Query(...), ratingKey: str = Query(...)):
     title, year, thumb, art = meta["title"], meta["year"], meta["thumb"], meta["art"]
     all_seasons = _seasons(ratingKey)
 
-    folder = _existing_folder_name(library, title, year)
-    folder_exists = folder is not None
-    if not folder:
-        folder = kometa_sanitize_folder(f"{title} ({year})" if year else title)
+    override_folder = folder_overrides.get_override(library, ratingKey)
+    folder_exists = False
+    folder = override_folder
+    if folder:
+        folder_exists = True
+    else:
+        folder = _existing_folder_name(library, title, year)
+        folder_exists = folder is not None
+        if not folder:
+            folder = kometa_sanitize_folder(f"{title} ({year})" if year else title)
 
     series_dir_fs = os.path.join(ASSETS_ROOT, library, folder)
 

--- a/app/services/folder_overrides.py
+++ b/app/services/folder_overrides.py
@@ -1,0 +1,127 @@
+"""Persistence helpers for per-item folder overrides."""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+from pathlib import Path
+from typing import Dict, Optional
+
+from .resolve import resolve_existing_dir_or_422
+
+logger = logging.getLogger(__name__)
+
+_LOCK = threading.Lock()
+
+_DEF_BASE = (
+    os.environ.get("KAM_STATE_ROOT")
+    or os.environ.get("KAM_CONFIG_ROOT")
+    or "/data"
+)
+_STORAGE_PATH = os.environ.get("KAM_FOLDER_OVERRIDES_PATH") or os.path.join(
+    _DEF_BASE, "folder_overrides.json"
+)
+
+
+def set_storage_path(path: str) -> None:
+    """Override the JSON persistence path (primarily for tests)."""
+    global _STORAGE_PATH
+    _STORAGE_PATH = path
+    logger.debug("Folder overrides storage path set to %s", path)
+
+
+def _get_storage_path() -> Path:
+    return Path(_STORAGE_PATH)
+
+
+def _load_locked() -> Dict[str, Dict[str, str]]:
+    path = _get_storage_path()
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return {}
+    except Exception as exc:
+        logger.warning("Unable to read folder overrides file %s: %s", path, exc)
+        return {}
+    try:
+        data = json.loads(raw) or {}
+    except Exception as exc:
+        logger.warning("Invalid JSON in folder overrides file %s: %s", path, exc)
+        return {}
+    # ensure nested dicts
+    out: Dict[str, Dict[str, str]] = {}
+    for lib, entries in data.items():
+        if isinstance(lib, str) and isinstance(entries, dict):
+            out[lib] = {str(k): str(v) for k, v in entries.items() if v is not None}
+    return out
+
+
+def _write_locked(data: Dict[str, Dict[str, str]]) -> None:
+    path = _get_storage_path()
+    parent = path.parent
+    try:
+        parent.mkdir(parents=True, exist_ok=True)
+    except Exception as exc:
+        logger.warning("Unable to create folder overrides parent %s: %s", parent, exc)
+    tmp_path = path.with_suffix(".tmp")
+    tmp_path.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
+    tmp_path.replace(path)
+
+
+def get_override(library: str, rating_key: str) -> Optional[str]:
+    if not library or not rating_key:
+        return None
+    key = str(rating_key)
+    with _LOCK:
+        data = _load_locked()
+        return data.get(library, {}).get(key)
+
+
+def set_override(library: str, rating_key: str, folder_name: str) -> str:
+    if not library:
+        raise ValueError("library is required")
+    if not rating_key:
+        raise ValueError("rating_key is required")
+    if not folder_name:
+        raise ValueError("folder_name is required")
+
+    resolved = resolve_existing_dir_or_422(library, folder_name)
+    canonical = os.path.basename(os.path.normpath(resolved))
+
+    key = str(rating_key)
+    with _LOCK:
+        data = _load_locked()
+        lib_entries = data.setdefault(library, {})
+        lib_entries[key] = canonical
+        _write_locked(data)
+    logger.debug(
+        "Stored folder override: library=%s ratingKey=%s -> %s",
+        library,
+        key,
+        canonical,
+    )
+    return canonical
+
+
+def clear_override(library: str, rating_key: str) -> bool:
+    if not library or not rating_key:
+        return False
+    key = str(rating_key)
+    removed = False
+    with _LOCK:
+        data = _load_locked()
+        lib_entries = data.get(library)
+        if lib_entries and key in lib_entries:
+            removed = True
+            lib_entries.pop(key, None)
+            if not lib_entries:
+                data.pop(library, None)
+            _write_locked(data)
+    if removed:
+        logger.debug(
+            "Cleared folder override: library=%s ratingKey=%s",
+            library,
+            key,
+        )
+    return removed

--- a/tests/test_collections_route.py
+++ b/tests/test_collections_route.py
@@ -1,5 +1,7 @@
+import importlib
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -37,14 +39,15 @@ class _DummyPlex:
 
 
 @pytest.fixture
-def collections_call(tmp_path, monkeypatch):
+def collections_env(tmp_path, monkeypatch):
     assets_root = tmp_path / "assets"
     collections_root = assets_root / "Collections"
     ready_folder = collections_root / "my cool collection"
     ready_folder.mkdir(parents=True)
+    override_folder = collections_root / "override folder"
+    override_folder.mkdir()
 
     from app import config
-    from app.routers import collections as collections_router
 
     monkeypatch.setattr(config, "PLEX_URL", "http://plex.test")
     monkeypatch.setattr(config, "PLEX_TOKEN", "token")
@@ -52,6 +55,17 @@ def collections_call(tmp_path, monkeypatch):
 
     monkeypatch.setenv("KAM_ASSETS_ROOT", str(assets_root))
     monkeypatch.setenv("COLLECTIONS_ROOT", str(collections_root))
+    monkeypatch.setattr(config, "COLLECTIONS_ROOT", str(collections_root))
+    overrides_path = tmp_path / "overrides.json"
+    monkeypatch.setenv("KAM_FOLDER_OVERRIDES_PATH", str(overrides_path))
+
+    resolve_module = importlib.reload(importlib.import_module("app.services.resolve"))
+    resolve_module.ASSETS_ROOT = str(assets_root)
+
+    folder_overrides = importlib.reload(importlib.import_module("app.services.folder_overrides"))
+    folder_overrides.set_storage_path(str(overrides_path))
+
+    collections_router = importlib.reload(importlib.import_module("app.routers.collections"))
 
     collections_router.ASSETS_ROOT = str(assets_root)
     collections_router.COLLECTIONS_ROOT = str(collections_root)
@@ -68,11 +82,16 @@ def collections_call(tmp_path, monkeypatch):
         params.update(kwargs)
         return collections_router.collections(**params)
 
-    return _call
+    return SimpleNamespace(
+        call=_call,
+        folder_overrides=folder_overrides,
+        override_folder=override_folder,
+        collections_root=collections_root,
+    )
 
 
-def test_collections_route_marks_asset_readiness(collections_call):
-    data = collections_call()
+def test_collections_route_marks_asset_readiness(collections_env):
+    data = collections_env.call()
     items = {it["title"]: it for it in data["items"]}
 
     ready = items["My Cool Collection"]
@@ -89,3 +108,19 @@ def test_index_html_consumes_asset_ready_flag():
     html = (ROOT / "app" / "web" / "index.html").read_text(encoding="utf-8")
     assert "filter(it => it?.assetReady !== false)" in html
     assert "let folderName = it?.folderName || \"\"" in html
+
+
+def test_collections_route_uses_overrides(collections_env):
+    folder = collections_env.override_folder
+    (folder / "poster.jpg").write_bytes(b"poster")
+
+    collections_env.folder_overrides.set_override("Collections", "2", folder.name)
+
+    data = collections_env.call()
+    items = {it["title"]: it for it in data["items"]}
+    overridden = items["Missing Assets"]
+
+    assert overridden["folderName"] == folder.name
+    assert overridden["assetReady"] is True
+    assert overridden["posterUrlLocal"] is not None
+    assert folder.name.replace(" ", "%20") in overridden["posterUrlLocal"]

--- a/tests/test_folder_overrides.py
+++ b/tests/test_folder_overrides.py
@@ -1,0 +1,104 @@
+import importlib
+import json
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+
+@pytest.fixture
+def overrides_env(tmp_path, monkeypatch):
+    assets_root = tmp_path / "assets"
+    movies_dir = assets_root / "Movies"
+    movies_dir.mkdir(parents=True)
+    movie_folder = movies_dir / "Jurassic World Fallen Kingdom (Extended Edition) (2018)"
+    movie_folder.mkdir()
+    (movie_folder / "poster.jpg").write_bytes(b"poster")
+    (movie_folder / "background.jpg").write_bytes(b"background")
+
+    collections_dir = assets_root / "Collections"
+    collections_dir.mkdir()
+    (collections_dir / "Override Collection").mkdir()
+
+    overrides_path = tmp_path / "overrides.json"
+
+    monkeypatch.setenv("KAM_ASSETS_ROOT", str(assets_root))
+    monkeypatch.setenv("KAM_FOLDER_OVERRIDES_PATH", str(overrides_path))
+
+    from app import config
+
+    monkeypatch.setattr(config, "LIBRARY_MAPPINGS", {"Movies": str(movies_dir)})
+    monkeypatch.setattr(config, "COLLECTIONS_ROOT", str(collections_dir))
+
+    resolve_module = importlib.reload(importlib.import_module("app.services.resolve"))
+    resolve_module.ASSETS_ROOT = str(assets_root)
+
+    folder_overrides = importlib.reload(importlib.import_module("app.services.folder_overrides"))
+    folder_overrides.set_storage_path(str(overrides_path))
+
+    assets_router = importlib.reload(importlib.import_module("app.routers.assets"))
+
+    return SimpleNamespace(
+        folder_overrides=folder_overrides,
+        assets_router=assets_router,
+        overrides_path=overrides_path,
+        movie_folder=movie_folder,
+        movies_dir=movies_dir,
+        collections_dir=collections_dir,
+    )
+
+
+def test_folder_override_roundtrip(overrides_env):
+    fo = overrides_env.folder_overrides
+
+    saved = fo.set_override("Movies", "1", overrides_env.movie_folder.name)
+    assert saved == overrides_env.movie_folder.name
+    assert fo.get_override("Movies", "1") == overrides_env.movie_folder.name
+
+    data = json.loads(overrides_env.overrides_path.read_text(encoding="utf-8"))
+    assert data == {"Movies": {"1": overrides_env.movie_folder.name}}
+
+    assert fo.clear_override("Movies", "1") is True
+    assert fo.get_override("Movies", "1") is None
+
+
+def test_assign_folder_endpoint_persists_override(overrides_env):
+    fo = overrides_env.folder_overrides
+    router = overrides_env.assets_router
+
+    payload = router.AssignFolderPayload(
+        library="Movies",
+        ratingKey="9",
+        folderName=overrides_env.movie_folder.name,
+    )
+    result = router.assign_folder(payload)
+
+    assert result["folderName"] == overrides_env.movie_folder.name
+    assert result["assetReady"] is True
+    assert result["posterExists"] is True
+    assert result["backgroundExists"] is True
+    assert fo.get_override("Movies", "9") == overrides_env.movie_folder.name
+
+
+def test_list_asset_folders(overrides_env):
+    router = overrides_env.assets_router
+    movie_folder = overrides_env.movie_folder
+    nested = movie_folder / "Extras"
+    nested.mkdir()
+    (movie_folder / "note.txt").write_text("hello", encoding="utf-8")
+
+    listing = router.list_asset_folders(library="Movies")
+    assert listing["library"] == "Movies"
+    names = {item["name"] for item in listing["items"]}
+    assert movie_folder.name in names
+
+    filtered = router.list_asset_folders(library="Movies", search="extras")
+    assert any(item["name"] == "Extras" for item in filtered["items"])
+
+    sub_listing = router.list_asset_folders(library="Movies", parent=movie_folder.name)
+    sub_names = {item["name"] for item in sub_listing["items"]}
+    assert "Extras" in sub_names
+    assert "note.txt" in sub_names
+
+    with pytest.raises(HTTPException):
+        router.list_asset_folders(library="Movies", parent="../..")

--- a/tests/test_items_route.py
+++ b/tests/test_items_route.py
@@ -1,0 +1,71 @@
+import importlib
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture
+def items_env(tmp_path, monkeypatch):
+    assets_root = tmp_path / "assets"
+    library = "Movies"
+    library_path = assets_root / library
+    folder = library_path / "My Film (2023)"
+    folder.mkdir(parents=True)
+    (folder / "poster.jpg").write_bytes(b"poster")
+
+    overrides_path = tmp_path / "overrides.json"
+
+    monkeypatch.setenv("KAM_ASSETS_ROOT", str(assets_root))
+    monkeypatch.setenv("KAM_FOLDER_OVERRIDES_PATH", str(overrides_path))
+    monkeypatch.setenv("PLEX_URL", "http://plex.test")
+    monkeypatch.setenv("PLEX_TOKEN", "token")
+
+    from app import config
+
+    monkeypatch.setattr(config, "LIBRARY_MAPPINGS", {library: str(library_path)})
+    monkeypatch.setattr(config, "COLLECTIONS_ROOT", "")
+
+    resolve_module = importlib.reload(importlib.import_module("app.services.resolve"))
+    resolve_module.ASSETS_ROOT = str(assets_root)
+
+    folder_overrides = importlib.reload(importlib.import_module("app.services.folder_overrides"))
+    folder_overrides.set_storage_path(str(overrides_path))
+
+    items_router = importlib.reload(importlib.import_module("app.routers.items"))
+
+    monkeypatch.setattr(items_router, "_section_key_by_name", lambda _: "1")
+
+    def fake_plex_list(path, params=None):
+        if params and params.get("type") == 1:
+            return [
+                {
+                    "title": "My Film",
+                    "year": 2023,
+                    "ratingKey": "11",
+                    "type": "movie",
+                    "thumb": "/thumb",
+                }
+            ]
+        return []
+
+    monkeypatch.setattr(items_router, "_plex_list", fake_plex_list)
+
+    def _call(**kwargs):
+        params = {"library": library, "page": 1, "page_size": 60, "query": None}
+        params.update(kwargs)
+        return items_router.list_items(**params)
+
+    return SimpleNamespace(
+        call=_call,
+        folder_overrides=folder_overrides,
+        folder=folder,
+    )
+
+
+def test_items_route_prefers_override(items_env):
+    items_env.folder_overrides.set_override("Movies", "11", items_env.folder.name)
+
+    data = items_env.call()
+    assert data["items"][0]["folderName"] == items_env.folder.name
+    assert data["items"][0]["assetReady"] is True
+    assert data["items"][0]["posterUrl"].startswith("/fileproxy")

--- a/tests/test_movie_route.py
+++ b/tests/test_movie_route.py
@@ -1,5 +1,7 @@
+import importlib
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -38,7 +40,7 @@ class _DummyItem:
 
 
 @pytest.fixture
-def movie_call(tmp_path, monkeypatch):
+def movie_env(tmp_path, monkeypatch):
     assets_root = tmp_path / "assets"
     library = "Movies"
     library_path = assets_root / library
@@ -52,15 +54,23 @@ def movie_call(tmp_path, monkeypatch):
     (library_path / "Completely Different (2020)").mkdir()
 
     from app import config
-    from app.services import resolve as resolve_module
-    from app.routers import movie as movie_router
 
     monkeypatch.setattr(config, "LIBRARY_MAPPINGS", {library: str(library_path)})
     monkeypatch.setattr(config, "PLEX_URL", "http://plex.test")
     monkeypatch.setattr(config, "PLEX_TOKEN", "token")
     monkeypatch.setattr(config, "CONFIG_ERRORS", [])
 
-    monkeypatch.setattr(resolve_module, "ASSETS_ROOT", str(assets_root))
+    monkeypatch.setenv("KAM_ASSETS_ROOT", str(assets_root))
+    overrides_path = tmp_path / "overrides.json"
+    monkeypatch.setenv("KAM_FOLDER_OVERRIDES_PATH", str(overrides_path))
+
+    resolve_module = importlib.reload(importlib.import_module("app.services.resolve"))
+    resolve_module.ASSETS_ROOT = str(assets_root)
+
+    folder_overrides = importlib.reload(importlib.import_module("app.services.folder_overrides"))
+    folder_overrides.set_storage_path(str(overrides_path))
+
+    movie_router = importlib.reload(importlib.import_module("app.routers.movie"))
 
     items = {
         1: _DummyItem("Jurassic World: Fallen Kingdom", 2018),
@@ -73,16 +83,35 @@ def movie_call(tmp_path, monkeypatch):
     def _call(rating_key: int):
         return movie_router.movie_api(library=library, ratingKey=rating_key)
 
-    return _call
+    return SimpleNamespace(
+        call=_call,
+        folder_overrides=folder_overrides,
+        library_path=library_path,
+        existing_variant=existing_variant,
+    )
 
 
-def test_movie_route_uses_resolved_folder(movie_call):
-    data = movie_call(1)
+def test_movie_route_uses_resolved_folder(movie_env):
+    data = movie_env.call(1)
     assert data["folderExists"] is True
     assert data["folderName"] == "Jurassic World Fallen Kingdom (Extended Edition) (2018)"
 
 
-def test_movie_route_rejects_unrelated_folder(movie_call):
-    data = movie_call(2)
+def test_movie_route_rejects_unrelated_folder(movie_env):
+    data = movie_env.call(2)
     assert data["folderExists"] is False
     assert data["folderName"] == "Some Other Movie (2021)"
+
+
+def test_movie_route_prefers_override(movie_env):
+    folder = movie_env.library_path / movie_env.existing_variant
+    (folder / "poster.jpg").write_bytes(b"poster")
+    (folder / "background.jpg").write_bytes(b"bg")
+
+    movie_env.folder_overrides.set_override("Movies", "1", folder.name)
+
+    data = movie_env.call(1)
+    assert data["folderName"] == folder.name
+    assert data["folderExists"] is True
+    assert data["posterExists"] is True
+    assert data["backgroundExists"] is True

--- a/tests/test_tv_route.py
+++ b/tests/test_tv_route.py
@@ -1,0 +1,102 @@
+import importlib
+from types import SimpleNamespace
+
+import pytest
+
+
+class _DummyResponse:
+    def __init__(self, payload):
+        self._payload = payload
+        self.headers = {"Content-Type": "application/json"}
+
+    def json(self):
+        return self._payload
+
+    @property
+    def text(self):  # pragma: no cover - not used in tests
+        return ""
+
+
+@pytest.fixture
+def tv_env(tmp_path, monkeypatch):
+    assets_root = tmp_path / "assets"
+    library = "TV Shows"
+    library_path = assets_root / library
+    show_folder = library_path / "My Show (2023)"
+    show_folder.mkdir(parents=True)
+    (show_folder / "poster.jpg").write_bytes(b"poster")
+    (show_folder / "background.jpg").write_bytes(b"background")
+    (show_folder / "Season01.jpg").write_bytes(b"s1")
+
+    overrides_path = tmp_path / "overrides.json"
+
+    monkeypatch.setenv("KAM_ASSETS_ROOT", str(assets_root))
+    monkeypatch.setenv("KAM_FOLDER_OVERRIDES_PATH", str(overrides_path))
+    monkeypatch.setenv("PLEX_URL", "http://plex.test")
+    monkeypatch.setenv("PLEX_TOKEN", "token")
+
+    from app import config
+
+    monkeypatch.setattr(config, "LIBRARY_MAPPINGS", {library: str(library_path)})
+    monkeypatch.setattr(config, "COLLECTIONS_ROOT", "")
+
+    resolve_module = importlib.reload(importlib.import_module("app.services.resolve"))
+    resolve_module.ASSETS_ROOT = str(assets_root)
+
+    folder_overrides = importlib.reload(importlib.import_module("app.services.folder_overrides"))
+    folder_overrides.set_storage_path(str(overrides_path))
+
+    tv_router = importlib.reload(importlib.import_module("app.routers.tv"))
+
+    def fake_plex(path):
+        if path.endswith("/children"):
+            payload = {
+                "MediaContainer": {
+                    "Metadata": [
+                        {
+                            "type": "season",
+                            "index": 1,
+                            "title": "Season 1",
+                            "ratingKey": "201",
+                            "thumb": "/season/thumb",
+                        }
+                    ]
+                }
+            }
+        else:
+            payload = {
+                "MediaContainer": {
+                    "Metadata": [
+                        {
+                            "type": "show",
+                            "title": "My Show",
+                            "year": 2023,
+                            "thumb": "/show/thumb",
+                            "art": "/show/art",
+                        }
+                    ]
+                }
+            }
+        return _DummyResponse(payload)
+
+    monkeypatch.setattr(tv_router, "_plex_json_or_xml", fake_plex)
+
+    def _call():
+        return tv_router.get_show(library=library, ratingKey="101")
+
+    return SimpleNamespace(
+        call=_call,
+        folder_overrides=folder_overrides,
+        show_folder=show_folder,
+    )
+
+
+def test_tv_route_prefers_override(tv_env):
+    tv_env.folder_overrides.set_override("TV Shows", "101", tv_env.show_folder.name)
+
+    data = tv_env.call()
+    assert data["folderName"] == tv_env.show_folder.name
+    assert data["folderExists"] is True
+    assert data["posterUrl"].startswith("/fileproxy")
+    assert data["backgroundUrl"].startswith("/fileproxy")
+    assert data["seasons"][0]["posterUrl"].startswith("/fileproxy")


### PR DESCRIPTION
## Summary
- add a JSON-backed folder override service and API router for assigning and browsing asset directories
- consult stored overrides in item, collection, movie, and TV routes to surface custom folders and cached art
- extend the test suite to cover override persistence, new asset router endpoints, and updated route behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df15e0492883308f0bdd449e5876fe