### PR TITLE
Add UI for assigning asset folders from index page

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,8 @@ Kometa Asset Manager can now be found in the Unraid app store. Simply mount your
 
 1. Open the web UI.
 2. Choose the item (movie, series, collection, or season) you want to update.
-3. Upload artwork. KAM will:
+3. If the item shows a red “Not Ready” badge, activate it to open the **folder finder** dialog, browse/search your Kometa assets, and assign the correct folder. Once paired the badge flips to ✔ Ready.
+4. Upload artwork. KAM will:
 
    * Convert to `.jpg`
    * Remove any existing `poster.*`, `background.*`, or `SeasonNN.*` for that item

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -45,7 +45,27 @@
   [data-theme="light"] .card[data-ready="false"]{border-color:#fca5a5}
   .year{color:var(--muted); font-size:13px}
   dialog{border:none; border-radius:14px; padding:0; max-width:520px; width:calc(100% - 24px)}
+  dialog::backdrop{background:rgba(0,0,0,.55)}
   .dlg-body{padding:16px}
+  .folder-dlg{max-width:640px}
+  .folder-dlg h2{margin:0 0 4px}
+  .folder-context{margin:0 0 12px; font-size:13px; color:var(--muted)}
+  .breadcrumbs{display:flex; flex-wrap:wrap; gap:4px; padding:0; margin:0 0 12px; list-style:none; font-size:13px}
+  .breadcrumbs li{display:flex; align-items:center; gap:4px}
+  .breadcrumbs button{background:none; border:none; padding:0 4px; border-radius:6px; color:var(--fg); cursor:pointer; font:inherit}
+  .breadcrumbs button:hover,.breadcrumbs button:focus{background:var(--border); outline:none}
+  .folder-search{display:flex; flex-direction:column; gap:6px; margin-bottom:12px}
+  .folder-search label{font-size:13px; color:var(--muted)}
+  .folder-results{border:1px solid var(--border); border-radius:12px; min-height:160px; max-height:320px; overflow:auto; padding:0; margin:0; list-style:none}
+  .folder-row{display:flex; align-items:center; justify-content:space-between; gap:8px; padding:10px 12px; border-bottom:1px solid var(--border)}
+  .folder-row:last-child{border-bottom:none}
+  .folder-option{flex:1 1 auto; text-align:left; background:none; border:none; color:var(--fg); font:inherit; cursor:pointer; padding:0}
+  .folder-option:hover,.folder-option:focus{color:var(--accent); outline:none}
+  .folder-open{background:none; border:1px solid var(--border); border-radius:999px; color:var(--fg); font-size:12px; padding:4px 10px; cursor:pointer}
+  .folder-open:hover,.folder-open:focus{border-color:var(--accent); outline:none}
+  .folder-row.is-selected{background:rgba(94,161,255,0.12)}
+  .folder-empty{padding:16px; text-align:center; font-size:14px; color:var(--muted)}
+  .folder-alert{margin-top:12px; font-size:13px; color:#ff7a7a; min-height:18px}
   .row{display:flex; gap:10px; align-items:center; margin:8px 0}
   .row label{min-width:110px; color:var(--muted)}
   .actions{display:flex; gap:8px; align-items:center; justify-content:flex-end; padding:10px 16px; border-top:1px solid var(--border)}
@@ -89,6 +109,31 @@
 <main>
   <div id="grid" aria-live="polite"></div>
 </main>
+
+<!-- Folder finder dialog -->
+<dialog id="folderFinder" class="folder-dlg" data-folder-dialog>
+  <form id="folderFinderForm" method="dialog" aria-labelledby="folderFinderHeading">
+    <div class="dlg-body">
+      <h2 id="folderFinderHeading">Select Asset Folder</h2>
+      <p class="folder-context" data-folder-context>
+        Choose a folder to pair with this library item.
+      </p>
+      <nav aria-label="Folder breadcrumbs">
+        <ol class="breadcrumbs" data-folder-breadcrumbs></ol>
+      </nav>
+      <div class="folder-search">
+        <label for="folderFinderSearch">Search folders</label>
+        <input id="folderFinderSearch" name="query" type="search" placeholder="Search by folder name" autocomplete="off" />
+      </div>
+      <ul class="folder-results" role="listbox" data-folder-results></ul>
+      <p class="folder-alert" role="alert" data-folder-alert></p>
+    </div>
+    <div class="actions">
+      <button type="button" data-folder-cancel>Cancel</button>
+      <button type="submit" id="folderFinderConfirm" class="btn" data-folder-confirm disabled>Use This Folder</button>
+    </div>
+  </form>
+</dialog>
 
 <!-- Upload dialog (left intact but no longer opened by clicking items) -->
 <dialog id="uploader">
@@ -139,6 +184,15 @@
   const lastBtn  = document.getElementById("lastBtn");
   const pageInfo = document.getElementById("pageInfo");
   const countEl  = document.getElementById("count");
+  const folderFinder = document.getElementById("folderFinder");
+  const folderFinderForm = document.getElementById("folderFinderForm");
+  const folderFinderContext = folderFinder ? folderFinder.querySelector("[data-folder-context]") : null;
+  const folderFinderBreadcrumbs = folderFinder ? folderFinder.querySelector("[data-folder-breadcrumbs]") : null;
+  const folderFinderResults = folderFinder ? folderFinder.querySelector("[data-folder-results]") : null;
+  const folderFinderAlert = folderFinder ? folderFinder.querySelector("[data-folder-alert]") : null;
+  const folderFinderSearch = document.getElementById("folderFinderSearch");
+  const folderFinderConfirm = folderFinder ? folderFinder.querySelector("[data-folder-confirm]") : null;
+  const folderFinderCancel = folderFinder ? folderFinder.querySelector("[data-folder-cancel]") : null;
 
   const state = {
     library: null,
@@ -146,7 +200,20 @@
     totalPages: 1,
     pageSize: 60,
     totalCount: 0,
-    query: null
+    query: null,
+    items: []
+  };
+
+  const folderState = {
+    item: null,
+    library: null,
+    currentPath: null,
+    breadcrumbs: [],
+    results: [],
+    selection: null,
+    isSearching: false,
+    query: "",
+    loading: false,
   };
 
   // Progress helpers
@@ -295,6 +362,288 @@
   }
   function esc(s){ return (s||"").replace(/[&<>"]/g, m => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[m])); }
 
+  function normalizeFolderEntry(entry){
+    if (!entry) return null;
+    const name = entry.name || entry.folderName || entry.folder || entry.label || entry.title;
+    if (!name) return null;
+    const path = entry.path || entry.folderPath || entry.fullPath || entry.id || name;
+    return {
+      name: String(name),
+      path: String(path),
+      hasChildren: entry.hasChildren === undefined ? true : Boolean(entry.hasChildren),
+    };
+  }
+
+  function computeBreadcrumbs(data){
+    const incoming = Array.isArray(data && data.breadcrumbs) ? data.breadcrumbs : [];
+    if (incoming.length){
+      return incoming.map((crumb, index) => ({
+        name: crumb?.name || crumb?.title || crumb?.label || crumb?.folderName || (index === 0 ? "Root" : "…"),
+        path: crumb?.path ?? crumb?.folderPath ?? crumb?.id ?? (index === 0 ? null : null),
+      }));
+    }
+    const current = folderState.currentPath;
+    const base = [{ name: "Root", path: null }];
+    if (!current){
+      return base;
+    }
+    const parts = String(current).split(/[\\/]+/).filter(Boolean);
+    let acc = "";
+    for (const part of parts){
+      acc = acc ? `${acc}/${part}` : part;
+      base.push({ name: part, path: acc });
+    }
+    return base;
+  }
+
+  function renderFolderBreadcrumbs(breadcrumbs){
+    if (!folderFinderBreadcrumbs) return;
+    folderFinderBreadcrumbs.innerHTML = "";
+    const crumbs = Array.isArray(breadcrumbs) && breadcrumbs.length ? breadcrumbs : [{ name: "Root", path: null }];
+    crumbs.forEach((crumb, index) => {
+      const li = document.createElement("li");
+      const btn = document.createElement("button");
+      btn.type = "button";
+      btn.textContent = crumb.name || (index === 0 ? "Root" : "…");
+      btn.dataset.folderBreadcrumb = "true";
+      btn.addEventListener("click", (ev) => {
+        ev.preventDefault();
+        loadFolderListing({ path: crumb.path || null, query: null });
+      });
+      if (index === crumbs.length - 1 && !folderState.isSearching){
+        btn.setAttribute("aria-current", "location");
+        btn.disabled = true;
+      }
+      li.appendChild(btn);
+      if (index < crumbs.length - 1){
+        const sep = document.createElement("span");
+        sep.textContent = "/";
+        sep.setAttribute("aria-hidden", "true");
+        li.appendChild(sep);
+      }
+      folderFinderBreadcrumbs.appendChild(li);
+    });
+    if (folderState.isSearching && folderState.query){
+      const li = document.createElement("li");
+      const label = document.createElement("span");
+      label.className = "tag";
+      label.textContent = `Search: ${folderState.query}`;
+      li.appendChild(label);
+      folderFinderBreadcrumbs.appendChild(li);
+    }
+  }
+
+  function highlightFolderSelection(){
+    if (!folderFinderResults) return;
+    const rows = folderFinderResults.querySelectorAll(".folder-row");
+    rows.forEach((row) => {
+      const rowPath = row.getAttribute("data-folder-path");
+      if (folderState.selection && rowPath === folderState.selection.path){
+        row.classList.add("is-selected");
+        row.setAttribute("aria-selected", "true");
+      } else {
+        row.classList.remove("is-selected");
+        row.removeAttribute("aria-selected");
+      }
+    });
+  }
+
+  function renderFolderResults(folders){
+    if (!folderFinderResults) return;
+    folderFinderResults.innerHTML = "";
+    const list = Array.isArray(folders) ? folders : [];
+    if (!list.length){
+      const empty = document.createElement("li");
+      empty.className = "folder-empty";
+      empty.textContent = folderState.isSearching
+        ? "No folders matched your search."
+        : "No folders available in this location.";
+      folderFinderResults.appendChild(empty);
+      if (folderFinderConfirm) folderFinderConfirm.disabled = true;
+      highlightFolderSelection();
+      return;
+    }
+    list.forEach((folder) => {
+      const li = document.createElement("li");
+      li.className = "folder-row";
+      li.setAttribute("role", "option");
+      li.setAttribute("data-folder-path", folder.path);
+
+      const option = document.createElement("button");
+      option.type = "button";
+      option.className = "folder-option";
+      option.dataset.folderSelect = "true";
+      option.textContent = folder.name;
+      option.title = `Select \"${folder.name}\"`;
+      option.addEventListener("click", (ev) => {
+        ev.preventDefault();
+        selectFolder(folder);
+      });
+      li.appendChild(option);
+
+      if (folder.hasChildren !== false){
+        const openBtn = document.createElement("button");
+        openBtn.type = "button";
+        openBtn.className = "folder-open";
+        openBtn.dataset.folderOpen = "true";
+        openBtn.textContent = folderState.isSearching ? "Go" : "Open";
+        openBtn.addEventListener("click", (ev) => {
+          ev.preventDefault();
+          ev.stopPropagation();
+          folderState.selection = null;
+          if (folderFinderConfirm) folderFinderConfirm.disabled = true;
+          loadFolderListing({ path: folder.path, query: null });
+        });
+        li.appendChild(openBtn);
+      }
+
+      folderFinderResults.appendChild(li);
+    });
+    highlightFolderSelection();
+  }
+
+  function selectFolder(folder){
+    folderState.selection = folder;
+    if (folderFinderConfirm) folderFinderConfirm.disabled = !folder;
+    if (folderFinderAlert) folderFinderAlert.textContent = "";
+    highlightFolderSelection();
+  }
+
+  async function loadFolderListing({ path = null, query = null, preserveSelection = false } = {}){
+    if (!folderFinderResults) return;
+    folderState.loading = true;
+    folderState.currentPath = path || null;
+    folderState.query = query || "";
+    folderState.isSearching = Boolean(query);
+    if (!preserveSelection){
+      folderState.selection = null;
+      if (folderFinderConfirm) folderFinderConfirm.disabled = true;
+    }
+    folderFinderResults.innerHTML = "";
+    const loadingRow = document.createElement("li");
+    loadingRow.className = "folder-empty";
+    loadingRow.textContent = "Loading folders…";
+    folderFinderResults.appendChild(loadingRow);
+
+    try {
+      const params = new URLSearchParams();
+      if (folderState.library) params.set("library", folderState.library);
+      if (path) params.set("path", path);
+      if (query) params.set("query", query);
+      const response = await fetch(`/api/asset-folders?${params.toString()}`);
+      const data = await safeJson(response);
+      if (!response.ok){
+        throw new Error(responseErrorMessage(response, data));
+      }
+      const rawList = Array.isArray(data?.folders)
+        ? data.folders
+        : Array.isArray(data?.items)
+          ? data.items
+          : [];
+      const normalized = rawList
+        .map(normalizeFolderEntry)
+        .filter(Boolean);
+      folderState.results = normalized;
+      folderState.breadcrumbs = computeBreadcrumbs(data);
+      renderFolderBreadcrumbs(folderState.breadcrumbs);
+      renderFolderResults(normalized);
+      if (folderFinderAlert) folderFinderAlert.textContent = "";
+    } catch (err) {
+      folderState.results = [];
+      renderFolderBreadcrumbs(computeBreadcrumbs({}));
+      renderFolderResults([]);
+      if (folderFinderAlert) folderFinderAlert.textContent = err?.message || String(err);
+    } finally {
+      folderState.loading = false;
+    }
+  }
+
+  function setFolderFinderContext(item){
+    if (!folderFinderContext) return;
+    const title = item?.title || item?.name || "(Untitled)";
+    const library = folderState.library || state.library || "";
+    folderFinderContext.textContent = `Library: ${library} • Item: ${title}`;
+  }
+
+  function openFolderFinderFor(item){
+    if (!folderFinder || typeof folderFinder.showModal !== "function") return;
+    folderState.item = item;
+    folderState.library = item?.library || state.library || "";
+    folderState.currentPath = null;
+    folderState.selection = null;
+    folderState.query = "";
+    folderState.isSearching = false;
+    setFolderFinderContext(item);
+    if (folderFinderSearch) folderFinderSearch.value = "";
+    if (folderFinderConfirm) folderFinderConfirm.disabled = true;
+    if (folderFinderAlert) folderFinderAlert.textContent = "";
+    renderFolderBreadcrumbs([{ name: "Root", path: null }]);
+    renderFolderResults([]);
+    try {
+      folderFinder.showModal();
+      loadFolderListing({ path: null, query: null });
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  function closeFolderFinder(){
+    if (!folderFinder) return;
+    try {
+      folderFinder.close();
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  async function handleFolderAssignment(ev){
+    ev.preventDefault();
+    if (!folderState.selection){
+      if (folderFinderAlert) folderFinderAlert.textContent = "Select a folder before confirming.";
+      if (folderFinderConfirm) folderFinderConfirm.disabled = true;
+      return;
+    }
+    if (!folderState.item){
+      if (folderFinderAlert) folderFinderAlert.textContent = "Unable to determine the item to update.";
+      return;
+    }
+    if (folderFinderConfirm) folderFinderConfirm.disabled = true;
+    const payload = {
+      library: folderState.library,
+      folderName: folderState.selection.name,
+    };
+    const ratingKey = folderState.item?.ratingKey || folderState.item?.key || folderState.item?.id;
+    if (ratingKey !== undefined && ratingKey !== null && ratingKey !== "") {
+      payload.ratingKey = ratingKey;
+    }
+    if (folderState.selection.path) {
+      payload.folderPath = folderState.selection.path;
+    }
+
+    try {
+      const response = await fetch("/api/items/assign-folder", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const data = await safeJson(response);
+      if (!response.ok){
+        throw new Error(responseErrorMessage(response, data));
+      }
+      const assignedName = data?.folderName || folderState.selection.name;
+      folderState.item.assetReady = true;
+      folderState.item.folderName = assignedName;
+      folderState.item.folder = assignedName;
+      closeFolderFinder();
+      renderItems(state.items);
+      flashStatusMessage(`Folder assigned: ${assignedName}`);
+      await loadPage(state.page);
+    } catch (err) {
+      if (folderFinderAlert) folderFinderAlert.textContent = err?.message || String(err);
+      if (folderFinderConfirm) folderFinderConfirm.disabled = !folderState.selection;
+    }
+  }
+
   // NEW: determine if an item is a TV show
   function isShowItem(it, libraryName){
     const libTV = (libraryName || '').toLowerCase().includes('tv');
@@ -347,7 +696,22 @@
       status.textContent = isReady ? "✔ Ready" : "✖ Not Ready";
       status.title = isReady
         ? "Asset folder found. This item is ready for imports."
-        : "Asset folder missing. This item is not ready for imports.";
+        : "Asset folder missing. Click to choose a folder.";
+      if (!isReady) {
+        status.dataset.folderTrigger = "true";
+        status.setAttribute("role", "button");
+        status.setAttribute("aria-haspopup", "dialog");
+        status.setAttribute("aria-controls", "folderFinder");
+        status.tabIndex = 0;
+        const openBadgeDialog = (ev) => {
+          if (ev.type === "keydown" && ev.key !== "Enter" && ev.key !== " ") return;
+          ev.stopPropagation();
+          if (ev.type === "keydown") ev.preventDefault();
+          openFolderFinderFor(it);
+        };
+        status.addEventListener("click", openBadgeDialog);
+        status.addEventListener("keydown", openBadgeDialog);
+      }
       t.appendChild(status);
 
       const y = document.createElement("div");
@@ -419,8 +783,9 @@
       state.page = data.page || p || 1;
       state.totalPages = data.total_pages || 1;
       state.totalCount = data.total_count || (data.items ? data.items.length : 0);
+      state.items = Array.isArray(data.items) ? data.items : [];
       countEl.textContent = `${state.totalCount.toLocaleString()} items`;
-      renderItems(data.items || []);
+      renderItems(state.items);
       updatePager();
     } catch (e) {
       flashStatusMessage(String(e));
@@ -808,6 +1173,38 @@
       loadPage(1);
     }, 300);
   });
+
+  if (folderFinderForm) folderFinderForm.addEventListener("submit", handleFolderAssignment);
+  if (folderFinderCancel) {
+    folderFinderCancel.addEventListener("click", (ev) => {
+      ev.preventDefault();
+      closeFolderFinder();
+    });
+  }
+  if (folderFinder) {
+    folderFinder.addEventListener("cancel", (ev) => {
+      ev.preventDefault();
+      closeFolderFinder();
+    });
+    folderFinder.addEventListener("close", () => {
+      folderState.item = null;
+      folderState.selection = null;
+    });
+  }
+  let folderFinderSearchTimer = null;
+  if (folderFinderSearch) {
+    folderFinderSearch.addEventListener("input", () => {
+      clearTimeout(folderFinderSearchTimer);
+      folderFinderSearchTimer = setTimeout(() => {
+        const term = folderFinderSearch.value.trim();
+        if (term) {
+          loadFolderListing({ path: folderState.currentPath, query: term });
+        } else {
+          loadFolderListing({ path: folderState.currentPath, query: null, preserveSelection: false });
+        }
+      }, 250);
+    });
+  }
 
   // Upload dialog code left as-is (no longer invoked by clicking cards)
   const dlg = document.getElementById("uploader");

--- a/tests/test_collections_route.py
+++ b/tests/test_collections_route.py
@@ -89,3 +89,6 @@ def test_index_html_consumes_asset_ready_flag():
     html = (ROOT / "app" / "web" / "index.html").read_text(encoding="utf-8")
     assert "filter(it => it?.assetReady !== false)" in html
     assert "let folderName = it?.folderName || \"\"" in html
+    assert "id=\"folderFinder\"" in html
+    assert "data-folder-results" in html
+    assert "status.dataset.folderTrigger" in html


### PR DESCRIPTION
## Summary
- add an accessible folder finder dialog with breadcrumbs, search, and results powered by the asset-folder API
- wire not-ready badges to open the dialog, browse folders, and post assignments back to the server while refreshing the grid
- extend HTML coverage and README usage notes for the new folder assignment workflow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df15e5cf5483308ca304a3c4f8fdd8