### PR TITLE
feat: add react libraries dashboard

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+.dist
+/dist
+.env.local
+.vite
+

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>KAM</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "kam-frontend",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.1",
+    "vite": "^5.2.0"
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,18 @@
+import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
+import LibraryPage from './pages/LibraryPage.jsx';
+import { ThemeProvider } from './theme/ThemeProvider.jsx';
+
+function App() {
+  return (
+    <ThemeProvider>
+      <BrowserRouter>
+        <Routes>
+          <Route path="/" element={<Navigate to="/libraries" replace />} />
+          <Route path="/libraries" element={<LibraryPage />} />
+        </Routes>
+      </BrowserRouter>
+    </ThemeProvider>
+  );
+}
+
+export default App;

--- a/frontend/src/components/FolderFinderModal.jsx
+++ b/frontend/src/components/FolderFinderModal.jsx
@@ -1,0 +1,273 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+function normalizeFolderEntry(entry) {
+  if (!entry) return null;
+  const name = entry.name || entry.folderName || entry.label || entry.title;
+  if (!name) return null;
+  const path = entry.path ?? entry.folderPath ?? '';
+  const hasChildren = entry.hasChildren !== false && entry.isDir !== false;
+  return {
+    name: String(name),
+    path: path === '' ? '' : String(path),
+    hasChildren,
+  };
+}
+
+function makeBreadcrumbs(currentPath, query) {
+  const crumbs = [];
+  crumbs.push({ label: 'Root', path: '' });
+  if (currentPath) {
+    const parts = String(currentPath).split(/[\\/]+/).filter(Boolean);
+    let acc = '';
+    parts.forEach((part) => {
+      acc = acc ? `${acc}/${part}` : part;
+      crumbs.push({ label: part, path: acc });
+    });
+  }
+  if (query) {
+    crumbs.push({ label: `Search: ${query}`, path: null, isSearch: true });
+  }
+  return crumbs;
+}
+
+function FolderFinderModal({ isOpen, library, item, onClose, onFolderAssigned }) {
+  const effectiveLibrary = item?.library || library;
+  const [currentPath, setCurrentPath] = useState('');
+  const [results, setResults] = useState([]);
+  const [selection, setSelection] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [searchInput, setSearchInput] = useState('');
+  const [searchTerm, setSearchTerm] = useState('');
+  const [isSearching, setIsSearching] = useState(false);
+  const [assigning, setAssigning] = useState(false);
+  const debounceRef = useRef();
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setSearchInput('');
+    setSearchTerm('');
+    setSelection(null);
+    setError('');
+  }, [isOpen, effectiveLibrary]);
+
+  const loadFolders = useCallback(
+    async ({ path = '', query = '', preserveSelection = false } = {}) => {
+      if (!effectiveLibrary) {
+        setResults([]);
+        setError('No library mapping available for this item.');
+        return;
+      }
+      setLoading(true);
+      if (!preserveSelection) {
+        setSelection(null);
+      }
+      setError('');
+      setIsSearching(Boolean(query));
+      const params = new URLSearchParams();
+      params.set('library', effectiveLibrary);
+      if (path) params.set('parent', path);
+      if (query) params.set('search', query);
+
+      try {
+        const response = await fetch(`/api/asset-folders?${params.toString()}`);
+        const data = await response.json();
+        if (!response.ok) {
+          const message = data?.detail || data?.error || `${response.status} ${response.statusText}`;
+          throw new Error(message);
+        }
+        const list = Array.isArray(data?.folders)
+          ? data.folders
+          : Array.isArray(data?.items)
+          ? data.items
+          : [];
+        const normalized = list.map(normalizeFolderEntry).filter(Boolean);
+        setResults(normalized);
+        const parentPath = data?.parent ?? path ?? '';
+        setCurrentPath(parentPath || '');
+      } catch (err) {
+        setResults([]);
+        setError(err.message || 'Failed to load folders');
+      } finally {
+        setLoading(false);
+      }
+    },
+    [effectiveLibrary]
+  );
+
+  useEffect(() => {
+    if (!isOpen) return;
+    loadFolders({ path: '', query: '' });
+  }, [isOpen, loadFolders]);
+
+  useEffect(() => {
+    if (!isOpen) return undefined;
+    clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      setSearchTerm(searchInput.trim());
+    }, 250);
+    return () => clearTimeout(debounceRef.current);
+  }, [searchInput, isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    loadFolders({ path: currentPath, query: searchTerm, preserveSelection: false });
+  }, [searchTerm, isOpen, currentPath, loadFolders]);
+
+  const breadcrumbs = useMemo(() => makeBreadcrumbs(currentPath, isSearching ? searchTerm : ''), [currentPath, isSearching, searchTerm]);
+
+  const contextLabel = useMemo(() => {
+    const title = item?.title || item?.name || '(Untitled)';
+    if (!effectiveLibrary) return title;
+    return `Library: ${effectiveLibrary} • Item: ${title}`;
+  }, [effectiveLibrary, item]);
+
+  const handleSelect = (entry) => {
+    setSelection(entry);
+    setError('');
+  };
+
+  const handleOpen = (entry) => {
+    if (!entry?.path) return;
+    loadFolders({ path: entry.path, query: '', preserveSelection: false });
+    setSearchInput('');
+    setSearchTerm('');
+  };
+
+  const handleBreadcrumbClick = (crumb) => {
+    loadFolders({ path: crumb.path || '', query: '', preserveSelection: false });
+    setSearchInput('');
+    setSearchTerm('');
+  };
+
+  const handleConfirm = async (event) => {
+    event.preventDefault();
+    if (!selection) {
+      setError('Select a folder before confirming.');
+      return;
+    }
+    if (!effectiveLibrary) {
+      setError('Missing library context.');
+      return;
+    }
+    const ratingKey = item?.ratingKey ?? item?.key ?? item?.id;
+    const payload = {
+      library: effectiveLibrary,
+      folderName: selection.name,
+    };
+    if (ratingKey != null) {
+      payload.ratingKey = String(ratingKey);
+    }
+    setAssigning(true);
+    setError('');
+    try {
+      const response = await fetch('/api/items/assign-folder', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      const data = await response.json();
+      if (!response.ok) {
+        const message = data?.detail || data?.error || `${response.status} ${response.statusText}`;
+        throw new Error(message);
+      }
+      const folderName = data?.folderName || selection.name;
+      onFolderAssigned?.({ folderName, details: data, selection });
+    } catch (err) {
+      setError(err.message || 'Failed to assign folder');
+    } finally {
+      setAssigning(false);
+    }
+  };
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="dialog-backdrop">
+      <div className="dialog-panel folder-dlg" role="dialog" aria-modal="true" aria-labelledby="folderFinderHeading">
+        <form onSubmit={handleConfirm}>
+          <div className="dialog-body">
+            <h2 id="folderFinderHeading">Select Asset Folder</h2>
+            <p className="folder-context">{contextLabel}</p>
+            <nav aria-label="Folder breadcrumbs">
+              <ol className="breadcrumbs">
+                {breadcrumbs.map((crumb, index) => (
+                  <li key={`${crumb.label}-${index}`}>
+                    {crumb.isSearch ? (
+                      <span className="tag">{crumb.label}</span>
+                    ) : (
+                      <button
+                        type="button"
+                        onClick={() => handleBreadcrumbClick(crumb)}
+                        disabled={index === breadcrumbs.length - 1 && !isSearching}
+                        aria-current={index === breadcrumbs.length - 1 && !isSearching ? 'location' : undefined}
+                      >
+                        {crumb.label}
+                      </button>
+                    )}
+                    {index < breadcrumbs.length - 1 && !crumb.isSearch ? <span aria-hidden="true">/</span> : null}
+                  </li>
+                ))}
+              </ol>
+            </nav>
+            <div className="folder-search">
+              <label htmlFor="folderFinderSearch">Search folders</label>
+              <input
+                id="folderFinderSearch"
+                type="search"
+                placeholder="Search by folder name"
+                value={searchInput}
+                onChange={(event) => setSearchInput(event.target.value)}
+                autoComplete="off"
+              />
+            </div>
+            <ul className="folder-results" role="listbox">
+              {loading && <li className="folder-empty">Loading folders…</li>}
+              {!loading && !results.length && (
+                <li className="folder-empty">
+                  {isSearching && searchTerm ? 'No folders matched your search.' : 'No folders available in this location.'}
+                </li>
+              )}
+              {!loading &&
+                results.map((entry) => {
+                  const isSelected = selection?.path === entry.path && selection?.name === entry.name;
+                  return (
+                    <li
+                      key={`${entry.path}-${entry.name}`}
+                      className={`folder-row${isSelected ? ' is-selected' : ''}`}
+                      role="option"
+                      aria-selected={isSelected}
+                    >
+                      <button type="button" className="folder-option" onClick={() => handleSelect(entry)}>
+                        {entry.name}
+                      </button>
+                      {entry.hasChildren !== false && (
+                        <button type="button" className="folder-open" onClick={() => handleOpen(entry)}>
+                          {isSearching ? 'Go' : 'Open'}
+                        </button>
+                      )}
+                    </li>
+                  );
+                })}
+            </ul>
+            <p className="folder-alert" role="alert">
+              {error}
+            </p>
+          </div>
+          <div className="actions">
+            <button type="button" onClick={onClose} disabled={assigning}>
+              Cancel
+            </button>
+            <button type="submit" className="btn" disabled={!selection || assigning}>
+              {assigning ? 'Assigning…' : 'Use This Folder'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export default FolderFinderModal;

--- a/frontend/src/components/ImportStatusPanel.jsx
+++ b/frontend/src/components/ImportStatusPanel.jsx
@@ -1,0 +1,35 @@
+function formatFailure(entry) {
+  if (!entry) return 'Unknown issue';
+  const parts = [];
+  if (entry.library) parts.push(`[${entry.library}]`);
+  if (entry.title) parts.push(entry.title);
+  if (entry.folder && entry.folder !== entry.title) parts.push(`(${entry.folder})`);
+  let text = parts.join(' ');
+  if (entry.asset) text = text ? `${text} – ${entry.asset}` : entry.asset;
+  if (entry.message) text = text ? `${text}: ${entry.message}` : entry.message;
+  return text || 'Unknown issue';
+}
+
+function ImportStatusPanel({ active, percent, label, errors }) {
+  const hasErrors = Array.isArray(errors) && errors.length > 0;
+  const clamped = Number.isFinite(percent) ? Math.max(0, Math.min(100, percent)) : 0;
+  const classes = ['import-status'];
+  if (active) classes.push('is-active');
+  if (hasErrors) classes.push('has-errors');
+
+  return (
+    <div className={classes.join(' ')} aria-live="polite">
+      <div className="progress-wrapper">
+        <div className="progress-track">
+          <div className="progress-bar" style={{ width: `${clamped}%` }} />
+        </div>
+        <span className="progress-label">{label}</span>
+      </div>
+      <ul className="error-list">
+        {hasErrors && errors.map((entry, index) => <li key={index}>{formatFailure(entry)}</li>)}
+      </ul>
+    </div>
+  );
+}
+
+export default ImportStatusPanel;

--- a/frontend/src/components/ItemGrid.jsx
+++ b/frontend/src/components/ItemGrid.jsx
@@ -1,0 +1,98 @@
+import { buildDetailUrl, normalizePoster } from '../utils/items.js';
+
+function ItemGrid({ items, library, onRequestFolder, loading, error }) {
+  if (loading) {
+    return <div className="loading-state">Loading items…</div>;
+  }
+
+  if (error) {
+    return <div className="error-state">{error}</div>;
+  }
+
+  if (!items.length) {
+    return <div className="empty-state">No items found.</div>;
+  }
+
+  return (
+    <div id="grid" aria-live="polite">
+      {items.map((item, index) => {
+        const rawKey = item?.ratingKey ?? item?.key ?? item?.id ?? item?.title ?? index;
+        const key = typeof rawKey === 'string' ? rawKey : String(rawKey);
+        return <ItemCard key={key} item={item} library={library} onRequestFolder={onRequestFolder} />;
+      })}
+    </div>
+  );
+}
+
+function ItemCard({ item, library, onRequestFolder }) {
+  const ready = item?.assetReady !== false;
+  const title = item?.title || item?.name || '(Untitled)';
+  const year = item?.year;
+  const poster = normalizePoster(item);
+  const detailUrl = buildDetailUrl(item, library);
+  const readinessTooltip = ready ? 'Ready: asset folder found.' : 'Not ready: asset folder missing.';
+
+  const openFolder = (event) => {
+    if (!onRequestFolder) return;
+    if (event) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+    onRequestFolder(item);
+  };
+
+  const handleBadgeKey = (event) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      openFolder(event);
+    }
+  };
+
+  const handleCardClick = (event) => {
+    if (!detailUrl) return;
+    if (event.metaKey || event.ctrlKey) {
+      window.open(detailUrl, '_blank');
+    } else {
+      window.location.href = detailUrl;
+    }
+  };
+
+  return (
+    <div
+      className="card"
+      data-ready={ready ? 'true' : 'false'}
+      title={detailUrl ? `${readinessTooltip} Click to open details.` : readinessTooltip}
+      onClick={detailUrl ? handleCardClick : undefined}
+      role={detailUrl ? 'button' : undefined}
+      tabIndex={detailUrl ? 0 : undefined}
+      onKeyDown={detailUrl ? (event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          handleCardClick(event);
+        }
+      } : undefined}
+    >
+      <img className="poster" src={poster} alt={title} loading="lazy" />
+      <div className="meta">
+        <div className="title">
+          <span className="title-text" title={title}>
+            {title}
+          </span>
+          <span
+            className={`ready-badge ${ready ? 'ready' : 'not-ready'}`}
+            title={ready ? 'Asset folder found. This item is ready for imports.' : 'Asset folder missing. Click to choose a folder.'}
+            role={!ready ? 'button' : undefined}
+            tabIndex={!ready ? 0 : undefined}
+            onClick={!ready ? openFolder : undefined}
+            onKeyDown={!ready ? handleBadgeKey : undefined}
+            aria-haspopup={!ready ? 'dialog' : undefined}
+          >
+            {ready ? '✔ Ready' : '✖ Not Ready'}
+          </span>
+        </div>
+        <div className="year">{year ? String(year) : ''}</div>
+      </div>
+    </div>
+  );
+}
+
+export default ItemGrid;

--- a/frontend/src/components/LibraryToolbar.jsx
+++ b/frontend/src/components/LibraryToolbar.jsx
@@ -1,0 +1,85 @@
+function LibraryToolbar({
+  libraries,
+  selectedLibrary,
+  onLibraryChange,
+  searchValue,
+  onSearchChange,
+  onImportAll,
+  importDisabled,
+  importTitle,
+  page,
+  totalPages,
+  onFirst,
+  onPrev,
+  onNext,
+  onLast,
+  countLabel,
+  children,
+}) {
+  return (
+    <div className="page-header-tools" id="toolbar">
+      <label className="sr-only" htmlFor="librarySelect">
+        Plex library
+      </label>
+      <select
+        id="librarySelect"
+        className="library-select"
+        value={selectedLibrary || ''}
+        onChange={(event) => onLibraryChange(event.target.value)}
+      >
+        {libraries.length === 0 && (
+          <option value="" disabled>
+            Loading…
+          </option>
+        )}
+        {libraries.map((lib) => (
+          <option key={lib} value={lib}>
+            {lib}
+          </option>
+        ))}
+      </select>
+
+      <label className="sr-only" htmlFor="librarySearch">
+        Search library
+      </label>
+      <input
+        id="librarySearch"
+        className="library-search"
+        type="search"
+        placeholder="Search…"
+        value={searchValue}
+        onChange={(event) => onSearchChange(event.target.value)}
+      />
+
+      <button type="button" onClick={onImportAll} disabled={importDisabled} title={importTitle}>
+        Import Assets
+      </button>
+
+      <div className="pager" id="pager">
+        <button type="button" onClick={onFirst} disabled={page <= 1}>
+          « First
+        </button>
+        <button type="button" onClick={onPrev} disabled={page <= 1}>
+          ‹ Prev
+        </button>
+        <span aria-live="polite" id="pageInfo">
+          Page {page} / {totalPages || 1}
+        </span>
+        <button type="button" onClick={onNext} disabled={page >= totalPages}>
+          Next ›
+        </button>
+        <button type="button" onClick={onLast} disabled={page >= totalPages}>
+          Last »
+        </button>
+      </div>
+
+      <span className="count-label" id="count">
+        {countLabel}
+      </span>
+
+      {children}
+    </div>
+  );
+}
+
+export default LibraryToolbar;

--- a/frontend/src/hooks/useLibraryItems.js
+++ b/frontend/src/hooks/useLibraryItems.js
@@ -1,0 +1,233 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+const PAGE_SIZE = 60;
+
+async function fetchJson(url, options) {
+  const response = await fetch(url, options);
+  if (!response.ok) {
+    const message = `${response.status} ${response.statusText}`;
+    throw new Error(message);
+  }
+  return response.json();
+}
+
+export function useLibraryItems({ initialLibrary } = {}) {
+  const [libraries, setLibraries] = useState([]);
+  const [library, setLibrary] = useState(initialLibrary || '');
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [totalCount, setTotalCount] = useState(0);
+  const [items, setItems] = useState([]);
+  const [query, setQuery] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const fetchAbort = useRef(null);
+  const initialLibraryRef = useRef(initialLibrary);
+
+  const fetchLibraries = useCallback(async () => {
+    try {
+      const data = await fetchJson('/api/libraries');
+      let libs = Array.isArray(data?.libraries) ? data.libraries : Array.isArray(data) ? data : [];
+      libs = libs.map((name) => String(name));
+
+      try {
+        const probe = await fetch('/collections?page=1&page_size=1');
+        if (probe.ok && !libs.includes('Collections')) {
+          libs = libs.concat('Collections');
+        }
+      } catch (err) {
+        console.warn('Collections probe failed', err);
+      }
+
+      setLibraries(libs);
+      if (!libs.length) return;
+
+      const desired = initialLibraryRef.current;
+      if (desired && libs.includes(desired)) {
+        initialLibraryRef.current = null;
+        setLibrary(desired);
+        return;
+      }
+      if (!library || !libs.includes(library)) {
+        setLibrary(libs[0]);
+      }
+    } catch (err) {
+      setError(err.message || 'Failed to fetch libraries');
+    }
+  }, [library]);
+
+  useEffect(() => {
+    fetchLibraries();
+  }, [fetchLibraries]);
+
+  const loadItems = useCallback(
+    async ({ targetLibrary, targetPage, searchTerm } = {}) => {
+      const lib = targetLibrary ?? library;
+      if (!lib) return;
+      const desiredPage = targetPage ?? page;
+      const q = searchTerm ?? query;
+      const normalized = lib.trim().toLowerCase();
+      const base = normalized === 'collections' ? '/collections' : '/api/items';
+      const params = new URLSearchParams();
+      if (base !== '/collections') {
+        params.set('library', lib);
+      }
+      params.set('page', String(desiredPage));
+      params.set('page_size', String(PAGE_SIZE));
+      if (q) {
+        params.set('query', q);
+      }
+
+      if (fetchAbort.current) {
+        fetchAbort.current.abort();
+      }
+      const controller = new AbortController();
+      fetchAbort.current = controller;
+      setLoading(true);
+      setError(null);
+
+      try {
+        const response = await fetch(`${base}?${params.toString()}`, { signal: controller.signal });
+        if (!response.ok) {
+          const message = `${response.status} ${response.statusText}`;
+          throw new Error(message);
+        }
+        const data = await response.json();
+        setItems(Array.isArray(data?.items) ? data.items : []);
+        setTotalPages(data?.total_pages || 1);
+        setTotalCount(data?.total_count || (Array.isArray(data?.items) ? data.items.length : 0));
+      } catch (err) {
+        if (err.name === 'AbortError') return;
+        setItems([]);
+        setTotalPages(1);
+        setTotalCount(0);
+        setError(err.message || 'Failed to load items');
+      } finally {
+        setLoading(false);
+      }
+    },
+    [library, page, query]
+  );
+
+  useEffect(() => {
+    if (!library) return;
+    loadItems();
+  }, [library, page, query, loadItems]);
+
+  useEffect(() => () => fetchAbort.current?.abort(), []);
+
+  const changeLibrary = useCallback((next) => {
+    setPage(1);
+    setLibrary(next);
+  }, []);
+
+  const changePage = useCallback((nextPage) => {
+    setPage(nextPage);
+  }, []);
+
+  const changeQuery = useCallback((nextQuery) => {
+    setPage(1);
+    setQuery(nextQuery);
+  }, []);
+
+  const reload = useCallback(() => {
+    loadItems();
+  }, [loadItems]);
+
+  const fetchAllForLibrary = useCallback(
+    async (lib, searchTerm) => {
+      if (!lib) return { items: [], totalPages: 0, totalCount: 0 };
+      const normalized = lib.trim().toLowerCase();
+      const base = normalized === 'collections' ? '/collections' : '/api/items';
+      const params = new URLSearchParams();
+      if (base !== '/collections') {
+        params.set('library', lib);
+      }
+      params.set('page_size', String(PAGE_SIZE));
+      if (searchTerm) {
+        params.set('query', searchTerm);
+      }
+
+      const makeUrl = (pageNumber) => {
+        const search = new URLSearchParams(params);
+        search.set('page', String(pageNumber));
+        return `${base}?${search.toString()}`;
+      };
+
+      const firstResponse = await fetch(makeUrl(1));
+      if (!firstResponse.ok) {
+        const message = `${firstResponse.status} ${firstResponse.statusText}`;
+        throw new Error(message);
+      }
+      const firstData = await firstResponse.json();
+      const allItems = Array.isArray(firstData?.items) ? [...firstData.items] : [];
+      const totalPagesResp = firstData?.total_pages || 1;
+      const totalCountResp = firstData?.total_count || allItems.length;
+
+      for (let p = 2; p <= totalPagesResp; p += 1) {
+        const response = await fetch(makeUrl(p));
+        if (!response.ok) {
+          const message = `${response.status} ${response.statusText}`;
+          throw new Error(message);
+        }
+        const data = await response.json();
+        if (Array.isArray(data?.items)) {
+          allItems.push(...data.items);
+        }
+      }
+
+      return { items: allItems, totalPages: totalPagesResp, totalCount: totalCountResp };
+    },
+    []
+  );
+
+  const updateItem = useCallback((ratingKey, updates) => {
+    setItems((prev) =>
+      prev.map((item) => {
+        const key = item?.ratingKey ?? item?.key ?? item?.id;
+        if (key == null) return item;
+        if (String(key) !== String(ratingKey)) return item;
+        return { ...item, ...updates };
+      })
+    );
+  }, []);
+
+  return useMemo(
+    () => ({
+      libraries,
+      library,
+      setLibrary: changeLibrary,
+      page,
+      setPage: changePage,
+      totalPages,
+      totalCount,
+      items,
+      query,
+      setQuery: changeQuery,
+      loading,
+      error,
+      reload,
+      fetchAllForLibrary,
+      updateItem,
+      pageSize: PAGE_SIZE,
+    }),
+    [
+      libraries,
+      library,
+      changeLibrary,
+      page,
+      changePage,
+      totalPages,
+      totalCount,
+      items,
+      query,
+      changeQuery,
+      loading,
+      error,
+      reload,
+      fetchAllForLibrary,
+      updateItem,
+    ]
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,474 @@
+:root {
+  --bg: #0b0b0f;
+  --fg: #e8e8ee;
+  --muted: #a9a9b5;
+  --card: #15151c;
+  --accent: #5ea1ff;
+  --border: #2a2a36;
+}
+
+[data-theme="light"] {
+  --bg: #ffffff;
+  --fg: #11111a;
+  --muted: #4a4a55;
+  --card: #f6f6fb;
+  --accent: #3b82f6;
+  --border: #d7d7e0;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font: 16px/1.35 system-ui, -apple-system, Segoe UI, Roboto, Ubuntu;
+  background: var(--bg);
+  color: var(--fg);
+}
+
+#root {
+  min-height: 100vh;
+  background: var(--bg);
+  color: var(--fg);
+}
+
+header {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  padding: 14px 12px;
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  background: var(--bg);
+  z-index: 5;
+}
+
+header h1 {
+  font-size: 18px;
+  margin: 0 8px 0 0;
+}
+
+select,
+input,
+button {
+  background: var(--card);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 8px 10px;
+}
+
+select:focus,
+input:focus,
+button:focus {
+  outline: 2px solid var(--accent);
+}
+
+button {
+  cursor: pointer;
+}
+
+button[disabled] {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.btn {
+  cursor: pointer;
+}
+
+.page-header-tools {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.library-select {
+  min-width: 200px;
+}
+
+.library-search {
+  min-width: 220px;
+}
+
+.pager {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  margin-left: 12px;
+}
+
+.count-label {
+  color: var(--muted);
+  margin-left: 8px;
+}
+
+.import-status {
+  display: none;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 220px;
+  max-width: 340px;
+  color: var(--muted);
+  align-items: flex-start;
+}
+
+.import-status.is-active {
+  display: flex;
+}
+
+.import-status .progress-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  width: 100%;
+}
+
+.import-status .progress-track {
+  position: relative;
+  width: 100%;
+  height: 8px;
+  background: var(--border);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.import-status .progress-bar {
+  position: absolute;
+  inset: 0;
+  width: 0%;
+  background: var(--accent);
+  transition: width 0.25s ease;
+}
+
+.import-status .progress-label {
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.import-status .error-list {
+  margin: 0;
+  padding-left: 18px;
+  font-size: 13px;
+  line-height: 1.4;
+  color: #ff7a7a;
+  display: none;
+}
+
+.import-status.has-errors .error-list {
+  display: block;
+}
+
+.import-status.has-errors .progress-label {
+  color: #ffb4b4;
+}
+
+.theme-toggle {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 999px;
+  font-size: 18px;
+}
+
+main {
+  min-height: 0;
+}
+
+#grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 12px;
+  padding: 16px;
+}
+
+.card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.card[role="button"] {
+  cursor: pointer;
+}
+
+.poster {
+  width: 100%;
+  aspect-ratio: 2 / 3;
+  height: auto;
+  object-fit: contain;
+  background: #222;
+  display: block;
+}
+
+.meta {
+  padding: 8px 10px;
+}
+
+.title {
+  font-weight: 600;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: start;
+  column-gap: 6px;
+  row-gap: 4px;
+  min-height: 3.4em;
+}
+
+.title-text {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1.2;
+}
+
+.ready-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 6px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.ready-badge.ready {
+  background: #1f8f4d;
+  color: #fff;
+}
+
+.ready-badge.not-ready {
+  background: #b91c1c;
+  color: #fff;
+}
+
+[data-theme="light"] .ready-badge.ready {
+  background: #22c55e;
+  color: #065f46;
+}
+
+[data-theme="light"] .ready-badge.not-ready {
+  background: #fca5a5;
+  color: #7f1d1d;
+}
+
+.card[data-ready="false"] {
+  border-color: #532626;
+}
+
+[data-theme="light"] .card[data-ready="false"] {
+  border-color: #fca5a5;
+}
+
+.year {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.dialog-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 20;
+}
+
+.dialog-panel {
+  background: var(--bg);
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  max-width: 640px;
+  width: calc(100% - 24px);
+  overflow: hidden;
+}
+
+.dialog-body {
+  padding: 16px;
+}
+
+.folder-dlg h2 {
+  margin: 0 0 4px;
+}
+
+.folder-context {
+  margin: 0 0 12px;
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.breadcrumbs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding: 0;
+  margin: 0 0 12px;
+  list-style: none;
+  font-size: 13px;
+}
+
+.breadcrumbs li {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.breadcrumbs button {
+  background: none;
+  border: none;
+  padding: 0 4px;
+  border-radius: 6px;
+  color: var(--fg);
+  cursor: pointer;
+  font: inherit;
+}
+
+.breadcrumbs button:hover,
+.breadcrumbs button:focus {
+  background: var(--border);
+  outline: none;
+}
+
+.folder-search {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 12px;
+}
+
+.folder-search label {
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.folder-results {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  min-height: 160px;
+  max-height: 320px;
+  overflow: auto;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.folder-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+.folder-row:last-child {
+  border-bottom: none;
+}
+
+.folder-option {
+  flex: 1 1 auto;
+  text-align: left;
+  background: none;
+  border: none;
+  color: var(--fg);
+  font: inherit;
+  cursor: pointer;
+  padding: 0;
+}
+
+.folder-option:hover,
+.folder-option:focus {
+  color: var(--accent);
+  outline: none;
+}
+
+.folder-open {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--fg);
+  font-size: 12px;
+  padding: 4px 10px;
+  cursor: pointer;
+}
+
+.folder-open:hover,
+.folder-open:focus {
+  border-color: var(--accent);
+  outline: none;
+}
+
+.folder-row.is-selected {
+  background: rgba(94, 161, 255, 0.12);
+}
+
+.folder-empty {
+  padding: 16px;
+  text-align: center;
+  font-size: 14px;
+  color: var(--muted);
+}
+
+.folder-alert {
+  margin-top: 12px;
+  font-size: 13px;
+  color: #ff7a7a;
+  min-height: 18px;
+}
+
+.actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  justify-content: flex-end;
+  padding: 10px 16px;
+  border-top: 1px solid var(--border);
+}
+
+.tag {
+  display: inline-block;
+  padding: 2px 8px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.sr-only {
+  position: absolute;
+  left: -9999px;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+
+.empty-state,
+.error-state {
+  padding: 48px 16px;
+  text-align: center;
+  color: var(--muted);
+}
+
+.error-state {
+  color: #ff7a7a;
+}
+
+.loading-state {
+  padding: 48px 16px;
+  text-align: center;
+  color: var(--muted);
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/src/pages/LibraryPage.jsx
+++ b/frontend/src/pages/LibraryPage.jsx
@@ -1,0 +1,311 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import FolderFinderModal from '../components/FolderFinderModal.jsx';
+import ImportStatusPanel from '../components/ImportStatusPanel.jsx';
+import ItemGrid from '../components/ItemGrid.jsx';
+import LibraryToolbar from '../components/LibraryToolbar.jsx';
+import { useLibraryItems } from '../hooks/useLibraryItems.js';
+import { useTheme } from '../theme/ThemeProvider.jsx';
+import { responseErrorMessage, safeJson } from '../utils/api.js';
+import { isShowItem } from '../utils/items.js';
+import {
+  collectResultFailures,
+  importAllSeasons,
+  importCollectionAssets,
+  importMovieAssets,
+  importShowPosterPreferShowEndpoint,
+  pushFailureEntry,
+  summarizeImportResult,
+} from '../utils/importers.js';
+
+function LibraryPage() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const initialLibrary = searchParams.get('lib') || undefined;
+  const {
+    libraries,
+    library,
+    setLibrary,
+    page,
+    setPage,
+    totalPages,
+    totalCount,
+    items,
+    query,
+    setQuery,
+    loading,
+    error,
+    reload,
+    fetchAllForLibrary,
+    updateItem,
+  } = useLibraryItems({ initialLibrary });
+
+  const { toggleTheme } = useTheme();
+
+  const [searchInput, setSearchInput] = useState(query || '');
+  const searchTimerRef = useRef();
+
+  useEffect(() => setSearchInput(query || ''), [query]);
+
+  useEffect(() => {
+    if (!library) return;
+    setSearchParams({ lib: library });
+  }, [library, setSearchParams]);
+
+  useEffect(() => () => clearTimeout(searchTimerRef.current), []);
+
+  const handleSearchChange = useCallback(
+    (value) => {
+      setSearchInput(value);
+      clearTimeout(searchTimerRef.current);
+      searchTimerRef.current = setTimeout(() => {
+        const trimmed = value.trim();
+        setQuery(trimmed);
+      }, 300);
+    },
+    [setQuery]
+  );
+
+  const handleFirst = useCallback(() => setPage(1), [setPage]);
+  const handlePrev = useCallback(() => setPage(Math.max(1, page - 1)), [setPage, page]);
+  const handleNext = useCallback(() => setPage(Math.min(totalPages || 1, page + 1)), [setPage, page, totalPages]);
+  const handleLast = useCallback(() => setPage(totalPages || 1), [setPage, totalPages]);
+
+  const [importState, setImportState] = useState({ active: false, percent: 0, label: '', errors: [] });
+  const hideTimerRef = useRef();
+  const [isImporting, setIsImporting] = useState(false);
+
+  const showStatus = useCallback(({ percent = 0, label = '', errors = [], active = true }) => {
+    clearTimeout(hideTimerRef.current);
+    setImportState({ active, percent, label, errors });
+  }, []);
+
+  const hideStatus = useCallback((delay = 0) => {
+    clearTimeout(hideTimerRef.current);
+    hideTimerRef.current = setTimeout(() => {
+      setImportState({ active: false, percent: 0, label: '', errors: [] });
+    }, delay);
+  }, []);
+
+  useEffect(() => () => clearTimeout(hideTimerRef.current), []);
+
+  const [folderModalOpen, setFolderModalOpen] = useState(false);
+  const [folderModalItem, setFolderModalItem] = useState(null);
+
+  const handleRequestFolder = useCallback((item) => {
+    setFolderModalItem(item);
+    setFolderModalOpen(true);
+  }, []);
+
+  const handleCloseFolderModal = useCallback(() => {
+    setFolderModalItem(null);
+    setFolderModalOpen(false);
+  }, []);
+
+  const handleFolderAssigned = useCallback(
+    async ({ folderName }) => {
+      if (!folderModalItem) return;
+      const ratingKey = folderModalItem?.ratingKey ?? folderModalItem?.key ?? folderModalItem?.id;
+      if (ratingKey != null) {
+        updateItem(String(ratingKey), { assetReady: true, folderName, folder: folderName });
+      }
+      handleCloseFolderModal();
+      if (!isImporting) {
+        showStatus({ active: true, percent: 0, label: `Folder assigned: ${folderName}`, errors: [] });
+        hideStatus(2000);
+      }
+      await reload();
+    },
+    [folderModalItem, updateItem, handleCloseFolderModal, isImporting, showStatus, hideStatus, reload]
+  );
+
+  const handleImportAll = useCallback(async () => {
+    if (!library) return;
+    const lib = library.trim();
+    if (!lib) return;
+    setIsImporting(true);
+    const lower = lib.toLowerCase();
+    const isCollections = lower === 'collections';
+    const isTVLib = lower.includes('tv');
+    const failures = [];
+
+    showStatus({ active: true, percent: 0, label: 'Preparing import…', errors: [] });
+
+    try {
+      const { items: allItems = [] } = await fetchAllForLibrary(lib, query);
+      const importable = allItems.filter((item) => item?.assetReady !== false);
+      const skipped = allItems.filter((item) => item?.assetReady === false);
+
+      skipped.forEach((skip) => {
+        const context = {
+          library: lib,
+          title: skip?.title || skip?.name || '(Untitled)',
+          folder: skip?.folderName || skip?.folder || skip?.name || skip?.title || '',
+        };
+        pushFailureEntry(failures, context, 'Item', 'Skipped (asset folder missing)');
+      });
+
+      if (!importable.length) {
+        if (failures.length) {
+          const count = failures.length;
+          showStatus({
+            active: true,
+            percent: 0,
+            label: `Import skipped. ${count} item${count === 1 ? '' : 's'} missing asset folders.`,
+            errors: failures.slice(),
+          });
+        } else {
+          showStatus({ active: true, percent: 0, label: 'Nothing to import.', errors: [] });
+          hideStatus(2000);
+        }
+        return;
+      }
+
+      let processed = 0;
+      const total = importable.length;
+      const skipSuffix = skipped.length
+        ? ` (skipping ${skipped.length} not-ready item${skipped.length === 1 ? '' : 's'})`
+        : '';
+
+      const updateProgress = () => {
+        const pct = total ? (processed / total) * 100 : 100;
+        showStatus({
+          active: true,
+          percent: pct,
+          label: `Importing assets from Plex… ${processed}/${total}${skipSuffix}`,
+          errors: failures.slice(),
+        });
+      };
+
+      updateProgress();
+
+      for (const item of importable) {
+        const title = item?.title || item?.name || '(Untitled)';
+        let folderName = item?.folderName || '';
+        if (!folderName && item?.assetReady !== false) {
+          folderName = item?.folder || item?.name || item?.title || '';
+        }
+        const ratingKey = item?.ratingKey ?? item?.key ?? item?.id;
+        const context = { library: lib, title, folder: folderName };
+
+        try {
+          if (isCollections) {
+            const result = await importCollectionAssets(lib, ratingKey, folderName);
+            collectResultFailures(failures, context, result);
+          } else if (isTVLib || isShowItem(item, lib)) {
+            let showData = null;
+            if (ratingKey != null) {
+              try {
+                const url = `/api/show?library=${encodeURIComponent(lib)}&ratingKey=${encodeURIComponent(ratingKey)}`;
+                const response = await fetch(url);
+                const data = await safeJson(response);
+                if (!response.ok) {
+                  throw new Error(responseErrorMessage(response, data));
+                }
+                showData = data;
+              } catch (err) {
+                pushFailureEntry(failures, context, 'Show Lookup', err?.message || String(err));
+              }
+            }
+            const showFolder = showData?.folderName || folderName;
+            const seasonsMeta = Array.isArray(showData?.seasons) ? showData.seasons : [];
+            const showResult = await importShowPosterPreferShowEndpoint(lib, ratingKey, showFolder);
+            collectResultFailures(failures, context, showResult);
+            const hasSeasonResults = Array.isArray(showResult.seasons) && showResult.seasons.length > 0;
+            if (!hasSeasonResults && seasonsMeta.length) {
+              const seasonResult = await importAllSeasons(lib, showFolder, seasonsMeta, ratingKey);
+              collectResultFailures(failures, context, seasonResult);
+            }
+          } else {
+            const result = await importMovieAssets(lib, ratingKey, folderName);
+            collectResultFailures(failures, context, result);
+          }
+        } catch (err) {
+          pushFailureEntry(failures, context, 'Import', err?.message || String(err));
+        }
+
+        processed += 1;
+        updateProgress();
+      }
+
+      await reload();
+
+      if (failures.length) {
+        showStatus({ active: true, percent: 100, label: summarizeImportResult(failures), errors: failures.slice() });
+      } else {
+        showStatus({ active: true, percent: 100, label: 'Import complete.', errors: [] });
+        hideStatus(2500);
+      }
+    } catch (err) {
+      const message = `Import failed: ${err?.message || err}`;
+      pushFailureEntry(failures, { library: lib, title: '', folder: '' }, 'Import', message);
+      showStatus({ active: true, percent: 0, label: message, errors: failures.slice() });
+    } finally {
+      setIsImporting(false);
+    }
+  }, [library, fetchAllForLibrary, query, reload, showStatus, hideStatus]);
+
+  const countLabel = useMemo(() => {
+    const count = Number(totalCount) || 0;
+    return `${count.toLocaleString()} item${count === 1 ? '' : 's'}`;
+  }, [totalCount]);
+
+  const normalizedLibrary = (library || '').trim();
+  const importTooltip = normalizedLibrary
+    ? normalizedLibrary.toLowerCase() === 'collections'
+      ? 'Import all collection posters/backgrounds from Plex into Kometa asset folders'
+      : 'Import all posters/backgrounds (and TV seasons) from Plex into Kometa asset folders'
+    : 'Choose a library first.';
+
+  return (
+    <div>
+      <header>
+        <h1>KAM</h1>
+        <LibraryToolbar
+          libraries={libraries}
+          selectedLibrary={library || ''}
+          onLibraryChange={setLibrary}
+          searchValue={searchInput}
+          onSearchChange={handleSearchChange}
+          onImportAll={handleImportAll}
+          importDisabled={!library || isImporting || loading}
+          importTitle={importTooltip}
+          page={page || 1}
+          totalPages={totalPages || 1}
+          onFirst={handleFirst}
+          onPrev={handlePrev}
+          onNext={handleNext}
+          onLast={handleLast}
+          countLabel={countLabel}
+        >
+          <ImportStatusPanel
+            active={importState.active}
+            percent={importState.percent}
+            label={importState.label}
+            errors={importState.errors}
+          />
+        </LibraryToolbar>
+        <button type="button" className="theme-toggle" onClick={toggleTheme} title="Toggle theme">
+          🌓
+        </button>
+      </header>
+      <main>
+        <ItemGrid
+          items={items}
+          library={library}
+          onRequestFolder={handleRequestFolder}
+          loading={loading}
+          error={error}
+        />
+      </main>
+      <FolderFinderModal
+        isOpen={folderModalOpen}
+        item={folderModalItem}
+        library={library}
+        onClose={handleCloseFolderModal}
+        onFolderAssigned={handleFolderAssigned}
+      />
+    </div>
+  );
+}
+
+export default LibraryPage;

--- a/frontend/src/theme/ThemeProvider.jsx
+++ b/frontend/src/theme/ThemeProvider.jsx
@@ -1,0 +1,36 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+
+const ThemeContext = createContext({
+  theme: 'dark',
+  toggleTheme: () => {},
+});
+
+const STORAGE_KEY = 'kam-theme';
+
+export function ThemeProvider({ children }) {
+  const [theme, setTheme] = useState(() => {
+    if (typeof window === 'undefined') return 'dark';
+    const saved = window.localStorage.getItem(STORAGE_KEY);
+    return saved || 'dark';
+  });
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    document.documentElement.setAttribute('data-theme', theme);
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(STORAGE_KEY, theme);
+    }
+  }, [theme]);
+
+  const toggleTheme = useCallback(() => {
+    setTheme((prev) => (prev === 'dark' ? 'light' : 'dark'));
+  }, []);
+
+  const value = useMemo(() => ({ theme, toggleTheme }), [theme, toggleTheme]);
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -1,0 +1,69 @@
+export async function safeJson(response) {
+  try {
+    return await response.json();
+  } catch (error) {
+    return null;
+  }
+}
+
+export function responseErrorMessage(response, data) {
+  if (!response) return 'Unknown error';
+  return (
+    (data && (data.detail || data.error || data.message)) || `${response.status} ${response.statusText}`
+  );
+}
+
+export function normalizeAssetResult(part, fallbackError = null) {
+  return {
+    ok: Boolean(part && part.ok),
+    path: (part && part.path) || null,
+    src: (part && part.src) || null,
+    error: (part && part.error) || fallbackError || null,
+  };
+}
+
+export function pushFailureEntry(list, context, asset, message) {
+  list.push({
+    library: context?.library || '',
+    title: context?.title || '',
+    folder: context?.folder || '',
+    asset,
+    message: message || 'Unknown error',
+  });
+}
+
+export function collectResultFailures(list, context, result) {
+  if (!result) return;
+  const hasPoster = result.poster && typeof result.poster === 'object';
+  const hasBackground = result.background && typeof result.background === 'object';
+  const seasons = Array.isArray(result.seasons) ? result.seasons : [];
+  if (hasPoster && !result.poster.ok) {
+    pushFailureEntry(list, context, 'Poster', result.poster.error || 'Failed to import poster');
+  }
+  if (hasBackground && !result.background.ok) {
+    pushFailureEntry(list, context, 'Background', result.background.error || 'Failed to import background');
+  }
+  seasons.forEach((season) => {
+    if (season && season.ok) return;
+    const idx = season && season.index;
+    let label = 'Season';
+    if (idx !== undefined && idx !== null) {
+      const idxNum = Number(idx);
+      if (Number.isFinite(idxNum)) {
+        label = `Season ${String(idxNum).padStart(2, '0')}`;
+      } else {
+        label = `Season ${idx}`;
+      }
+    }
+    pushFailureEntry(list, context, label, (season && season.error) || 'Failed to import season poster');
+  });
+  if (!result.ok) {
+    const hasSpecific =
+      (hasPoster && result.poster && result.poster.error) ||
+      (hasBackground && result.background && result.background.error) ||
+      seasons.some((season) => season && (!season.ok || season.error));
+    if (!hasSpecific && result.error) {
+      pushFailureEntry(list, context, 'Import', result.error);
+    }
+  }
+}

--- a/frontend/src/utils/importers.js
+++ b/frontend/src/utils/importers.js
@@ -1,0 +1,157 @@
+import { collectResultFailures, normalizeAssetResult, pushFailureEntry, responseErrorMessage, safeJson } from './api.js';
+
+export async function importMovieAssets(library, ratingKey, folderName) {
+  const fd = new FormData();
+  fd.append('library', library);
+  if (ratingKey != null) fd.append('ratingKey', String(ratingKey));
+  if (folderName) fd.append('folderName', folderName);
+  try {
+    const response = await fetch('/api/import/movie', { method: 'POST', body: fd });
+    const data = await safeJson(response);
+    const results = data && (data.results || data) ? data.results || data : {};
+    const message = response.ok ? null : responseErrorMessage(response, data);
+    const poster = normalizeAssetResult(results.poster, message);
+    const background = normalizeAssetResult(results.background, message);
+    const ok = Boolean((data && typeof data.ok === 'boolean' ? data.ok : null) ?? (poster.ok || background.ok));
+    return {
+      ok: ok && response.ok,
+      poster,
+      background,
+      seasons: [],
+      error: message || (data && data.error) || null,
+      endpoint: 'movie',
+    };
+  } catch (error) {
+    const message = error?.message || String(error);
+    return {
+      ok: false,
+      poster: normalizeAssetResult(null, message),
+      background: normalizeAssetResult(null, message),
+      seasons: [],
+      error: message,
+      endpoint: 'movie',
+    };
+  }
+}
+
+export async function importCollectionAssets(library, ratingKey, folderName) {
+  const fd = new FormData();
+  fd.append('library', library);
+  if (ratingKey != null) fd.append('ratingKey', String(ratingKey));
+  if (folderName) fd.append('folderName', folderName);
+  try {
+    const response = await fetch('/api/import/collection', { method: 'POST', body: fd });
+    const data = await safeJson(response);
+    const results = data && (data.results || data) ? data.results || data : {};
+    const message = response.ok ? null : responseErrorMessage(response, data);
+    const poster = normalizeAssetResult(results.poster, message);
+    const background = normalizeAssetResult(results.background, message);
+    const ok = Boolean((data && typeof data.ok === 'boolean' ? data.ok : null) ?? (poster.ok || background.ok));
+    return {
+      ok: ok && response.ok,
+      poster,
+      background,
+      seasons: [],
+      error: message || (data && data.error) || null,
+      endpoint: 'collection',
+    };
+  } catch (error) {
+    const message = error?.message || String(error);
+    return {
+      ok: false,
+      poster: normalizeAssetResult(null, message),
+      background: normalizeAssetResult(null, message),
+      seasons: [],
+      error: message,
+      endpoint: 'collection',
+    };
+  }
+}
+
+export async function importShowPosterPreferShowEndpoint(library, ratingKey, folderName) {
+  const fd = new FormData();
+  fd.append('library', library);
+  if (ratingKey != null) fd.append('ratingKey', String(ratingKey));
+  if (folderName) fd.append('folderName', folderName);
+  try {
+    const response = await fetch('/api/import/show', { method: 'POST', body: fd });
+    const data = await safeJson(response);
+    const message = response.ok ? null : responseErrorMessage(response, data);
+    const poster = normalizeAssetResult(data && data.poster, message);
+    const background = normalizeAssetResult(data && data.background, message);
+    const seasonsRaw = Array.isArray(data && data.seasons) ? data.seasons : [];
+    const seasons = seasonsRaw.map((season) => ({
+      ok: Boolean(season && season.ok),
+      index: season && (season.index ?? season.season ?? season.number ?? null),
+      path: season && season.path ? season.path : null,
+      src: season && season.src ? season.src : null,
+      error: season && season.error ? season.error : null,
+    }));
+    const ok = Boolean((data && typeof data.ok === 'boolean' ? data.ok : null) ?? (poster.ok || background.ok || seasons.some((season) => season.ok)));
+    const result = {
+      ok: ok && response.ok,
+      poster,
+      background,
+      seasons,
+      error: message || (data && data.error) || null,
+      endpoint: 'show',
+    };
+    if (response.ok) return result;
+    if (response.status === 404 || response.status === 405) {
+      const fallback = await importMovieAssets(library, ratingKey, folderName);
+      fallback.fallbackReason = message;
+      return fallback;
+    }
+    return result;
+  } catch (error) {
+    const fallback = await importMovieAssets(library, ratingKey, folderName);
+    fallback.fallbackReason = error?.message || String(error);
+    return fallback;
+  }
+}
+
+export async function importAllSeasons(library, showFolder, seasons, ratingKey) {
+  const results = [];
+  let anyOk = false;
+  for (const season of seasons || []) {
+    const idxRaw = season && (season.index ?? season.season ?? season.number ?? null);
+    const entry = { ok: false, index: idxRaw ?? null, path: null, src: null, error: null };
+    const idx = Number(idxRaw);
+    if (!Number.isFinite(idx)) {
+      entry.error = `Invalid season index: ${idxRaw}`;
+      results.push(entry);
+      continue;
+    }
+    const fd = new FormData();
+    fd.append('library', library);
+    if (showFolder) fd.append('folderName', showFolder);
+    fd.append('season', String(idx));
+    if (ratingKey != null) fd.append('ratingKey', String(ratingKey));
+    try {
+      const response = await fetch('/api/import/season', { method: 'POST', body: fd });
+      const data = await safeJson(response);
+      if (!response.ok) {
+        entry.error = responseErrorMessage(response, data);
+      } else {
+        entry.ok = Boolean((data && typeof data.ok === 'boolean' ? data.ok : null) ?? response.ok);
+        entry.path = (data && data.path) || null;
+        entry.src = (data && data.src) || null;
+        if (!entry.ok) entry.error = (data && data.error) || null;
+      }
+    } catch (error) {
+      entry.error = error?.message || String(error);
+    }
+    if (!entry.error && !entry.ok) entry.error = 'Unknown error';
+    if (entry.ok) anyOk = true;
+    results.push(entry);
+  }
+  return { ok: anyOk, seasons: results, endpoint: 'season' };
+}
+
+export function summarizeImportResult(failures) {
+  const count = failures.length;
+  if (!count) return 'Import complete.';
+  return `Import completed with ${count} failure${count === 1 ? '' : 's'}.`;
+}
+
+export { collectResultFailures, pushFailureEntry };

--- a/frontend/src/utils/items.js
+++ b/frontend/src/utils/items.js
@@ -1,0 +1,29 @@
+export function isShowItem(item, libraryName) {
+  const lib = (libraryName || '').toLowerCase();
+  const type = String(item?.type || '').toLowerCase();
+  return lib.includes('tv') || type === 'show' || item?.isShow === true;
+}
+
+export function buildDetailUrl(item, libraryName) {
+  const lib = (libraryName || '').trim();
+  if (!lib) return null;
+  if (lib.toLowerCase() === 'collections') return null;
+  const ratingKey = item?.ratingKey ?? item?.key ?? item?.id;
+  if (ratingKey == null) return null;
+  const encodedLib = encodeURIComponent(lib);
+  const encodedKey = encodeURIComponent(ratingKey);
+  const dest = isShowItem(item, libraryName) ? 'show.html' : 'movie.html';
+  return `${dest}?library=${encodedLib}&ratingKey=${encodedKey}`;
+}
+
+export function normalizePoster(item) {
+  return (
+    item?.posterUrl ||
+    item?.posterUrlLocal ||
+    item?.posterUrlPlex ||
+    item?.thumb ||
+    item?.background ||
+    item?.art ||
+    ''
+  );
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    host: '0.0.0.0',
+    port: 5173,
+    proxy: {
+      '/api': 'http://localhost:8000',
+      '/collections': 'http://localhost:8000',
+      '/fileproxy': 'http://localhost:8000'
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- bootstrap a Vite-powered React frontend with a /libraries route and theme context
- rebuild the library toolbar, item grid, import status, and folder finder as modular React components
- port the library/item fetching hook and import workflows to use the existing APIs

## Testing
- npm install (fails: 403 Forbidden from registry)


------
https://chatgpt.com/codex/tasks/task_e_68dfc02bfad4833089dc0283e4b06a3f