### PR TITLE
Add SPA movie details route with upload and import handlers

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,10 +1,12 @@
 # app/main.py
 import logging
 import os
+from pathlib import Path
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
+from fastapi.responses import FileResponse
 
 from .logging_config import configure_logging
 
@@ -42,6 +44,14 @@ app.include_router(movie.router)
 app.include_router(imports.router)
 app.include_router(fileproxy.router)
 app.include_router(assets.router)
+
+WEB_DIR = Path(__file__).resolve().parent / "web"
+
+
+@app.get("/libraries/{library}/movies/{ratingKey}", include_in_schema=False)
+async def movie_details_page(library: str, ratingKey: str):
+    """Serve the movie detail HTML so the SPA-style route works."""
+    return FileResponse(WEB_DIR / "movie.html")
 
 # ---- SAFE assets mount (env-driven) ----
 # Prefer explicit envs if you set them; otherwise infer from COLLECTIONS_ROOT.

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -655,11 +655,14 @@
     const isCollections = (state.library || '').trim().toLowerCase() === 'collections';
     if (isCollections) return; // unchanged behavior for Collections
 
-    const rk = encodeURIComponent(it.ratingKey || it.key || it.id || '');
-    const lib = encodeURIComponent(state.library || '');
-    const dest = isShowItem(it, state.library) ? 'show.html' : 'movie.html';
-    const url = `${dest}?library=${lib}&ratingKey=${rk}`;
-    return url;
+    const rawRatingKey = it.ratingKey || it.key || it.id || '';
+    const encodedRatingKey = encodeURIComponent(String(rawRatingKey));
+    const rawLibrary = state.library || '';
+    const encodedLibrary = encodeURIComponent(String(rawLibrary));
+    if (isShowItem(it, state.library)) {
+      return `show.html?library=${encodedLibrary}&ratingKey=${encodedRatingKey}`;
+    }
+    return `/libraries/${encodedLibrary}/movies/${encodedRatingKey}`;
   }
 
   function renderItems(items){

--- a/app/web/movie.html
+++ b/app/web/movie.html
@@ -15,7 +15,7 @@
   a.btn:hover,button.btn:hover{border-color:var(--accent)}
   main{padding:16px}
   .row{display:flex; gap:16px; flex-wrap:wrap}
-  .card{background:var(--card); border:1px solid var(--border); border-radius:12px; padding:12px} overflow:hidden;
+  .card{background:var(--card); border:1px solid var(--border); border-radius:12px; padding:12px; overflow:hidden;}
   .label{font-size:13px; color:var(--muted); margin-bottom:6px}
   .grid{display:grid; grid-template-columns:repeat(auto-fill, minmax(240px,1fr)); gap:12px; margin-top:12px}
   .exists{font-size:12px; color:#4ade80; margin-left:6px}
@@ -32,7 +32,7 @@
 <body>
 <header>
   <a id="back" class="btn" href="index.html">← Back</a>
-  <h1>Movie</h1>
+  <h1 id="title">Movie</h1>
 </header>
 <main>
   <div id="folderWarning" class="warning"><strong>✖</strong>Asset folder not found. Create the Kometa asset folder first.</div>
@@ -69,142 +69,274 @@
 
   const $ = (sel) => document.querySelector(sel);
 
-  async function j(url) {
-    const r = await fetch(url);
-    if (!r.ok) throw new Error(url + " -> " + r.status);
-    return r.json();
-  }
-
-  let library, ratingKey, data;
   const status = $("#status");
-  const posterFlag = $("#posterFlag");
-  const bgFlag = $("#bgFlag");
   const folderWarning = $("#folderWarning");
-  const interactiveEls = [$("#posterFile"), $("#bgFile"), $("#importPoster"), $("#uploadPoster"), $("#importBg"), $("#uploadBg")];
   const missingMsg = "Create the Kometa asset folder first.";
+  const els = {
+    back: $("#back"),
+    title: $("#title"),
+    posterFile: $("#posterFile"),
+    bgFile: $("#bgFile"),
+    uploadPoster: $("#uploadPoster"),
+    uploadBg: $("#uploadBg"),
+    importPoster: $("#importPoster"),
+    importBg: $("#importBg"),
+    posterFlag: $("#posterFlag"),
+    bgFlag: $("#bgFlag"),
+    posterImg: $("#posterImg"),
+    bgImg: $("#bgImg"),
+  };
+
+  const state = {
+    library: "",
+    ratingKey: "",
+    folderName: "",
+    folderExists: false,
+    plexPosterUrl: null,
+    plexBackgroundUrl: null,
+    data: null,
+  };
+
+  function setStatus(message) {
+    if (status) status.textContent = message || "";
+  }
 
   function flag(el, exists) {
-    el.className = exists ? "exists" : "missing";
+    if (!el) return;
     el.textContent = exists ? "exists" : "missing";
+    el.className = exists ? "exists" : "missing";
   }
 
-  function getParams() {
+  function bust(url) {
+    if (!url) return url;
+    const suffix = url.includes("?") ? "&" : "?";
+    return `${url}${suffix}t=${Date.now()}`;
+  }
+
+  function applyFolderState() {
+    const exists = Boolean(state.folderExists);
+    if (folderWarning) folderWarning.style.display = exists ? "none" : "block";
+    const controls = [
+      els.posterFile,
+      els.bgFile,
+      els.uploadPoster,
+      els.uploadBg,
+      els.importPoster,
+      els.importBg,
+    ];
+    for (const el of controls) {
+      if (!el) continue;
+      el.disabled = !exists;
+      if (!exists && el.tagName === "INPUT") {
+        el.value = "";
+      }
+    }
+    if (!exists) {
+      setStatus(missingMsg);
+    } else if (status && status.textContent === missingMsg) {
+      setStatus("");
+    }
+  }
+
+  function parseRoute() {
+    const trimmed = location.pathname.replace(/^\/+|\/+$/g, "");
+    const parts = trimmed ? trimmed.split("/") : [];
+    if (parts.length >= 4 && parts[0] === "libraries" && parts[2] === "movies") {
+      return {
+        library: decodeURIComponent(parts[1] || ""),
+        ratingKey: decodeURIComponent(parts[3] || ""),
+      };
+    }
     const u = new URL(location.href);
     return {
-      library: u.searchParams.get("library") || "",
-      ratingKey: u.searchParams.get("ratingKey") || "",
+      library: u.searchParams.get("library") || u.searchParams.get("lib") || "",
+      ratingKey: u.searchParams.get("ratingKey") || u.searchParams.get("id") || "",
     };
   }
 
+  function setBackLink() {
+    if (!els.back) return;
+    const params = new URLSearchParams();
+    if (state.library) params.set("lib", state.library);
+    const query = params.toString();
+    els.back.href = query ? `/index.html?${query}` : `/index.html`;
+  }
+
+  async function fetchJson(url, options) {
+    const response = await fetch(url, options);
+    const text = await response.text();
+    if (!response.ok) {
+      let message = text || `HTTP ${response.status}`;
+      if (text) {
+        try {
+          const parsed = JSON.parse(text);
+          message = parsed?.detail || parsed?.error || parsed?.message || message;
+        } catch (_) {
+          // ignore JSON parse error, keep text message
+        }
+      }
+      throw new Error(message);
+    }
+    if (!text) return {};
+    try {
+      return JSON.parse(text);
+    } catch (_) {
+      return {};
+    }
+  }
+
+  function render() {
+    const data = state.data || {};
+    const titlePieces = [];
+    if (data.title) titlePieces.push(data.title);
+    if (data.year) titlePieces.push(`(${data.year})`);
+    const titleText = titlePieces.join(" ") || "Movie";
+    if (els.title) els.title.textContent = titleText;
+    document.title = `KAM • ${titleText}`;
+
+    applyFolderState();
+
+    const posterExists = typeof data.posterExists === "boolean"
+      ? data.posterExists
+      : Boolean(data.posterUrl);
+    const backgroundExists = typeof data.backgroundExists === "boolean"
+      ? data.backgroundExists
+      : Boolean(data.backgroundUrl);
+
+    flag(els.posterFlag, posterExists);
+    flag(els.bgFlag, backgroundExists);
+
+    const posterSrc = data.posterUrl || state.plexPosterUrl;
+    if (els.posterImg) {
+      if (posterSrc) {
+        els.posterImg.src = bust(posterSrc);
+        els.posterImg.style.display = "block";
+      } else {
+        els.posterImg.style.display = "none";
+      }
+    }
+
+    const bgSrc = data.backgroundUrl || state.plexBackgroundUrl;
+    if (els.bgImg) {
+      if (bgSrc) {
+        els.bgImg.src = bust(bgSrc);
+        els.bgImg.style.display = "block";
+      } else {
+        els.bgImg.style.display = "none";
+      }
+    }
+
+    if (!state.folderExists) {
+      setStatus(missingMsg);
+    }
+  }
+
   async function load() {
-    const p = getParams();
-    library = p.library;
-    ratingKey = p.ratingKey;
-    const url = `/api/movie?library=${encodeURIComponent(library)}&ratingKey=${encodeURIComponent(ratingKey)}`;
-    data = await j(url);
-    render(data);
-  }
-
-  function render(d) {
-    data = d;
-    const folderExists = !!d.folderExists;
-    if (folderWarning) folderWarning.style.display = folderExists ? "none" : "block";
-    for (const el of interactiveEls) {
-      if (!el) continue;
-      el.disabled = !folderExists;
-      if (!folderExists && el.tagName === "INPUT") el.value = "";
-    }
-    if (!folderExists) {
-      status.textContent = missingMsg;
-    } else if (status.textContent === missingMsg) {
-      status.textContent = "";
-    }
-
-    const posterSrc = d.posterUrl || d.posterUrlPlex || "";
-    const bgSrc = d.backgroundUrl || d.backgroundUrlPlex || "";
-
-    const pi = $("#posterImg");
-    if (posterSrc) { pi.src = posterSrc; pi.style.display = "block"; } else { pi.style.display = "none"; }
-    flag(posterFlag, !!d.posterUrl);
-
-    const bi = $("#bgImg");
-    if (bgSrc) { bi.src = bgSrc; bi.style.display = "block"; } else { bi.style.display = "none"; }
-    flag(bgFlag, !!d.backgroundUrl);
-  }
-
-  async function upload(kind, fileInput) {
-    if (!data || !data.folderExists) {
-      status.textContent = missingMsg;
+    if (!state.library || !state.ratingKey) {
+      setStatus("Missing library or ratingKey.");
+      applyFolderState();
       return;
     }
-    const file = fileInput.files[0];
-    if (!file) { status.textContent = "Choose a file first."; return; }
-    status.textContent = "Uploading...";
+    setStatus("");
+    try {
+      const query = new URLSearchParams({
+        library: state.library,
+        ratingKey: state.ratingKey,
+      });
+      const data = await fetchJson(`/api/movie?${query.toString()}`);
+      state.data = data || {};
+      state.folderName = data?.folderName || "";
+      state.folderExists = Boolean(data?.folderExists);
+      state.plexPosterUrl = data?.posterUrlPlex || data?.plexPosterUrl || null;
+      state.plexBackgroundUrl = data?.backgroundUrlPlex || data?.plexBackgroundUrl || null;
+      if (typeof data?.ratingKey !== "undefined") {
+        state.ratingKey = String(data.ratingKey);
+      }
+      render();
+    } catch (err) {
+      setStatus(err?.message || String(err));
+      applyFolderState();
+    }
+  }
 
+  async function handleUpload(kind, input) {
+    if (!state.folderExists) {
+      setStatus(missingMsg);
+      return;
+    }
+    if (!input) return;
+    const file = input.files && input.files[0];
+    if (!file) {
+      setStatus("Choose a file first.");
+      return;
+    }
+    const label = kind === "poster" ? "poster" : "background";
+    setStatus(`Uploading ${label}...`);
     const fd = new FormData();
-    fd.append("library", library);
-    fd.append("ratingKey", data.ratingKey);
-    fd.append("folderName", data.folderName);
+    fd.append("library", state.library);
+    fd.append("ratingKey", state.ratingKey);
+    fd.append("folderName", state.folderName || "");
     fd.append("kind", kind);
     fd.append("file", file);
-
-    const r = await fetch("/api/upload", { method: "POST", body: fd });
-    if (!r.ok) { status.textContent = "Upload failed."; throw new Error(await r.text()); }
-    await r.json();
-
-    const fresh = await j(`/api/movie?library=${encodeURIComponent(library)}&ratingKey=${encodeURIComponent(ratingKey)}`);
-    render(fresh);
-    status.textContent = "Done.";
+    try {
+      await fetchJson("/api/upload", { method: "POST", body: fd });
+      input.value = "";
+      setStatus("Done.");
+      await load();
+    } catch (err) {
+      setStatus(err?.message || String(err));
+    }
   }
 
-
-  async function importBg() {
-    if (!data || !data.folderExists) {
-      status.textContent = missingMsg;
+  async function handleImport(kind) {
+    if (!state.folderExists) {
+      setStatus(missingMsg);
       return;
     }
-    status.textContent = "Importing from Plex...";
+    const label = kind === "poster" ? "poster" : "background";
+    setStatus(`Importing ${label}...`);
     const fd = new FormData();
-    fd.append("library", library);
-    fd.append("ratingKey", data.ratingKey);
-    fd.append("folderName", data.folderName);
-    if (data.backgroundUrlPlex) fd.append("url", data.backgroundUrlPlex);
-
-    const r = await fetch("/api/import/background", { method: "POST", body: fd });
-    if (!r.ok) { status.textContent = "Import failed."; throw new Error(await r.text()); }
-    await r.json();
-
-    const fresh = await j(`/api/movie?library=${encodeURIComponent(library)}&ratingKey=${encodeURIComponent(ratingKey)}`);
-    render(fresh);
-    status.textContent = "Done.";
+    fd.append("library", state.library);
+    fd.append("ratingKey", state.ratingKey);
+    fd.append("folderName", state.folderName || "");
+    const plexUrl = kind === "poster" ? state.plexPosterUrl : state.plexBackgroundUrl;
+    if (plexUrl) fd.append("url", plexUrl);
+    try {
+      await fetchJson(`/api/import/${kind}`, { method: "POST", body: fd });
+      setStatus("Done.");
+      await load();
+    } catch (err) {
+      setStatus(err?.message || String(err));
+    }
   }
 
-async function importPoster() {
-    if (!data || !data.folderExists) {
-      status.textContent = missingMsg;
+  function init() {
+    const route = parseRoute();
+    state.library = route.library || "";
+    state.ratingKey = route.ratingKey ? String(route.ratingKey) : "";
+    setBackLink();
+    if (!state.library || !state.ratingKey) {
+      applyFolderState();
+      setStatus("Missing library or ratingKey.");
       return;
     }
-    status.textContent = "Importing from Plex...";
-    const fd = new FormData();
-    fd.append("library", library);
-    fd.append("ratingKey", data.ratingKey);
-    fd.append("folderName", data.folderName);
-
-    const r = await fetch("/api/import/poster", { method: "POST", body: fd });
-    if (!r.ok) { status.textContent = "Import failed."; throw new Error(await r.text()); }
-    await r.json();
-
-    const fresh = await j(`/api/movie?library=${encodeURIComponent(library)}&ratingKey=${encodeURIComponent(ratingKey)}`);
-    render(fresh);
-    status.textContent = "Done.";
+    load();
   }
 
   document.addEventListener("DOMContentLoaded", () => {
-    $("#uploadPoster").onclick = () => upload("poster", $("#posterFile"));
-    $("#uploadBg").onclick = () => upload("background", $("#bgFile"));
-    $("#importPoster").onclick = () => importPoster();
-    $("#importBg").onclick = () => importBg();
-    load().catch((e) => (status.textContent = String(e)));
+    if (els.uploadPoster) {
+      els.uploadPoster.addEventListener("click", () => handleUpload("poster", els.posterFile));
+    }
+    if (els.uploadBg) {
+      els.uploadBg.addEventListener("click", () => handleUpload("background", els.bgFile));
+    }
+    if (els.importPoster) {
+      els.importPoster.addEventListener("click", () => handleImport("poster"));
+    }
+    if (els.importBg) {
+      els.importBg.addEventListener("click", () => handleImport("background"));
+    }
+    init();
   });
 </script>
 </body>


### PR DESCRIPTION
## Summary
- add a FastAPI page route for `/libraries/{library}/movies/{ratingKey}` so the SPA-style navigation works
- update the library grid navigation to link movies to the new detail route
- refresh the movie detail page logic to mirror folder state, support uploads/imports, and show status messaging

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dfc030d52c833081f002618cc35b8c