### PR TITLE
Add React show details page with upload/import wiring

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -31,6 +31,7 @@ from .routers import (
     movie,
     tv,
     upload,
+    ui,
 )
 
 app.include_router(libraries.router)
@@ -42,6 +43,7 @@ app.include_router(movie.router)
 app.include_router(imports.router)
 app.include_router(fileproxy.router)
 app.include_router(assets.router)
+app.include_router(ui.router)
 
 # ---- SAFE assets mount (env-driven) ----
 # Prefer explicit envs if you set them; otherwise infer from COLLECTIONS_ROOT.

--- a/app/routers/ui.py
+++ b/app/routers/ui.py
@@ -1,0 +1,15 @@
+# app/routers/ui.py
+from pathlib import Path
+
+from fastapi import APIRouter
+from fastapi.responses import FileResponse
+
+router = APIRouter()
+
+_SHOW_HTML = Path("app/web/show-react.html").resolve()
+
+
+@router.get("/libraries/{library}/shows/{ratingKey}")
+async def show_details_page(library: str, ratingKey: str):
+    """Serve the React show details experience for deep links."""
+    return FileResponse(_SHOW_HTML)

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -657,7 +657,10 @@
 
     const rk = encodeURIComponent(it.ratingKey || it.key || it.id || '');
     const lib = encodeURIComponent(state.library || '');
-    const dest = isShowItem(it, state.library) ? 'show.html' : 'movie.html';
+    if (isShowItem(it, state.library)) {
+      return `/libraries/${lib}/shows/${rk}`;
+    }
+    const dest = 'movie.html';
     const url = `${dest}?library=${lib}&ratingKey=${rk}`;
     return url;
   }

--- a/app/web/show-react.html
+++ b/app/web/show-react.html
@@ -1,0 +1,475 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>KAM • Show Details</title>
+  <link rel="preconnect" href="https://unpkg.com" crossorigin>
+  <style>
+    :root { --bg:#0b0b0f; --fg:#e8e8ee; --muted:#a9a9b5; --card:#15151c; --accent:#5ea1ff; --border:#2a2a36; --danger:#f87171; --success:#34d399; }
+    [data-theme="light"] { --bg:#ffffff; --fg:#11111a; --muted:#4a4a55; --card:#f6f6fb; --accent:#3b82f6; --border:#d7d7e0; --danger:#dc2626; --success:#0f766e; }
+    *{box-sizing:border-box}
+    body{margin:0; font:16px/1.4 system-ui,-apple-system,Segoe UI,Roboto,Ubuntu; background:var(--bg); color:var(--fg); min-height:100vh;}
+    a{color:inherit}
+    header{display:flex; align-items:center; gap:12px; padding:16px; border-bottom:1px solid var(--border); position:sticky; top:0; background:var(--bg); z-index:10;}
+    header h1{margin:0; font-size:20px; font-weight:600}
+    .btn{background:var(--card); color:var(--fg); border:1px solid var(--border); border-radius:10px; padding:8px 12px; cursor:pointer; font:inherit; transition:border-color .2s ease, opacity .2s ease;}
+    .btn:hover,.btn:focus{border-color:var(--accent); outline:none}
+    .btn[disabled]{opacity:.45; cursor:not-allowed}
+    main{padding:20px; display:flex; flex-direction:column; gap:20px;}
+    .warning{display:flex; align-items:flex-start; gap:10px; border:1px solid rgba(248,113,113,0.65); background:rgba(127,29,29,0.45); color:#fecaca; border-radius:12px; padding:12px 14px;}
+    .warning strong{font-size:18px}
+    .card-grid{display:grid; grid-template-columns:repeat(auto-fit, minmax(280px,1fr)); gap:16px;}
+    .card{background:var(--card); border:1px solid var(--border); border-radius:14px; padding:16px; display:flex; flex-direction:column; gap:12px; min-height:100%;}
+    .label{font-size:13px; letter-spacing:.03em; text-transform:uppercase; color:var(--muted);}
+    .artwork-img{width:100%; height:auto; border-radius:12px; object-fit:cover; background:#000;}
+    .actions-row{display:flex; flex-direction:column; gap:8px;}
+    @media(min-width:640px){.actions-row{flex-direction:row; align-items:center;}}
+    input[type="file"]{background:var(--card); color:var(--fg); border:1px solid var(--border); border-radius:10px; padding:8px;}
+    input[type="file"]::file-selector-button{background:var(--border); color:var(--fg); border:none; border-radius:8px; padding:6px 10px; margin-right:10px; cursor:pointer;}
+    input[type="file"][disabled]{opacity:.5; cursor:not-allowed}
+    .status-text{font-size:13px; color:var(--muted); min-height:1.4em;}
+    .status-text.error{color:var(--danger);}
+    .status-text.success{color:var(--success);}
+    .season-grid{display:grid; grid-template-columns:repeat(auto-fill, minmax(240px,1fr)); gap:16px;}
+    .season-card{background:var(--card); border:1px solid var(--border); border-radius:14px; padding:14px; display:flex; flex-direction:column; gap:10px;}
+    .season-title{font-weight:600; font-size:15px;}
+    .season-img{width:100%; height:auto; max-height:240px; border-radius:10px; object-fit:cover; background:#000;}
+    .season-actions{display:flex; flex-direction:column; gap:8px;}
+    @media(min-width:620px){.season-actions{flex-direction:row; align-items:center;}}
+    .meta-line{font-size:14px; color:var(--muted);}
+    .status-banner{padding:12px 14px; border-radius:12px; font-size:14px;}
+    .status-banner.error{border:1px solid rgba(248,113,113,0.75); background:rgba(153,27,27,0.45); color:#fecaca;}
+    .status-banner.info{border:1px solid var(--border); background:var(--card); color:var(--muted);}
+  </style>
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+</head>
+<body>
+  <div id="root"></div>
+  <script>
+    (function(){
+      const { useState, useEffect, useMemo, useCallback, useRef } = React;
+      const e = React.createElement;
+
+      function safeJson(response){
+        return response.text().then(text => {
+          if (!text) return null;
+          try { return JSON.parse(text); }
+          catch (_) { return null; }
+        });
+      }
+
+      function responseErrorMessage(response, data){
+        if (data && typeof data === 'object'){
+          if (data.detail) return String(data.detail);
+          if (data.error) return String(data.error);
+          if (Array.isArray(data.errors) && data.errors.length) return String(data.errors[0]);
+        }
+        return `HTTP ${response.status}`;
+      }
+
+      function defaultOperation(){
+        return { uploading:false, importing:false, error:null, success:false };
+      }
+
+      function ArtworkCard(props){
+        const { kind, label, imageUrl, folderExists, plexUrl, operation, onUpload, onImport } = props;
+        const [file, setFile] = useState(null);
+        const inputRef = useRef(null);
+
+        useEffect(() => {
+          if (!operation.uploading && !operation.importing && operation.success){
+            setFile(null);
+            if (inputRef.current) inputRef.current.value = '';
+          }
+        }, [operation.uploading, operation.importing, operation.success]);
+
+        const busy = operation.uploading || operation.importing;
+        const disabled = !folderExists || busy;
+
+        function handleUpload(){
+          if (!file || !onUpload) return;
+          onUpload(kind, file).then(() => {
+            if (inputRef.current) inputRef.current.value = '';
+            setFile(null);
+          }).catch(() => {});
+        }
+
+        function handleImport(){
+          if (!onImport) return;
+          onImport(kind, plexUrl);
+        }
+
+        const status = operation.error
+          ? e('div', { className: 'status-text error' }, operation.error)
+          : operation.success
+            ? e('div', { className: 'status-text success' }, operation.importing ? 'Imported successfully.' : 'Uploaded successfully.')
+            : e('div', { className: 'status-text' }, busy ? 'Working…' : '\u00a0');
+
+        return e('div', { className: 'card' },
+          e('div', { className: 'label' }, label),
+          imageUrl ? e('img', { src: imageUrl, alt: label, className: 'artwork-img' }) : null,
+          e('div', { className: 'actions-row' },
+            e('input', {
+              ref: inputRef,
+              type: 'file',
+              accept: 'image/*',
+              disabled: !folderExists || operation.importing,
+              onChange: ev => {
+                const f = ev.target.files && ev.target.files[0] ? ev.target.files[0] : null;
+                setFile(f);
+              }
+            }),
+            e('button', {
+              className: 'btn',
+              onClick: handleUpload,
+              disabled: !folderExists || !file || operation.uploading || operation.importing
+            }, operation.uploading ? 'Uploading…' : 'Upload'),
+            e('button', {
+              className: 'btn',
+              onClick: handleImport,
+              disabled: !folderExists || operation.uploading || operation.importing
+            }, operation.importing ? 'Importing…' : 'Import')
+          ),
+          status
+        );
+      }
+
+      function SeasonCard(props){
+        const { season, folderExists, operation, onUpload, onImport } = props;
+        const [file, setFile] = useState(null);
+        const inputRef = useRef(null);
+        const busy = operation.uploading || operation.importing;
+        const disabledInput = !folderExists || operation.importing;
+
+        useEffect(() => {
+          if (!busy && operation.success){
+            setFile(null);
+            if (inputRef.current) inputRef.current.value = '';
+          }
+        }, [busy, operation.success]);
+
+        function handleUpload(){
+          if (!file) return;
+          onUpload(season.index, file).then(() => {
+            if (inputRef.current) inputRef.current.value = '';
+            setFile(null);
+          }).catch(() => {});
+        }
+
+        function handleImport(){
+          onImport(season.index, season.plexPosterUrl || null);
+        }
+
+        const status = operation.error
+          ? e('div', { className: 'status-text error' }, operation.error)
+          : operation.success
+            ? e('div', { className: 'status-text success' }, operation.importing ? 'Imported.' : 'Uploaded.')
+            : e('div', { className: 'status-text' }, busy ? 'Working…' : '\u00a0');
+
+        return e('div', { className: 'season-card' },
+          e('div', { className: 'season-title' }, season.title || `Season ${String(season.index).padStart(2, '0')}`),
+          season.posterUrl ? e('img', { className: 'season-img', src: season.posterUrl, alt: season.title || 'Season poster' }) : null,
+          e('div', { className: 'season-actions' },
+            e('input', {
+              ref: inputRef,
+              type: 'file',
+              accept: 'image/*',
+              disabled: disabledInput,
+              onChange: ev => {
+                const f = ev.target.files && ev.target.files[0] ? ev.target.files[0] : null;
+                setFile(f);
+              }
+            }),
+            e('button', {
+              className: 'btn',
+              onClick: handleUpload,
+              disabled: !folderExists || !file || operation.uploading || operation.importing
+            }, operation.uploading ? 'Uploading…' : 'Upload'),
+            e('button', {
+              className: 'btn',
+              onClick: handleImport,
+              disabled: !folderExists || operation.uploading || operation.importing
+            }, operation.importing ? 'Importing…' : 'Import')
+          ),
+          status
+        );
+      }
+
+      function SeasonGrid(props){
+        const { seasons, folderExists, operations, onUpload, onImport } = props;
+        if (!seasons || !seasons.length){
+          return e('div', { className: 'status-text' }, 'No seasons found for this series.');
+        }
+        return e('div', { className: 'season-grid' },
+          seasons.map(season => {
+            const op = (operations && operations[season.index]) || defaultOperation();
+            return e(SeasonCard, {
+              key: season.index,
+              season,
+              folderExists,
+              operation: op,
+              onUpload,
+              onImport,
+            });
+          })
+        );
+      }
+
+      function usePathParams(){
+        return useMemo(() => {
+          const parts = window.location.pathname.split('/').filter(Boolean);
+          let library = '';
+          let ratingKey = '';
+          if (parts.length >= 4 && parts[0] === 'libraries' && parts[2] === 'shows'){
+            library = decodeURIComponent(parts[1] || '');
+            ratingKey = decodeURIComponent(parts[3] || '');
+          } else {
+            const urlp = new URLSearchParams(window.location.search);
+            library = urlp.get('library') || '';
+            ratingKey = urlp.get('ratingKey') || '';
+          }
+          return { library, ratingKey };
+        }, []);
+      }
+
+      function App(){
+        const { library, ratingKey } = usePathParams();
+        const [detail, setDetail] = useState(null);
+        const [loading, setLoading] = useState(true);
+        const [error, setError] = useState(null);
+        const [operations, setOperations] = useState({
+          poster: defaultOperation(),
+          background: defaultOperation(),
+          seasons: {}
+        });
+
+        const folderExists = detail && detail.folderExists;
+
+        const fetchDetails = useCallback(async () => {
+          if (!library || !ratingKey){
+            setError('Missing library or rating key.');
+            setLoading(false);
+            return;
+          }
+          setLoading(true);
+          setError(null);
+          try {
+            const url = `/api/show?library=${encodeURIComponent(library)}&ratingKey=${encodeURIComponent(ratingKey)}`;
+            const response = await fetch(url);
+            const data = await safeJson(response);
+            if (!response.ok){
+              throw new Error(data && (data.detail || data.error) ? (data.detail || data.error) : `Failed to load (${response.status})`);
+            }
+            setDetail(data || null);
+            document.title = data && data.title ? `KAM • ${data.title}` : 'KAM • Show Details';
+          } catch (err){
+            setError(err && err.message ? err.message : String(err));
+            setDetail(null);
+          } finally {
+            setLoading(false);
+          }
+        }, [library, ratingKey]);
+
+        useEffect(() => {
+          fetchDetails();
+        }, [fetchDetails]);
+
+        function resetOperation(kind, updater){
+          setOperations(prev => {
+            const next = { ...prev };
+            if (kind === 'poster' || kind === 'background'){
+              next[kind] = typeof updater === 'function' ? updater(prev[kind]) : updater;
+            }
+            return next;
+          });
+        }
+
+        function updateSeasonOperation(index, updater){
+          setOperations(prev => {
+            const next = { ...prev, seasons: { ...prev.seasons } };
+            const current = next.seasons[index] || defaultOperation();
+            next.seasons[index] = typeof updater === 'function' ? updater(current) : updater;
+            return next;
+          });
+        }
+
+        const handleShowUpload = useCallback(async (kind, file) => {
+          if (!detail || !detail.folderName) return;
+          resetOperation(kind, op => ({ ...op, uploading:true, error:null, success:false }));
+          try {
+            const form = new FormData();
+            form.append('library', library);
+            form.append('folderName', detail.folderName || '');
+            form.append('kind', kind);
+            form.append('file', file);
+            const response = await fetch('/api/upload_show', { method:'POST', body:form });
+            const data = await safeJson(response);
+            if (!response.ok){
+              throw new Error(responseErrorMessage(response, data));
+            }
+            resetOperation(kind, op => ({ ...op, uploading:false, success:true, error:null }));
+            await fetchDetails();
+          } catch (err){
+            resetOperation(kind, op => ({ ...op, uploading:false, success:false, error: err && err.message ? err.message : String(err) }));
+            throw err;
+          }
+        }, [detail, library, fetchDetails]);
+
+        const handleShowImport = useCallback(async (kind, _plexUrl) => {
+          if (!detail || !detail.folderName) return;
+          resetOperation(kind, op => ({ ...op, importing:true, error:null, success:false }));
+          try {
+            const form = new FormData();
+            form.append('library', library);
+            form.append('folderName', detail.folderName || '');
+            form.append('ratingKey', ratingKey);
+            form.append('includePoster', String(kind === 'poster'));
+            form.append('includeBackground', String(kind === 'background'));
+            form.append('includeSeasons', 'false');
+            const response = await fetch('/api/import/show', { method:'POST', body:form });
+            const data = await safeJson(response);
+            const part = kind === 'poster' ? (data && data.poster) : (data && data.background);
+            if (!response.ok || !(part && part.ok)){
+              const message = part && part.error ? part.error : (data && data.error ? data.error : responseErrorMessage(response, data));
+              throw new Error(message);
+            }
+            resetOperation(kind, op => ({ ...op, importing:false, success:true, error:null }));
+            await fetchDetails();
+          } catch (err){
+            resetOperation(kind, op => ({ ...op, importing:false, success:false, error: err && err.message ? err.message : String(err) }));
+          }
+        }, [detail, library, ratingKey, fetchDetails]);
+
+        const handleSeasonUpload = useCallback(async (index, file) => {
+          if (!detail || !detail.folderName) return;
+          updateSeasonOperation(index, op => ({ ...op, uploading:true, error:null, success:false }));
+          try {
+            const form = new FormData();
+            form.append('library', library);
+            form.append('folderName', detail.folderName || '');
+            form.append('season', String(index));
+            form.append('file', file);
+            const response = await fetch('/api/upload_season', { method:'POST', body:form });
+            const data = await safeJson(response);
+            if (!response.ok){
+              throw new Error(responseErrorMessage(response, data));
+            }
+            updateSeasonOperation(index, op => ({ ...op, uploading:false, success:true, error:null }));
+            await fetchDetails();
+          } catch (err){
+            updateSeasonOperation(index, op => ({ ...op, uploading:false, success:false, error: err && err.message ? err.message : String(err) }));
+            throw err;
+          }
+        }, [detail, library, fetchDetails]);
+
+        const handleSeasonImport = useCallback(async (index, plexUrl) => {
+          if (!detail || !detail.folderName) return;
+          updateSeasonOperation(index, op => ({ ...op, importing:true, error:null, success:false }));
+          try {
+            const form = new FormData();
+            form.append('library', library);
+            form.append('folderName', detail.folderName || '');
+            form.append('season', String(index));
+            form.append('ratingKey', ratingKey);
+            if (plexUrl) form.append('url', plexUrl);
+            const response = await fetch('/api/import/season', { method:'POST', body:form });
+            const data = await safeJson(response);
+            if (!response.ok || !(data && data.ok)){
+              const message = data && data.error ? data.error : responseErrorMessage(response, data || {});
+              throw new Error(message);
+            }
+            updateSeasonOperation(index, op => ({ ...op, importing:false, success:true, error:null }));
+            await fetchDetails();
+          } catch (err){
+            updateSeasonOperation(index, op => ({ ...op, importing:false, success:false, error: err && err.message ? err.message : String(err) }));
+          }
+        }, [detail, library, ratingKey, fetchDetails]);
+
+        if (!library || !ratingKey){
+          return e('main', null,
+            e('div', { className: 'status-banner error' }, 'Missing library or rating key in URL.')
+          );
+        }
+
+        const backHref = `/index.html?lib=${encodeURIComponent(library)}`;
+        const header = e('header', null,
+          e('a', { href: backHref, className: 'btn' }, '\u2190 Back'),
+          e('h1', null, detail && detail.title ? detail.title : 'Show Details'),
+          detail && detail.year ? e('span', { className: 'meta-line' }, `(${detail.year})`) : null
+        );
+
+        if (loading){
+          return e(React.Fragment, null,
+            header,
+            e('main', null,
+              e('div', { className: 'status-banner info' }, 'Loading…')
+            )
+          );
+        }
+
+        if (error){
+          return e(React.Fragment, null,
+            header,
+            e('main', null,
+              e('div', { className: 'status-banner error' }, error),
+              e('button', { className: 'btn', onClick: fetchDetails }, 'Retry')
+            )
+          );
+        }
+
+        const seasons = (detail && detail.seasons) || [];
+        const operationsState = operations.seasons || {};
+
+        return e(React.Fragment, null,
+          header,
+          e('main', null,
+            !folderExists ? e('div', { className: 'warning' },
+              e('strong', null, '✖'),
+              e('div', null, 'Asset folder not found. Create the Kometa asset folder first.')
+            ) : null,
+            e('section', null,
+              e('div', { className: 'card-grid' },
+                e(ArtworkCard, {
+                  kind: 'poster',
+                  label: 'Series Poster',
+                  imageUrl: detail && detail.posterUrl,
+                  folderExists,
+                  plexUrl: detail && detail.plexPosterUrl,
+                  operation: operations.poster || defaultOperation(),
+                  onUpload: handleShowUpload,
+                  onImport: handleShowImport
+                }),
+                e(ArtworkCard, {
+                  kind: 'background',
+                  label: 'Background',
+                  imageUrl: detail && detail.backgroundUrl,
+                  folderExists,
+                  plexUrl: detail && detail.plexBackgroundUrl,
+                  operation: operations.background || defaultOperation(),
+                  onUpload: handleShowUpload,
+                  onImport: handleShowImport
+                })
+              )
+            ),
+            e('section', null,
+              e('h2', null, 'Seasons'),
+              e(SeasonGrid, {
+                seasons,
+                folderExists,
+                operations: operationsState,
+                onUpload: handleSeasonUpload,
+                onImport: handleSeasonImport
+              })
+            )
+          )
+        );
+      }
+
+      const root = ReactDOM.createRoot(document.getElementById('root'));
+      root.render(e(App));
+    })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a FastAPI route that serves a new React-driven show details page for `/libraries/:library/shows/:ratingKey`
- build the show details experience with poster/background controls, season grid, and upload/import flows that refresh metadata on success
- update the library grid so TV shows deep-link into the React details route instead of the legacy static page

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dfc0355e8483308426ad780c6180da