### PR TITLE
Ensure fallback asset copied during Vite build

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.DS_Store
+dist

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,52 @@
+import { defineConfig, type Plugin } from "vite";
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { resolve, join } from "node:path";
+
+const outputDir = resolve(__dirname, "../app/web");
+const fallbackSource = resolve(__dirname, "../app/web/fallback.png");
+
+let fallbackBuffer: Buffer | null = null;
+let reportedMissing = false;
+
+function refreshFallbackBuffer(): void {
+  try {
+    fallbackBuffer = readFileSync(fallbackSource);
+    reportedMissing = false;
+  } catch (error) {
+    if (!fallbackBuffer && !reportedMissing) {
+      console.warn(
+        `[vite] Unable to read fallback image at ${fallbackSource}:`,
+        error
+      );
+      reportedMissing = true;
+    }
+  }
+}
+
+refreshFallbackBuffer();
+
+function copyFallbackPlugin(): Plugin {
+  return {
+    name: "copy-shared-fallback",
+    apply: "build",
+    buildStart() {
+      refreshFallbackBuffer();
+    },
+    closeBundle() {
+      if (!fallbackBuffer) {
+        return;
+      }
+      mkdirSync(outputDir, { recursive: true });
+      writeFileSync(join(outputDir, "fallback.png"), fallbackBuffer);
+    },
+  };
+}
+
+export default defineConfig({
+  build: {
+    outDir: outputDir,
+    emptyOutDir: true,
+  },
+  publicDir: "public",
+  plugins: [copyFallbackPlugin()],
+});


### PR DESCRIPTION
## Summary
- add a Vite build plugin that restores `app/web/fallback.png` into the generated output so the fallback asset survives clean builds without living in the frontend tree
- add a frontend `.gitignore` entry for local build artefacts

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dfc34f54e483309bf4abaa8ad94d30