### PR TITLE
Ensure poster normalization returns fallback image

### DIFF
--- a/frontend/src/utils/items.js
+++ b/frontend/src/utils/items.js
@@ -24,6 +24,6 @@ export function normalizePoster(item) {
     item?.thumb ||
     item?.background ||
     item?.art ||
-    ''
+    '/fallback.png'
   );
 }


### PR DESCRIPTION
## Summary
- ensure `normalizePoster` returns the shared fallback asset whenever no poster, thumb, background, or art URL is present
- noted that `ItemGrid` already consumes `normalizePoster`, so `<img>` elements always receive a usable `src`

## Testing
- npm install *(fails: 403 Forbidden fetching @vitejs/plugin-react)*

------
https://chatgpt.com/codex/tasks/task_e_68dfcffb59b083308c53ac03d948ea9a