### PR TITLE
Build frontend during Docker image creation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+frontend/node_modules
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,11 @@
+FROM node:20 AS frontend-build
+WORKDIR /workspace
+COPY frontend/package*.json ./
+RUN npm install
+COPY frontend/ ./
+COPY app/web/fallback.png ./app/web/fallback.png
+RUN npm run build
+
 FROM python:3.11-slim
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
@@ -11,6 +19,7 @@ RUN python -m pip install --upgrade pip && \
     pip install --no-cache-dir -r /tmp/requirements.txt
 
 COPY . /app
+COPY --from=frontend-build /workspace/app/web /app/app/web
 ENV PYTHONPATH=/app
 EXPOSE 8000
 


### PR DESCRIPTION
## Summary
- add a Node-based stage to install dependencies and build the React frontend
- copy the built web assets into the Python image and ignore node_modules in the Docker context

## Testing
- `docker build -t kam-test .` *(fails: docker not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfd4af455883309f4efb6b265957cb