### PR TITLE
Fix Vite output paths for flattened repo layout

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,10 +1,14 @@
 import { defineConfig, type Plugin } from "vite";
 import react from "@vitejs/plugin-react";
-import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
 import { resolve, join } from "node:path";
 
-const outputDir = resolve(__dirname, "../app/web");
-const fallbackSource = resolve(__dirname, "../app/web/fallback.png");
+const repoRoot = existsSync(resolve(__dirname, "../app/web"))
+  ? resolve(__dirname, "..")
+  : resolve(__dirname, ".");
+
+const outputDir = resolve(repoRoot, "app/web");
+const fallbackSource = resolve(repoRoot, "app/web/fallback.png");
 
 let fallbackBuffer: Buffer | null = null;
 let reportedMissing = false;


### PR DESCRIPTION
## Summary
- detect the repository root by probing for the shared app/web directory so both flattened and nested layouts resolve correctly
- reuse the derived root for the build output directory and fallback asset source to keep the copy plugin functional

## Testing
- npm run build *(fails: requires npm packages that cannot be downloaded in this environment)*


------
https://chatgpt.com/codex/tasks/task_e_68dfe365892883309c22c96179dc6cae