### PR TITLE
Serve SPA assets from dedicated directory

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -69,5 +69,12 @@ if ASSETS_ROOT and os.path.isdir(ASSETS_ROOT):
 else:
     logger.warning("Skipping /assets mount. Not found in container: %r", ASSETS_ROOT)
 
+# Serve SPA build assets separately so they don't rely on the user-configured mount
+app.mount(
+    "/spa-assets",
+    StaticFiles(directory="app/web/spa-assets"),
+    name="spa-assets",
+)
+
 # ---- Static Web UI ----
 app.mount("/", StaticFiles(directory="app/web", html=True), name="web")

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,6 +8,7 @@ const repoRoot = existsSync(resolve(__dirname, "../app/web"))
   : resolve(__dirname, ".");
 
 const outputDir = resolve(repoRoot, "app/web");
+const spaAssetsDir = "spa-assets";
 const fallbackSource = resolve(repoRoot, "app/web/fallback.png");
 
 let fallbackBuffer: Buffer | null = null;
@@ -51,6 +52,7 @@ export default defineConfig({
   build: {
     outDir: outputDir,
     emptyOutDir: true,
+    assetsDir: spaAssetsDir,
   },
   publicDir: "public",
   plugins: [react(), copyFallbackPlugin()],


### PR DESCRIPTION
## Summary
- configure Vite to emit SPA bundles into a dedicated `spa-assets` subdirectory while keeping the fallback copy logic unchanged
- mount the new `/spa-assets` route in FastAPI so hashed bundle files are served independently of user-provided asset mounts

## Testing
- `npm run build` *(fails: unable to download npm dependencies in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfe5de9bc08330bec36e224713d5eb