### PR TITLE
Add pointer cursor to Not Ready badge

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -248,11 +248,13 @@ main {
 .ready-badge.ready {
   background: #1f8f4d;
   color: #fff;
+  cursor: default;
 }
 
 .ready-badge.not-ready {
   background: #b91c1c;
   color: #fff;
+  cursor: pointer;
 }
 
 [data-theme="light"] .ready-badge.ready {


### PR DESCRIPTION
## Summary
- make the Not Ready badge show a pointer cursor to indicate it is interactive
- keep the Ready badge using the default cursor to signal it is static

## Testing
- npm install *(fails: 403 Forbidden fetching @vitejs/plugin-react)*

------
https://chatgpt.com/codex/tasks/task_e_68dfefc55824833091ccd7c001826f91