### PR TITLE
Remove unused Jinja dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 fastapi==0.115.*
 uvicorn[standard]==0.30.*
-jinja2
 python-multipart
 plexapi
 requests


### PR DESCRIPTION
## Summary
- remove the unused jinja2 package from the Python requirements

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dff8bd42bc8330882d4cce8eb3ecc8