### PR TITLE
Fix movie param parsing for index pages

### DIFF
--- a/app/web/movie.html
+++ b/app/web/movie.html
@@ -86,9 +86,13 @@
     let library = "";
     let ratingKey = "";
 
-    if (parts.length >= 4 && parts[0] === "libraries" && parts[2] === "movies") {
+    const isLibraryMoviePath = parts.length >= 4 && parts[0] === "libraries" && parts[2] === "movies";
+    const ratingKeySegment = parts[3];
+    const hasValidRatingKey = !!ratingKeySegment && !ratingKeySegment.endsWith(".html");
+
+    if (isLibraryMoviePath && hasValidRatingKey) {
       library = decodeURIComponent(parts[1] || "");
-      ratingKey = decodeURIComponent(parts[3] || "");
+      ratingKey = decodeURIComponent(ratingKeySegment);
     } else {
       const u = new URL(location.href);
       library = u.searchParams.get("library") || "";


### PR DESCRIPTION
## Summary
- ensure movie detail pages only read path segments when a real rating key is present
- fall back to query-string parsing for index listings or missing rating keys

## Testing
- node - <<'NODE' ...


------
https://chatgpt.com/codex/tasks/task_e_68e0053d643c83308a03fee11c603fdb