### PR TITLE
Update movie page navigation and validation

### DIFF
--- a/app/web/movie.html
+++ b/app/web/movie.html
@@ -29,7 +29,7 @@
 </head>
 <body>
 <header>
-  <a id="back" class="btn" href="index.html">← Back</a>
+  <a id="back" class="btn" href="/libraries">← Back</a>
   <h1>Movie</h1>
 </header>
 <main>
@@ -73,6 +73,7 @@
 
   let library, ratingKey, data;
   const status = $("#status");
+  const back = $("#back");
   const posterFlag = $("#posterFlag");
   const bgFlag = $("#bgFlag");
 
@@ -106,6 +107,17 @@
     const p = getParams();
     library = p.library;
     ratingKey = p.ratingKey;
+
+    back.href = "/libraries";
+    if (library) {
+      back.href = `/libraries?lib=${encodeURIComponent(library)}`;
+    }
+
+    if (!library || !ratingKey) {
+      status.textContent = "Select a library and movie to view details.";
+      return;
+    }
+
     const url = `/api/movie?library=${encodeURIComponent(library)}&ratingKey=${encodeURIComponent(ratingKey)}`;
     data = await j(url);
     render(data);


### PR DESCRIPTION
## Summary
- default the movie page back link to the libraries view and update it once the library context is known
- prevent /api/movie requests when the library or ratingKey parameters are missing and surface a status message

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e008e488848330ae925eb33b32b007