### PR TITLE
Ensure themed link colors for cards and buttons

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -75,6 +75,11 @@ button[disabled] {
   cursor: not-allowed;
 }
 
+a.btn:link,
+a.btn:visited {
+  color: var(--fg);
+}
+
 .btn {
   display: inline-flex;
   align-items: center;
@@ -208,6 +213,12 @@ main {
   padding: 16px;
 }
 
+#grid a.card:link,
+#grid a.card:visited {
+  color: var(--fg);
+  text-decoration: none;
+}
+
 .card {
   background: var(--card);
   border: 1px solid var(--border);
@@ -215,6 +226,13 @@ main {
   overflow: hidden;
   display: flex;
   flex-direction: column;
+}
+
+#grid a.card:hover,
+#grid a.card:focus {
+  color: var(--accent);
+  border-color: var(--accent);
+  outline: none;
 }
 
 .card[role="button"] {


### PR DESCRIPTION
## Summary
- keep card links in the grid aligned with the theme colors for default and visited states
- add hover and focus feedback on cards using the accent color
- ensure button-styled links retain themed colors when visited

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e00af7e56c8330bd702c3ef3d0369c