### PR TITLE
Make ready badge interactive for folder selection

### DIFF
--- a/frontend/src/components/ItemGrid.jsx
+++ b/frontend/src/components/ItemGrid.jsx
@@ -31,7 +31,9 @@ function ItemCard({ item, library, onRequestFolder }) {
   const year = item?.year;
   const poster = normalizePoster(item);
   const detailPath = buildDetailPath(item, library);
-  const readinessTooltip = ready ? 'Ready: asset folder found.' : 'Not ready: asset folder missing.';
+  const readinessTooltip = ready
+    ? 'Ready: asset folder found. Click to change the assigned folder.'
+    : 'Not ready: asset folder missing. Click to choose a folder.';
 
   const openFolder = (event) => {
     if (!onRequestFolder) return;
@@ -60,12 +62,16 @@ function ItemCard({ item, library, onRequestFolder }) {
           </span>
           <span
             className={`ready-badge ${ready ? 'ready' : 'not-ready'}`}
-            title={ready ? 'Asset folder found. This item is ready for imports.' : 'Asset folder missing. Click to choose a folder.'}
-            role={!ready ? 'button' : undefined}
-            tabIndex={!ready ? 0 : undefined}
-            onClick={!ready ? openFolder : undefined}
-            onKeyDown={!ready ? handleBadgeKey : undefined}
-            aria-haspopup={!ready ? 'dialog' : undefined}
+            title={
+              ready
+                ? 'Asset folder found. Click to change the assigned folder.'
+                : 'Asset folder missing. Click to choose a folder.'
+            }
+            role="button"
+            tabIndex={0}
+            onClick={openFolder}
+            onKeyDown={handleBadgeKey}
+            aria-haspopup="dialog"
           >
             {ready ? '✔ Ready' : '✖ Not Ready'}
           </span>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -281,18 +281,37 @@ main {
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.04em;
+  cursor: pointer;
+  transition: background 0.2s ease, box-shadow 0.2s ease;
 }
 
 .ready-badge.ready {
   background: #1f8f4d;
   color: #fff;
-  cursor: default;
+  cursor: pointer;
 }
 
 .ready-badge.not-ready {
   background: #b91c1c;
   color: #fff;
   cursor: pointer;
+}
+
+.ready-badge:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.ready-badge.ready:hover,
+.ready-badge.ready:focus-visible {
+  background: #24995a;
+  box-shadow: 0 0 0 2px rgba(36, 153, 90, 0.35);
+}
+
+.ready-badge.not-ready:hover,
+.ready-badge.not-ready:focus-visible {
+  background: #dc2626;
+  box-shadow: 0 0 0 2px rgba(220, 38, 38, 0.35);
 }
 
 [data-theme="light"] .ready-badge.ready {
@@ -303,6 +322,18 @@ main {
 [data-theme="light"] .ready-badge.not-ready {
   background: #fca5a5;
   color: #7f1d1d;
+}
+
+[data-theme="light"] .ready-badge.ready:hover,
+[data-theme="light"] .ready-badge.ready:focus-visible {
+  background: #4ade80;
+  box-shadow: 0 0 0 2px rgba(76, 222, 128, 0.35);
+}
+
+[data-theme="light"] .ready-badge.not-ready:hover,
+[data-theme="light"] .ready-badge.not-ready:focus-visible {
+  background: #fecaca;
+  box-shadow: 0 0 0 2px rgba(254, 202, 202, 0.5);
 }
 
 .card[data-ready="false"] {


### PR DESCRIPTION
## Summary
- give ready badges consistent button semantics so items can change folders after assignment
- refresh ready badge tooltip copy and styling to reflect the interactive behavior in both themes

## Testing
- npm install *(fails: 403 Forbidden fetching @vitejs/plugin-react)*

------
https://chatgpt.com/codex/tasks/task_e_68e0613362f883308a2bbcb02f62b1d5