### PR TITLE
Show current folder assignment in folder finder modal

### DIFF
--- a/frontend/src/components/FolderFinderModal.jsx
+++ b/frontend/src/components/FolderFinderModal.jsx
@@ -41,15 +41,21 @@ function FolderFinderModal({ isOpen, library, item, onClose, onFolderAssigned })
   const [searchTerm, setSearchTerm] = useState('');
   const [isSearching, setIsSearching] = useState(false);
   const [assigning, setAssigning] = useState(false);
+  const [currentFolder, setCurrentFolder] = useState('');
   const debounceRef = useRef();
 
   useEffect(() => {
-    if (!isOpen) return;
+    if (!isOpen) {
+      setCurrentFolder('');
+      return;
+    }
     setSearchInput('');
     setSearchTerm('');
     setSelection(null);
     setError('');
-  }, [isOpen, effectiveLibrary]);
+    const initialFolder = item?.folderName || item?.folder || '';
+    setCurrentFolder(initialFolder || '');
+  }, [isOpen, effectiveLibrary, item]);
 
   const loadFolders = useCallback(
     async ({ path = '', query = '', preserveSelection = false } = {}) => {
@@ -191,6 +197,10 @@ function FolderFinderModal({ isOpen, library, item, onClose, onFolderAssigned })
           <div className="dialog-body">
             <h2 id="folderFinderHeading">Select Asset Folder</h2>
             <p className="folder-context">{contextLabel}</p>
+            <p className="folder-current" aria-live="polite">
+              Current folder:{' '}
+              {currentFolder ? <strong>{currentFolder}</strong> : <span>Not assigned</span>}
+            </p>
             <nav aria-label="Folder breadcrumbs">
               <ol className="breadcrumbs">
                 {breadcrumbs.map((crumb, index) => (

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -382,6 +382,13 @@ main {
   color: var(--muted);
 }
 
+.folder-current {
+  margin: -4px 0 16px;
+  font-size: 13px;
+  color: var(--fg);
+  line-height: 1.4;
+}
+
 .breadcrumbs {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- show the current folder assignment when opening the folder finder modal
- reset folder state when switching items so assistive tech hears the change
- add styling for the current folder label to complement the existing context text

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0671631d48330abb63e606476b9c5