### PR TITLE
Add not-ready items view and shared library state

### DIFF
--- a/app/routers/items.py
+++ b/app/routers/items.py
@@ -128,6 +128,7 @@ def list_items(
     page: int = Query(1, ge=1),
     page_size: int = Query(60, ge=1, le=500),
     query: Optional[str] = Query(None),
+    not_ready_only: bool = Query(False, alias="notReadyOnly"),
 ):
     """
     Prefer local poster.jpg via fileproxy if it actually exists; otherwise fall back to Plex thumb.
@@ -155,23 +156,21 @@ def list_items(
         })
     rows.sort(key=lambda x: x["title"].lower())
 
-    total_count = len(rows)
-    total_pages = max(1, (total_count + page_size - 1) // page_size)
-    page = min(max(1, page), total_pages)
-    start = (page - 1) * page_size
-    end = min(start + page_size, total_count)
-    page_rows = rows[start:end]
-
-    out: List[Dict[str, Any]] = []
-    for it in page_rows:
+    decorated: List[Dict[str, Any]] = []
+    not_ready_total = 0
+    for it in rows:
         override = folder_overrides.get_override(library, it["ratingKey"])
         folder = override or _try_existing_asset_folder(library, it["title"], it["year"])
         asset_ready = True if override else bool(folder)
+        if not asset_ready:
+            not_ready_total += 1
+        if not_ready_only and asset_ready:
+            continue
         if folder and _local_poster_exists(library, folder):
             poster = _fileproxy_poster_url(library, folder)   # <-- /fileproxy now
         else:
             poster = _plex_poster_url(it["ratingKey"], it["thumb"])
-        out.append({
+        decorated.append({
             "ratingKey": it["ratingKey"],
             "title": it["title"],
             "year": it["year"],
@@ -182,9 +181,17 @@ def list_items(
             "posterUrl": poster,
         })
 
+    total_count = len(decorated)
+    total_pages = max(1, (total_count + page_size - 1) // page_size) if decorated else 1
+    page = min(max(1, page), total_pages)
+    start = (page - 1) * page_size
+    end = min(start + page_size, total_count)
+    page_rows = decorated[start:end]
+
     return {
         "page": page,
         "total_pages": total_pages,
         "total_count": total_count,
-        "items": out,
+        "items": page_rows,
+        "not_ready_count": not_ready_total,
     }

--- a/app/routers/ui.py
+++ b/app/routers/ui.py
@@ -15,3 +15,9 @@ _SHOW_REACT = _WEB_DIR / "show-react.html"
 async def show_details_page(library: str, ratingKey: str):
     """Serve the dedicated React show shell so its bundle can hydrate."""
     return FileResponse(_SHOW_REACT)
+
+
+@router.get("/libraries/{library}/not-ready")
+async def not_ready_page(library: str):
+    """Serve the SPA shell for the not-ready view."""
+    return FileResponse(_SPA_INDEX)

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,18 +1,23 @@
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
 import LibraryPage from './pages/LibraryPage.jsx';
 import MovieDetailPage from './pages/MovieDetailPage.jsx';
+import NotReadyPage from './pages/NotReadyPage.jsx';
 import ShowDetailPage from './pages/ShowDetailPage.jsx';
+import { LibraryItemsProvider } from './hooks/LibraryItemsProvider.jsx';
 import { ThemeProvider } from './theme/ThemeProvider.jsx';
 
 function App() {
   return (
     <ThemeProvider>
       <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<Navigate to="/libraries" replace />} />
-          <Route path="/libraries" element={<LibraryPage />} />
-          <Route path="/libraries/*" element={<LibraryPage />} />
-        </Routes>
+        <LibraryItemsProvider>
+          <Routes>
+            <Route path="/" element={<Navigate to="/libraries" replace />} />
+            <Route path="/libraries" element={<LibraryPage />} />
+            <Route path="/libraries/:library/not-ready" element={<NotReadyPage />} />
+            <Route path="/libraries/*" element={<LibraryPage />} />
+          </Routes>
+        </LibraryItemsProvider>
       </BrowserRouter>
     </ThemeProvider>
   );

--- a/frontend/src/components/LibraryToolbar.jsx
+++ b/frontend/src/components/LibraryToolbar.jsx
@@ -14,8 +14,18 @@ function LibraryToolbar({
   onNext,
   onLast,
   countLabel,
+  notReadyCount = 0,
+  onViewNotReady,
+  notReadyDisabled = false,
   children,
 }) {
+  const showNotReadyButton = Boolean(onViewNotReady);
+  const notReadyDisplay = Number(notReadyCount) || 0;
+  const disableNotReady = notReadyDisabled || notReadyDisplay <= 0;
+  const notReadyTitle = disableNotReady
+    ? 'No not-ready items to review yet.'
+    : 'Show only items missing asset folders.';
+
   return (
     <div className="page-header-tools" id="toolbar">
       <label className="sr-only" htmlFor="librarySelect">
@@ -54,6 +64,24 @@ function LibraryToolbar({
       <button type="button" onClick={onImportAll} disabled={importDisabled} title={importTitle}>
         Import Assets
       </button>
+
+      {showNotReadyButton ? (
+        <button
+          type="button"
+          className="not-ready-button"
+          onClick={onViewNotReady}
+          disabled={disableNotReady}
+          title={notReadyTitle}
+        >
+          Not Ready
+          <span
+            className="badge"
+            aria-label={`${notReadyDisplay.toLocaleString()} not-ready items`}
+          >
+            {notReadyDisplay.toLocaleString()}
+          </span>
+        </button>
+      ) : null}
 
       <div className="pager" id="pager">
         <button type="button" onClick={onFirst} disabled={page <= 1}>

--- a/frontend/src/hooks/LibraryItemsProvider.jsx
+++ b/frontend/src/hooks/LibraryItemsProvider.jsx
@@ -1,0 +1,22 @@
+import { createContext, useContext } from 'react';
+import { useLocation } from 'react-router-dom';
+import { useLibraryItems } from './useLibraryItems.js';
+
+const LibraryItemsContext = createContext(null);
+
+export function LibraryItemsProvider({ children }) {
+  const location = useLocation();
+  const searchParams = new URLSearchParams(location.search);
+  const initialLibrary = searchParams.get('lib') || undefined;
+  const value = useLibraryItems({ initialLibrary });
+
+  return <LibraryItemsContext.Provider value={value}>{children}</LibraryItemsContext.Provider>;
+}
+
+export function useLibraryItemsContext() {
+  const ctx = useContext(LibraryItemsContext);
+  if (!ctx) {
+    throw new Error('useLibraryItemsContext must be used within a LibraryItemsProvider');
+  }
+  return ctx;
+}

--- a/frontend/src/hooks/useLibraryItems.js
+++ b/frontend/src/hooks/useLibraryItems.js
@@ -21,6 +21,7 @@ export function useLibraryItems({ initialLibrary } = {}) {
   const [query, setQuery] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+  const [notReadyCount, setNotReadyCount] = useState(0);
 
   const fetchAbort = useRef(null);
   const initialLibraryRef = useRef(initialLibrary);
@@ -97,6 +98,13 @@ export function useLibraryItems({ initialLibrary } = {}) {
         setItems(Array.isArray(data?.items) ? data.items : []);
         setTotalPages(data?.total_pages || 1);
         setTotalCount(data?.total_count || (Array.isArray(data?.items) ? data.items.length : 0));
+        const nextNotReady =
+          typeof data?.not_ready_count === 'number'
+            ? data.not_ready_count
+            : typeof data?.notReadyCount === 'number'
+            ? data.notReadyCount
+            : 0;
+        setNotReadyCount(nextNotReady);
       } catch (err) {
         if (err.name === 'AbortError') return;
         setItems([]);
@@ -134,6 +142,41 @@ export function useLibraryItems({ initialLibrary } = {}) {
   const reload = useCallback(() => {
     loadItems();
   }, [loadItems]);
+
+  const refreshNotReadyCount = useCallback(
+    async (targetLibrary) => {
+      const lib = targetLibrary ?? library;
+      if (!lib) return 0;
+      const normalized = lib.trim().toLowerCase();
+      const base = normalized === 'collections' ? '/collections' : '/api/items';
+      const params = new URLSearchParams();
+      if (base !== '/collections') {
+        params.set('library', lib);
+      }
+      params.set('page', '1');
+      params.set('page_size', '1');
+      try {
+        const response = await fetch(`${base}?${params.toString()}`);
+        if (!response.ok) {
+          const message = `${response.status} ${response.statusText}`;
+          throw new Error(message);
+        }
+        const data = await response.json();
+        const nextNotReady =
+          typeof data?.not_ready_count === 'number'
+            ? data.not_ready_count
+            : typeof data?.notReadyCount === 'number'
+            ? data.notReadyCount
+            : 0;
+        setNotReadyCount(nextNotReady);
+        return nextNotReady;
+      } catch (err) {
+        console.warn('Failed to refresh not-ready count', err);
+        return notReadyCount;
+      }
+    },
+    [library, notReadyCount]
+  );
 
   const fetchAllForLibrary = useCallback(
     async (lib, searchTerm) => {
@@ -208,6 +251,9 @@ export function useLibraryItems({ initialLibrary } = {}) {
       loading,
       error,
       reload,
+      notReadyCount,
+      setNotReadyCount,
+      refreshNotReadyCount,
       fetchAllForLibrary,
       updateItem,
       pageSize: PAGE_SIZE,
@@ -226,6 +272,9 @@ export function useLibraryItems({ initialLibrary } = {}) {
       loading,
       error,
       reload,
+      notReadyCount,
+      setNotReadyCount,
+      refreshNotReadyCount,
       fetchAllForLibrary,
       updateItem,
     ]

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -111,6 +111,35 @@ a.btn:focus,
   flex-wrap: wrap;
 }
 
+.not-ready-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: transparent;
+  font-weight: 600;
+}
+
+.not-ready-button .badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 32px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--border);
+  font-size: 13px;
+}
+
+.not-ready-button:enabled:hover,
+.not-ready-button:enabled:focus-visible {
+  border-color: var(--accent);
+  color: var(--accent);
+  outline: none;
+}
+
 .library-select {
   min-width: 200px;
 }
@@ -200,6 +229,69 @@ a.btn:focus,
   height: 40px;
   border-radius: 999px;
   font-size: 18px;
+}
+
+.not-ready-header {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  padding: 16px;
+  border-bottom: 1px solid var(--border);
+  flex-wrap: wrap;
+}
+
+.not-ready-heading {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.not-ready-heading h1 {
+  margin: 0;
+}
+
+.not-ready-heading p {
+  margin: 4px 0 0;
+  color: var(--muted);
+}
+
+.back-button {
+  border-radius: 999px;
+  padding: 6px 12px;
+  border: 1px solid var(--border);
+  background: transparent;
+  font-weight: 600;
+}
+
+.back-button:hover,
+.back-button:focus-visible {
+  border-color: var(--accent);
+  color: var(--accent);
+  outline: none;
+}
+
+.not-ready-meta {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-left: auto;
+  color: var(--muted);
+}
+
+.badge-label {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: var(--border);
+  font-weight: 600;
+  color: var(--fg);
+}
+
+.not-ready-pager {
+  justify-content: center;
+  margin: 16px;
 }
 
 main {

--- a/frontend/src/pages/LibraryPage.jsx
+++ b/frontend/src/pages/LibraryPage.jsx
@@ -1,10 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import FolderFinderModal from '../components/FolderFinderModal.jsx';
 import ImportStatusPanel from '../components/ImportStatusPanel.jsx';
 import ItemGrid from '../components/ItemGrid.jsx';
 import LibraryToolbar from '../components/LibraryToolbar.jsx';
-import { useLibraryItems } from '../hooks/useLibraryItems.js';
+import { useLibraryItemsContext } from '../hooks/LibraryItemsProvider.jsx';
 import { useTheme } from '../theme/ThemeProvider.jsx';
 import { responseErrorMessage, safeJson } from '../utils/api.js';
 import { isShowItem } from '../utils/items.js';
@@ -19,8 +19,9 @@ import {
 } from '../utils/importers.js';
 
 function LibraryPage() {
+  const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
-  const initialLibrary = searchParams.get('lib') || undefined;
+  const urlLibrary = searchParams.get('lib') || '';
   const {
     libraries,
     library,
@@ -37,7 +38,8 @@ function LibraryPage() {
     reload,
     fetchAllForLibrary,
     updateItem,
-  } = useLibraryItems({ initialLibrary });
+    notReadyCount,
+  } = useLibraryItemsContext();
 
   const { toggleTheme } = useTheme();
 
@@ -45,6 +47,13 @@ function LibraryPage() {
   const searchTimerRef = useRef();
 
   useEffect(() => setSearchInput(query || ''), [query]);
+
+  useEffect(() => {
+    if (!urlLibrary) return;
+    if (urlLibrary !== library) {
+      setLibrary(urlLibrary);
+    }
+  }, [urlLibrary, library, setLibrary]);
 
   useEffect(() => {
     if (!library) return;
@@ -69,6 +78,12 @@ function LibraryPage() {
   const handlePrev = useCallback(() => setPage(Math.max(1, page - 1)), [setPage, page]);
   const handleNext = useCallback(() => setPage(Math.min(totalPages || 1, page + 1)), [setPage, page, totalPages]);
   const handleLast = useCallback(() => setPage(totalPages || 1), [setPage, totalPages]);
+
+  const handleViewNotReady = useCallback(() => {
+    if (!library || !notReadyCount) return;
+    const encoded = encodeURIComponent(library);
+    navigate(`/libraries/${encoded}/not-ready`);
+  }, [library, notReadyCount, navigate]);
 
   const [importState, setImportState] = useState({ active: false, percent: 0, label: '', errors: [] });
   const hideTimerRef = useRef();
@@ -276,6 +291,9 @@ function LibraryPage() {
           onNext={handleNext}
           onLast={handleLast}
           countLabel={countLabel}
+          notReadyCount={notReadyCount}
+          onViewNotReady={handleViewNotReady}
+          notReadyDisabled={!library || notReadyCount <= 0}
         >
           <ImportStatusPanel
             active={importState.active}

--- a/frontend/src/pages/NotReadyPage.jsx
+++ b/frontend/src/pages/NotReadyPage.jsx
@@ -1,0 +1,199 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import FolderFinderModal from '../components/FolderFinderModal.jsx';
+import ItemGrid from '../components/ItemGrid.jsx';
+import { useLibraryItemsContext } from '../hooks/LibraryItemsProvider.jsx';
+import { useTheme } from '../theme/ThemeProvider.jsx';
+
+function NotReadyPage() {
+  const navigate = useNavigate();
+  const { library: libraryParam } = useParams();
+  const targetLibrary = libraryParam ? decodeURIComponent(libraryParam) : '';
+  const {
+    library,
+    setLibrary,
+    pageSize,
+    notReadyCount,
+    setNotReadyCount,
+    updateItem,
+  } = useLibraryItemsContext();
+  const { toggleTheme } = useTheme();
+
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [folderModalOpen, setFolderModalOpen] = useState(false);
+  const [folderModalItem, setFolderModalItem] = useState(null);
+
+  useEffect(() => {
+    if (!targetLibrary) return;
+    if (targetLibrary !== library) {
+      setLibrary(targetLibrary);
+    }
+  }, [targetLibrary, library, setLibrary]);
+
+  useEffect(() => {
+    setPage(1);
+  }, [targetLibrary]);
+
+  const backHref = useMemo(() => {
+    if (!targetLibrary) {
+      return '/libraries';
+    }
+    const search = new URLSearchParams();
+    search.set('lib', targetLibrary);
+    return `/libraries?${search.toString()}`;
+  }, [targetLibrary]);
+
+  const fetchItems = useCallback(
+    async (desiredPage = 1) => {
+      if (!targetLibrary) {
+        setItems([]);
+        setTotalPages(1);
+        setNotReadyCount(0);
+        return;
+      }
+      setLoading(true);
+      setError('');
+      const params = new URLSearchParams();
+      params.set('library', targetLibrary);
+      params.set('page', String(desiredPage));
+      params.set('page_size', String(pageSize));
+      params.set('not_ready_only', '1');
+      try {
+        const response = await fetch(`/api/items?${params.toString()}`);
+        const data = await response.json();
+        if (!response.ok) {
+          const message = data?.detail || data?.error || `${response.status} ${response.statusText}`;
+          throw new Error(message);
+        }
+        const list = Array.isArray(data?.items) ? data.items : [];
+        const reportedPage = data?.page || desiredPage;
+        const nextTotalPages = data?.total_pages || 1;
+        setTotalPages(nextTotalPages);
+        if (reportedPage !== desiredPage) {
+          setPage(reportedPage);
+        }
+        setItems(list);
+        const nextNotReady =
+          typeof data?.not_ready_count === 'number'
+            ? data.not_ready_count
+            : typeof data?.notReadyCount === 'number'
+            ? data.notReadyCount
+            : 0;
+        setNotReadyCount(nextNotReady);
+      } catch (err) {
+        setItems([]);
+        setError(err.message || 'Failed to load not-ready items');
+      } finally {
+        setLoading(false);
+      }
+    },
+    [targetLibrary, pageSize, setNotReadyCount]
+  );
+
+  useEffect(() => {
+    fetchItems(page);
+  }, [fetchItems, page]);
+
+  const handleFirst = useCallback(() => setPage(1), []);
+  const handlePrev = useCallback(() => setPage((prev) => Math.max(1, prev - 1)), []);
+  const handleNext = useCallback(() => setPage((prev) => Math.min(totalPages, prev + 1)), [totalPages]);
+  const handleLast = useCallback(() => setPage(totalPages || 1), [totalPages]);
+
+  const handleRequestFolder = useCallback((item) => {
+    setFolderModalItem(item);
+    setFolderModalOpen(true);
+  }, []);
+
+  const handleCloseFolderModal = useCallback(() => {
+    setFolderModalItem(null);
+    setFolderModalOpen(false);
+  }, []);
+
+  const handleFolderAssigned = useCallback(
+    async ({ folderName }) => {
+      if (!folderModalItem) return;
+      const ratingKey = folderModalItem?.ratingKey ?? folderModalItem?.key ?? folderModalItem?.id;
+      if (ratingKey != null) {
+        updateItem(String(ratingKey), { assetReady: true, folderName, folder: folderName });
+      }
+      handleCloseFolderModal();
+      await fetchItems(page);
+    },
+    [folderModalItem, updateItem, handleCloseFolderModal, fetchItems, page]
+  );
+
+  const notReadyLabel = useMemo(() => {
+    const count = Number(notReadyCount) || 0;
+    return `${count.toLocaleString()} not-ready item${count === 1 ? '' : 's'}`;
+  }, [notReadyCount]);
+
+  const pageLabel = useMemo(() => {
+    return `Page ${page} / ${totalPages || 1}`;
+  }, [page, totalPages]);
+
+  const handleBack = useCallback(() => {
+    navigate(backHref);
+  }, [navigate, backHref]);
+
+  return (
+    <div>
+      <header className="not-ready-header">
+        <div className="not-ready-heading">
+          <button type="button" className="back-button" onClick={handleBack}>
+            ← Back
+          </button>
+          <div>
+            <h1>Not Ready Items</h1>
+            <p>
+              {targetLibrary ? `Library: ${targetLibrary}` : 'Select a library to review not-ready items.'}
+            </p>
+          </div>
+        </div>
+        <div className="not-ready-meta">
+          <span className="badge-label">{notReadyLabel}</span>
+          <span>{pageLabel}</span>
+        </div>
+        <button type="button" className="theme-toggle" onClick={toggleTheme} title="Toggle theme">
+          🌓
+        </button>
+      </header>
+      <main>
+        <ItemGrid
+          items={items}
+          library={targetLibrary}
+          onRequestFolder={handleRequestFolder}
+          loading={loading}
+          error={error}
+        />
+        <nav className="pager not-ready-pager" aria-label="Pagination">
+          <button type="button" onClick={handleFirst} disabled={page <= 1}>
+            « First
+          </button>
+          <button type="button" onClick={handlePrev} disabled={page <= 1}>
+            ‹ Prev
+          </button>
+          <span aria-live="polite">{pageLabel}</span>
+          <button type="button" onClick={handleNext} disabled={page >= totalPages}>
+            Next ›
+          </button>
+          <button type="button" onClick={handleLast} disabled={page >= totalPages}>
+            Last »
+          </button>
+        </nav>
+      </main>
+      <FolderFinderModal
+        isOpen={folderModalOpen}
+        item={folderModalItem}
+        library={targetLibrary}
+        onClose={handleCloseFolderModal}
+        onFolderAssigned={handleFolderAssigned}
+      />
+    </div>
+  );
+}
+
+export default NotReadyPage;


### PR DESCRIPTION
## Summary
- add a not-ready filter to `/api/items` that reports the total count and supports a not-ready-only mode
- wrap the SPA in a shared library items provider and expose a new `/libraries/:library/not-ready` route
- build a not-ready page with inline folder assignment and expose the count badge/button in the main toolbar

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68e06c46b11083308e023e51a84d8c9a