### PR TITLE
Fix duplicate notReadyCount state references

### DIFF
--- a/frontend/src/hooks/useLibraryItems.js
+++ b/frontend/src/hooks/useLibraryItems.js
@@ -23,7 +23,6 @@ export function useLibraryItems({ initialLibrary } = {}) {
   const [notReadyOnly, setNotReadyOnlyState] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
-  const [notReadyCount, setNotReadyCount] = useState(0);
 
   const fetchAbort = useRef(null);
   const initialLibraryRef = useRef(initialLibrary);
@@ -272,7 +271,6 @@ export function useLibraryItems({ initialLibrary } = {}) {
       loading,
       error,
       reload,
-      notReadyCount,
       setNotReadyCount,
       refreshNotReadyCount,
       fetchAllForLibrary,
@@ -296,7 +294,6 @@ export function useLibraryItems({ initialLibrary } = {}) {
       loading,
       error,
       reload,
-      notReadyCount,
       setNotReadyCount,
       refreshNotReadyCount,
       fetchAllForLibrary,

--- a/frontend/src/pages/LibraryPage.jsx
+++ b/frontend/src/pages/LibraryPage.jsx
@@ -41,7 +41,6 @@ function LibraryPage() {
     reload,
     fetchAllForLibrary,
     updateItem,
-    notReadyCount,
   } = useLibraryItemsContext();
 
   const { toggleTheme } = useTheme();


### PR DESCRIPTION
## Summary
- remove the duplicate notReadyCount state declaration and memo entries in useLibraryItems
- adjust LibraryPage to destructure the notReadyCount value only once from the hook

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e06fe6bd9c8330a3dd6e270cfa8d22