### PR TITLE
Fix duplicate notReadyCount usage

### DIFF
--- a/frontend/src/hooks/useLibraryItems.js
+++ b/frontend/src/hooks/useLibraryItems.js
@@ -17,7 +17,6 @@ export function useLibraryItems({ initialLibrary } = {}) {
   const [page, setPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
   const [totalCount, setTotalCount] = useState(0);
-  const [notReadyCount, setNotReadyCount] = useState(0);
   const [items, setItems] = useState([]);
   const [query, setQuery] = useState('');
   const [notReadyOnly, setNotReadyOnlyState] = useState(false);

--- a/frontend/src/pages/LibraryPage.jsx
+++ b/frontend/src/pages/LibraryPage.jsx
@@ -41,7 +41,6 @@ function LibraryPage() {
     reload,
     fetchAllForLibrary,
     updateItem,
-    notReadyCount,
   } = useLibraryItemsContext();
 
   const { toggleTheme } = useTheme();


### PR DESCRIPTION
## Summary
- remove the duplicate notReadyCount entry from LibraryPage's context destructuring
- eliminate the redundant notReadyCount state declaration inside useLibraryItems

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e07091df388330bfee941acc0da9a2