### PR TITLE
Adjust Collections not-ready fetch endpoint

### DIFF
--- a/frontend/src/pages/NotReadyPage.jsx
+++ b/frontend/src/pages/NotReadyPage.jsx
@@ -58,12 +58,19 @@ function NotReadyPage() {
       setLoading(true);
       setError('');
       const params = new URLSearchParams();
-      params.set('library', targetLibrary);
+      const trimmedLibrary = targetLibrary.trim();
+      const isCollections = trimmedLibrary.toLowerCase() === 'collections';
       params.set('page', String(desiredPage));
       params.set('page_size', String(pageSize));
       params.set('not_ready_only', '1');
       try {
-        const response = await fetch(`/api/items?${params.toString()}`);
+        let endpoint = '/api/items';
+        if (isCollections) {
+          endpoint = '/collections';
+        } else {
+          params.set('library', trimmedLibrary);
+        }
+        const response = await fetch(`${endpoint}?${params.toString()}`);
         const data = await response.json();
         if (!response.ok) {
           const message = data?.detail || data?.error || `${response.status} ${response.statusText}`;


### PR DESCRIPTION
## Summary
- update NotReadyPage to call the collections endpoint when the selected library is Collections
- ensure pagination and not-ready filters persist for both collections and Plex libraries

## Testing
- pytest tests/test_collections_route.py::test_collections_route_reports_not_ready_count_and_filters

------
https://chatgpt.com/codex/tasks/task_e_68e0709860dc8330aa3425865b20d2b4