### PR TITLE
Add toolbar navigation for library not-ready items

### DIFF
--- a/frontend/src/components/LibraryToolbar.jsx
+++ b/frontend/src/components/LibraryToolbar.jsx
@@ -15,11 +15,14 @@ function LibraryToolbar({
   onLast,
   countLabel,
   notReadyControl,
+  onViewNotReady = null,
+  notReadyCount = 0,
+  notReadyDisabled = false,
   children,
 }) {
-  const showNotReadyButton = Boolean(onViewNotReady);
+  const showNotReadyButton = typeof onViewNotReady === 'function';
   const notReadyDisplay = Number(notReadyCount) || 0;
-  const disableNotReady = notReadyDisabled || notReadyDisplay <= 0;
+  const disableNotReady = Boolean(notReadyDisabled) || notReadyDisplay <= 0;
   const notReadyTitle = disableNotReady
     ? 'No not-ready items to review yet.'
     : 'Show only items missing asset folders.';

--- a/frontend/src/pages/LibraryPage.jsx
+++ b/frontend/src/pages/LibraryPage.jsx
@@ -41,7 +41,6 @@ function LibraryPage() {
     reload,
     fetchAllForLibrary,
     updateItem,
-    notReadyCount,
   } = useLibraryItemsContext();
 
   const { toggleTheme } = useTheme();
@@ -85,6 +84,13 @@ function LibraryPage() {
   const handleToggleNotReady = useCallback(() => {
     setNotReadyOnly((prev) => !prev);
   }, [setNotReadyOnly]);
+
+  const handleViewNotReady = useCallback(() => {
+    if (!library) return;
+    const lib = library.trim();
+    if (!lib) return;
+    navigate(`/libraries/${encodeURIComponent(lib)}/not-ready`);
+  }, [library, navigate]);
 
   const [importState, setImportState] = useState({ active: false, percent: 0, label: '', errors: [] });
   const hideTimerRef = useRef();
@@ -291,6 +297,8 @@ function LibraryPage() {
     );
   }, [library, notReadyCount, notReadyOnly, handleToggleNotReady]);
 
+  const notReadyButtonDisabled = !library || (Number(notReadyCount) || 0) <= 0;
+
   return (
     <div>
       <header>
@@ -312,6 +320,9 @@ function LibraryPage() {
           onLast={handleLast}
           countLabel={countLabel}
           notReadyControl={notReadyControl}
+          onViewNotReady={handleViewNotReady}
+          notReadyCount={notReadyCount}
+          notReadyDisabled={notReadyButtonDisabled}
         >
           <ImportStatusPanel
             active={importState.active}


### PR DESCRIPTION
## Summary
- add defaults and guard rendering for the not-ready button in the library toolbar
- wire the library page to navigate to the not-ready route and disable the button when appropriate

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e070a6ea7c8330a81e624045443444