### PR TITLE
Add missing notReadyCount state initialization

### DIFF
--- a/frontend/src/hooks/useLibraryItems.js
+++ b/frontend/src/hooks/useLibraryItems.js
@@ -17,6 +17,7 @@ export function useLibraryItems({ initialLibrary } = {}) {
   const [page, setPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
   const [totalCount, setTotalCount] = useState(0);
+  const [notReadyCount, setNotReadyCount] = useState(0);
   const [items, setItems] = useState([]);
   const [query, setQuery] = useState('');
   const [notReadyOnly, setNotReadyOnlyState] = useState(false);


### PR DESCRIPTION
## Summary
- initialize the `notReadyCount` state in the `useLibraryItems` hook so its consumers can access it safely

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e07459d3288330bfca36e107d844b0