### PR TITLE
Add settings API with persistent JSON storage

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -31,6 +31,7 @@ from .routers import (
     items,
     libraries,
     movie,
+    settings,
     tv,
     upload,
     ui,
@@ -42,6 +43,7 @@ app.include_router(collections.router)
 app.include_router(upload.router)
 app.include_router(tv.router)
 app.include_router(movie.router)
+app.include_router(settings.router)
 app.include_router(imports.router)
 app.include_router(fileproxy.router)
 app.include_router(assets.router)

--- a/app/routers/settings.py
+++ b/app/routers/settings.py
@@ -1,0 +1,26 @@
+"""Settings API endpoints."""
+from __future__ import annotations
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+from typing import Literal
+
+from ..services import settings as settings_service
+
+router = APIRouter()
+
+
+class SettingsPayload(BaseModel):
+    theme: Literal["light", "dark"]
+
+
+@router.get("/api/settings", response_model=SettingsPayload)
+def get_settings() -> SettingsPayload:
+    data = settings_service.load_settings()
+    return SettingsPayload(**data)
+
+
+@router.put("/api/settings", response_model=SettingsPayload)
+def update_settings(payload: SettingsPayload) -> SettingsPayload:
+    stored = settings_service.save_settings(payload.model_dump())
+    return SettingsPayload(**stored)

--- a/app/routers/ui.py
+++ b/app/routers/ui.py
@@ -21,3 +21,9 @@ async def show_details_page(library: str, ratingKey: str):
 async def not_ready_page(library: str):
     """Serve the SPA shell for the not-ready view."""
     return FileResponse(_SPA_INDEX)
+
+
+@router.get("/settings", include_in_schema=False)
+async def settings_page():
+    """Serve the SPA shell when navigating to /settings."""
+    return FileResponse(_SPA_INDEX)

--- a/app/services/settings.py
+++ b/app/services/settings.py
@@ -1,0 +1,90 @@
+"""Helpers for persisting simple UI settings."""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+from pathlib import Path
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_SETTINGS: Dict[str, Any] = {"theme": "dark"}
+
+_DEF_BASE = (
+    os.environ.get("KAM_STATE_ROOT")
+    or os.environ.get("KAM_CONFIG_ROOT")
+    or "/data"
+)
+_STORAGE_PATH = os.environ.get("KAM_SETTINGS_PATH") or os.path.join(
+    _DEF_BASE, "settings.json"
+)
+
+_LOCK = threading.Lock()
+
+
+def set_settings_path(path: str) -> None:
+    """Override the JSON persistence path (primarily for tests)."""
+    global _STORAGE_PATH
+    _STORAGE_PATH = path
+    logger.debug("Settings storage path set to %s", path)
+
+
+def _get_storage_path() -> Path:
+    return Path(_STORAGE_PATH)
+
+
+def load_settings() -> Dict[str, Any]:
+    """Return the stored settings merged with defaults."""
+    with _LOCK:
+        return _load_locked()
+
+
+def save_settings(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Persist settings and return the stored payload merged with defaults."""
+    with _LOCK:
+        merged = _merge_with_defaults(data)
+        _write_locked(merged)
+        return merged
+
+
+def _merge_with_defaults(data: Dict[str, Any] | None) -> Dict[str, Any]:
+    merged = dict(_DEFAULT_SETTINGS)
+    if data:
+        for key, value in data.items():
+            merged[key] = value
+    return merged
+
+
+def _load_locked() -> Dict[str, Any]:
+    path = _get_storage_path()
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return dict(_DEFAULT_SETTINGS)
+    except Exception as exc:
+        logger.warning("Unable to read settings file %s: %s", path, exc)
+        return dict(_DEFAULT_SETTINGS)
+
+    try:
+        data = json.loads(raw) or {}
+    except Exception as exc:
+        logger.warning("Invalid JSON in settings file %s: %s", path, exc)
+        data = {}
+
+    return _merge_with_defaults(data if isinstance(data, dict) else {})
+
+
+def _write_locked(data: Dict[str, Any]) -> None:
+    path = _get_storage_path()
+    parent = path.parent
+    try:
+        parent.mkdir(parents=True, exist_ok=True)
+    except Exception as exc:
+        logger.warning("Unable to create settings parent %s: %s", parent, exc)
+    tmp_path = path.with_suffix(".tmp")
+    tmp_path.write_text(
+        json.dumps(data, indent=2, sort_keys=True), encoding="utf-8"
+    )
+    tmp_path.replace(path)

--- a/tests/test_settings_route.py
+++ b/tests/test_settings_route.py
@@ -1,0 +1,51 @@
+import importlib
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+@pytest.fixture
+def settings_modules(tmp_path, monkeypatch):
+    settings_path = tmp_path / "state" / "settings.json"
+    monkeypatch.setenv("KAM_SETTINGS_PATH", str(settings_path))
+
+    settings_service = importlib.reload(importlib.import_module("app.services.settings"))
+    settings_router = importlib.reload(importlib.import_module("app.routers.settings"))
+
+    return settings_router, settings_service, settings_path
+
+
+def test_get_settings_returns_defaults(settings_modules):
+    router, _, _ = settings_modules
+
+    resp = router.get_settings()
+    assert resp.model_dump() == {"theme": "dark"}
+
+
+def test_put_settings_updates_file(settings_modules):
+    router, service, path = settings_modules
+
+    payload = router.SettingsPayload(theme="light")
+    resp = router.update_settings(payload)
+    assert resp.model_dump() == {"theme": "light"}
+
+    stored = json.loads(path.read_text(encoding="utf-8"))
+    assert stored == {"theme": "light"}
+
+    # Ensure the service merges persisted values with defaults
+    assert service.load_settings() == {"theme": "light"}
+
+
+def test_put_settings_rejects_invalid_theme(settings_modules):
+    router, _, _ = settings_modules
+
+    with pytest.raises(ValidationError):
+        router.SettingsPayload(theme="blue")


### PR DESCRIPTION
## Summary
- add a settings persistence service that reads/writes JSON with defaults
- expose /api/settings endpoints and serve the SPA shell at /settings
- cover default load, updates, and validation failures with unit tests

## Testing
- pytest tests/test_settings_route.py

------
https://chatgpt.com/codex/tasks/task_e_68e106a464b8833086b486e402566919