### PR TITLE
Add settings page and persistent theme management

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
 import LibraryPage from './pages/LibraryPage.jsx';
 import MovieDetailPage from './pages/MovieDetailPage.jsx';
 import NotReadyPage from './pages/NotReadyPage.jsx';
+import SettingsPage from './pages/SettingsPage.jsx';
 import ShowDetailPage from './pages/ShowDetailPage.jsx';
 import { LibraryItemsProvider } from './hooks/LibraryItemsProvider.jsx';
 import { ThemeProvider } from './theme/ThemeProvider.jsx';
@@ -16,6 +17,7 @@ function App() {
             <Route path="/libraries" element={<LibraryPage />} />
             <Route path="/libraries/:library/not-ready" element={<NotReadyPage />} />
             <Route path="/libraries/*" element={<LibraryPage />} />
+            <Route path="/settings" element={<SettingsPage />} />
           </Routes>
         </LibraryItemsProvider>
       </BrowserRouter>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -220,7 +220,7 @@ a.btn:focus,
   color: #ffb4b4;
 }
 
-.theme-toggle {
+.settings-link {
   margin-left: auto;
   display: inline-flex;
   align-items: center;
@@ -228,7 +228,23 @@ a.btn:focus,
   width: 40px;
   height: 40px;
   border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--card);
+  color: var(--fg);
+  text-decoration: none;
   font-size: 18px;
+  transition: border-color 0.2s ease, color 0.2s ease, background 0.2s ease;
+}
+
+.settings-link:hover,
+.settings-link:focus-visible {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.settings-link:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 .not-ready-header {
@@ -699,6 +715,98 @@ main {
     flex-direction: row;
     align-items: center;
   }
+}
+
+.settings-page {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 24px 16px 48px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.settings-card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.settings-card h2 {
+  margin: 0;
+  font-size: 20px;
+}
+
+.settings-description {
+  margin: 0;
+  color: var(--muted);
+  font-size: 15px;
+}
+
+.settings-form fieldset {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.settings-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.settings-radio {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.02);
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.settings-radio input[type='radio'] {
+  margin: 0;
+}
+
+.settings-form fieldset[disabled] .settings-radio {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.settings-radio:focus-within {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.settings-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.settings-status {
+  font-size: 14px;
+  border-radius: 12px;
+  padding: 12px 16px;
+}
+
+.settings-status.success {
+  background: rgba(34, 197, 94, 0.1);
+  color: #6ee7b7;
+}
+
+.settings-status.error {
+  background: rgba(248, 113, 113, 0.1);
+  color: #fca5a5;
 }
 
 .asset-actions input[type='file'] {

--- a/frontend/src/pages/LibraryPage.jsx
+++ b/frontend/src/pages/LibraryPage.jsx
@@ -1,11 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import FolderFinderModal from '../components/FolderFinderModal.jsx';
 import ImportStatusPanel from '../components/ImportStatusPanel.jsx';
 import ItemGrid from '../components/ItemGrid.jsx';
 import LibraryToolbar from '../components/LibraryToolbar.jsx';
 import { useLibraryItemsContext } from '../hooks/LibraryItemsProvider.jsx';
-import { useTheme } from '../theme/ThemeProvider.jsx';
 import { responseErrorMessage, safeJson } from '../utils/api.js';
 import { isShowItem } from '../utils/items.js';
 import {
@@ -43,7 +42,6 @@ function LibraryPage() {
     updateItem,
   } = useLibraryItemsContext();
 
-  const { toggleTheme } = useTheme();
 
   const [searchInput, setSearchInput] = useState(query || '');
   const searchTimerRef = useRef();
@@ -331,9 +329,9 @@ function LibraryPage() {
             errors={importState.errors}
           />
         </LibraryToolbar>
-        <button type="button" className="theme-toggle" onClick={toggleTheme} title="Toggle theme">
-          🌓
-        </button>
+        <Link className="settings-link" to="/settings" aria-label="Open settings">
+          <span aria-hidden="true">⚙</span>
+        </Link>
       </header>
       <main>
         <ItemGrid

--- a/frontend/src/pages/MovieDetailPage.jsx
+++ b/frontend/src/pages/MovieDetailPage.jsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link, useParams, useSearchParams } from 'react-router-dom';
 import ArtworkCard from '../components/ArtworkCard.jsx';
 import { responseErrorMessage, safeJson } from '../utils/api.js';
-import { useTheme } from '../theme/ThemeProvider.jsx';
 
 const MISSING_FOLDER_MESSAGE = 'Create the Kometa asset folder first.';
 
@@ -24,7 +23,6 @@ function MovieDetailPage() {
   const library = rawLibrary ? String(rawLibrary) : '';
   const ratingKey = rawRatingKey ? String(rawRatingKey) : '';
 
-  const { toggleTheme } = useTheme();
 
   const [detail, setDetail] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -250,9 +248,9 @@ function MovieDetailPage() {
         <h1>{headerTitle}</h1>
         {headerYear ? <span className="detail-year">({headerYear})</span> : null}
         <span className="detail-header-gap" aria-hidden="true" />
-        <button type="button" className="theme-toggle" onClick={toggleTheme} title="Toggle theme">
-          🌓
-        </button>
+        <Link className="settings-link" to="/settings" aria-label="Open settings">
+          <span aria-hidden="true">⚙</span>
+        </Link>
       </header>
       <main className="detail-main">
         {loading ? (

--- a/frontend/src/pages/NotReadyPage.jsx
+++ b/frontend/src/pages/NotReadyPage.jsx
@@ -1,9 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router-dom';
 import FolderFinderModal from '../components/FolderFinderModal.jsx';
 import ItemGrid from '../components/ItemGrid.jsx';
 import { useLibraryItemsContext } from '../hooks/LibraryItemsProvider.jsx';
-import { useTheme } from '../theme/ThemeProvider.jsx';
 
 function NotReadyPage() {
   const navigate = useNavigate();
@@ -17,7 +16,6 @@ function NotReadyPage() {
     setNotReadyCount,
     updateItem,
   } = useLibraryItemsContext();
-  const { toggleTheme } = useTheme();
 
   const [page, setPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
@@ -164,9 +162,9 @@ function NotReadyPage() {
           <span className="badge-label">{notReadyLabel}</span>
           <span>{pageLabel}</span>
         </div>
-        <button type="button" className="theme-toggle" onClick={toggleTheme} title="Toggle theme">
-          🌓
-        </button>
+        <Link className="settings-link" to="/settings" aria-label="Open settings">
+          <span aria-hidden="true">⚙</span>
+        </Link>
       </header>
       <main>
         <ItemGrid

--- a/frontend/src/pages/SettingsPage.jsx
+++ b/frontend/src/pages/SettingsPage.jsx
@@ -1,0 +1,110 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useTheme } from '../theme/ThemeProvider.jsx';
+
+function SettingsPage() {
+  const { theme, savedTheme, loading, error, applyTheme, saveTheme, revertTheme } = useTheme();
+  const [selectedTheme, setSelectedTheme] = useState(theme);
+  const [status, setStatus] = useState(null);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    setSelectedTheme(theme);
+  }, [theme]);
+
+  useEffect(() => {
+    if (error) {
+      setStatus({ type: 'error', message: error });
+    }
+  }, [error]);
+
+  const busy = loading || saving;
+  const isDirty = useMemo(() => selectedTheme !== savedTheme, [selectedTheme, savedTheme]);
+
+  const handleThemeChange = (event) => {
+    const next = event.target.value;
+    setSelectedTheme(next);
+    applyTheme(next);
+    setStatus(null);
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    if (!isDirty) {
+      setStatus({ type: 'success', message: 'Theme is already up to date.' });
+      return;
+    }
+    setSaving(true);
+    setStatus(null);
+    try {
+      await saveTheme(selectedTheme);
+      setStatus({ type: 'success', message: 'Theme preference saved.' });
+    } catch (err) {
+      const message = err?.message || 'Failed to save theme preference.';
+      revertTheme();
+      setStatus({ type: 'error', message });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div>
+      <header>
+        <Link className="btn" to="/libraries">
+          ← Back
+        </Link>
+        <h1>Settings</h1>
+      </header>
+      <main className="settings-page">
+        <section className="settings-card">
+          <h2>Theme</h2>
+          <p className="settings-description">
+            Choose how KAM looks. Changes are previewed immediately and applied once saved.
+          </p>
+          <form onSubmit={handleSubmit} className="settings-form">
+            <fieldset disabled={busy}>
+              <legend className="sr-only">Theme preference</legend>
+              <label className="settings-radio">
+                <input
+                  type="radio"
+                  name="theme"
+                  value="dark"
+                  checked={selectedTheme === 'dark'}
+                  onChange={handleThemeChange}
+                />
+                <span>Dark</span>
+              </label>
+              <label className="settings-radio">
+                <input
+                  type="radio"
+                  name="theme"
+                  value="light"
+                  checked={selectedTheme === 'light'}
+                  onChange={handleThemeChange}
+                />
+                <span>Light</span>
+              </label>
+            </fieldset>
+            <div className="settings-actions">
+              <button type="submit" className="btn" disabled={busy || !isDirty}>
+                Save Changes
+              </button>
+            </div>
+          </form>
+          {status ? (
+            <div
+              className={`settings-status ${status.type}`}
+              role={status.type === 'error' ? 'alert' : 'status'}
+              aria-live="polite"
+            >
+              {status.message}
+            </div>
+          ) : null}
+        </section>
+      </main>
+    </div>
+  );
+}
+
+export default SettingsPage;

--- a/frontend/src/pages/ShowDetailPage.jsx
+++ b/frontend/src/pages/ShowDetailPage.jsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link, useParams, useSearchParams } from 'react-router-dom';
 import ArtworkCard from '../components/ArtworkCard.jsx';
 import { responseErrorMessage, safeJson } from '../utils/api.js';
-import { useTheme } from '../theme/ThemeProvider.jsx';
 
 const MISSING_FOLDER_MESSAGE = 'Create the Kometa asset folder first.';
 
@@ -23,8 +22,6 @@ function ShowDetailPage() {
   const rawRatingKey = params.ratingKey ?? searchParams.get('ratingKey') ?? searchParams.get('id') ?? '';
   const library = rawLibrary ? String(rawLibrary) : '';
   const ratingKey = rawRatingKey ? String(rawRatingKey) : '';
-
-  const { toggleTheme } = useTheme();
 
   const [detail, setDetail] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -420,9 +417,9 @@ function ShowDetailPage() {
         <h1>{headerTitle}</h1>
         {headerYear ? <span className="detail-year">({headerYear})</span> : null}
         <span className="detail-header-gap" aria-hidden="true" />
-        <button type="button" className="theme-toggle" onClick={toggleTheme} title="Toggle theme">
-          🌓
-        </button>
+        <Link className="settings-link" to="/settings" aria-label="Open settings">
+          <span aria-hidden="true">⚙</span>
+        </Link>
       </header>
       <main className="detail-main">
         {loading ? (

--- a/frontend/src/theme/ThemeProvider.jsx
+++ b/frontend/src/theme/ThemeProvider.jsx
@@ -1,32 +1,131 @@
-import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { responseErrorMessage, safeJson } from '../utils/api.js';
 
 const ThemeContext = createContext({
   theme: 'dark',
-  toggleTheme: () => {},
+  savedTheme: 'dark',
+  loading: false,
+  error: null,
+  applyTheme: () => {},
+  saveTheme: async () => 'dark',
+  refreshTheme: async () => 'dark',
+  revertTheme: () => {},
 });
 
-const STORAGE_KEY = 'kam-theme';
+const normalizeTheme = (value) => (value === 'light' ? 'light' : 'dark');
 
 export function ThemeProvider({ children }) {
-  const [theme, setTheme] = useState(() => {
-    if (typeof window === 'undefined') return 'dark';
-    const saved = window.localStorage.getItem(STORAGE_KEY);
-    return saved || 'dark';
-  });
+  const [theme, setTheme] = useState('dark');
+  const [savedTheme, setSavedTheme] = useState('dark');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
 
   useEffect(() => {
     if (typeof document === 'undefined') return;
-    document.documentElement.setAttribute('data-theme', theme);
-    if (typeof window !== 'undefined') {
-      window.localStorage.setItem(STORAGE_KEY, theme);
-    }
+    document.documentElement.setAttribute('data-theme', normalizeTheme(theme));
   }, [theme]);
 
-  const toggleTheme = useCallback(() => {
-    setTheme((prev) => (prev === 'dark' ? 'light' : 'dark'));
+  const applyTheme = useCallback((value) => {
+    setTheme(normalizeTheme(value));
   }, []);
 
-  const value = useMemo(() => ({ theme, toggleTheme }), [theme, toggleTheme]);
+  const refreshTheme = useCallback(async () => {
+    if (isMountedRef.current) {
+      setLoading(true);
+      setError(null);
+    }
+    try {
+      const response = await fetch('/api/settings');
+      const data = await safeJson(response);
+      if (!response.ok) {
+        throw new Error(responseErrorMessage(response, data));
+      }
+      const nextTheme = normalizeTheme(data?.theme);
+      if (isMountedRef.current) {
+        setSavedTheme(nextTheme);
+        setTheme(nextTheme);
+      }
+      return nextTheme;
+    } catch (err) {
+      const message = err?.message || 'Failed to load settings';
+      if (isMountedRef.current) {
+        setError(message);
+      }
+      throw new Error(message);
+    } finally {
+      if (isMountedRef.current) {
+        setLoading(false);
+      }
+    }
+  }, []);
+
+  const saveTheme = useCallback(
+    async (value) => {
+      const nextTheme = normalizeTheme(value);
+      if (isMountedRef.current) {
+        setLoading(true);
+        setError(null);
+      }
+      try {
+        const response = await fetch('/api/settings', {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ theme: nextTheme }),
+        });
+        const data = await safeJson(response);
+        if (!response.ok) {
+          throw new Error(responseErrorMessage(response, data));
+        }
+        if (isMountedRef.current) {
+          setSavedTheme(nextTheme);
+          setTheme(nextTheme);
+        }
+        return nextTheme;
+      } catch (err) {
+        const message = err?.message || 'Failed to save settings';
+        if (isMountedRef.current) {
+          setError(message);
+        }
+        throw new Error(message);
+      } finally {
+        if (isMountedRef.current) {
+          setLoading(false);
+        }
+      }
+    },
+    []
+  );
+
+  useEffect(() => {
+    refreshTheme().catch(() => {});
+  }, [refreshTheme]);
+
+  const revertTheme = useCallback(() => {
+    if (!isMountedRef.current) return;
+    setTheme(normalizeTheme(savedTheme));
+  }, [savedTheme]);
+
+  const value = useMemo(
+    () => ({
+      theme,
+      savedTheme,
+      loading,
+      error,
+      applyTheme,
+      saveTheme,
+      refreshTheme,
+      revertTheme,
+    }),
+    [theme, savedTheme, loading, error, applyTheme, saveTheme, refreshTheme, revertTheme]
+  );
 
   return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
 }


### PR DESCRIPTION
## Summary
- add a Settings page with theme radios that preview changes and report save status
- update the theme provider to load and persist `/api/settings` data while exposing apply/save helpers
- replace individual theme toggle buttons with a settings link, plus supporting route and styles

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e106a57ff8833087742aca19036bb8