### PR TITLE
Prevent duplicate library sync

### DIFF
--- a/frontend/src/pages/LibraryPage.jsx
+++ b/frontend/src/pages/LibraryPage.jsx
@@ -21,6 +21,7 @@ function LibraryPage() {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const urlLibrary = searchParams.get('lib') || '';
+  const lastUrlLibraryRef = useRef(urlLibrary);
   const {
     libraries,
     library,
@@ -50,6 +51,10 @@ function LibraryPage() {
 
   useEffect(() => {
     if (!urlLibrary) return;
+    if (lastUrlLibraryRef.current === urlLibrary) return;
+
+    lastUrlLibraryRef.current = urlLibrary;
+
     if (urlLibrary !== library) {
       setLibrary(urlLibrary);
     }


### PR DESCRIPTION
## Summary
- cache the last library query parameter processed in LibraryPage
- avoid resyncing the library state when the URL parameter has not changed

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e10b492b2483309a7a457281928afe