### PR TITLE
Add Plex URL/token settings to API and UI

### DIFF
--- a/app/routers/settings.py
+++ b/app/routers/settings.py
@@ -2,8 +2,9 @@
 from __future__ import annotations
 
 from fastapi import APIRouter
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 from typing import Literal
+from urllib.parse import urlparse
 
 from ..services import settings as settings_service
 
@@ -11,7 +12,35 @@ router = APIRouter()
 
 
 class SettingsPayload(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
     theme: Literal["light", "dark"]
+    plexUrl: str = Field(default="")
+    plexToken: str = Field(default="")
+
+    @field_validator("plexUrl", mode="before")
+    @classmethod
+    def _validate_plex_url(cls, value: str | None) -> str:
+        if value in (None, ""):
+            return ""
+        if not isinstance(value, str):
+            value = str(value)
+        stripped = value.strip()
+        if not stripped:
+            return ""
+        parsed = urlparse(stripped)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise ValueError("Invalid Plex URL")
+        return stripped
+
+    @field_validator("plexToken", mode="before")
+    @classmethod
+    def _validate_plex_token(cls, value: str | None) -> str:
+        if value in (None, ""):
+            return ""
+        if not isinstance(value, str):
+            value = str(value)
+        return value.strip()
 
 
 @router.get("/api/settings", response_model=SettingsPayload)

--- a/app/services/settings.py
+++ b/app/services/settings.py
@@ -10,7 +10,11 @@ from typing import Any, Dict
 
 logger = logging.getLogger(__name__)
 
-_DEFAULT_SETTINGS: Dict[str, Any] = {"theme": "dark"}
+_DEFAULT_SETTINGS: Dict[str, Any] = {
+    "theme": "dark",
+    "plexUrl": os.environ.get("PLEX_URL") or "",
+    "plexToken": os.environ.get("PLEX_TOKEN") or "",
+}
 
 _DEF_BASE = (
     os.environ.get("KAM_STATE_ROOT")

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -762,6 +762,34 @@ main {
   gap: 16px;
 }
 
+.settings-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border);
+}
+
+.settings-section h3 {
+  margin: 0;
+  font-size: 16px;
+}
+
+.settings-input {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.settings-input span {
+  font-weight: 600;
+  font-size: 14px;
+}
+
+.settings-input input {
+  width: 100%;
+}
+
 .settings-radio {
   display: inline-flex;
   align-items: center;

--- a/frontend/src/pages/SettingsPage.jsx
+++ b/frontend/src/pages/SettingsPage.jsx
@@ -3,14 +3,23 @@ import { Link } from 'react-router-dom';
 import { useTheme } from '../theme/ThemeProvider.jsx';
 
 function SettingsPage() {
-  const { theme, savedTheme, loading, error, applyTheme, saveTheme, revertTheme } = useTheme();
-  const [selectedTheme, setSelectedTheme] = useState(theme);
+  const {
+    theme,
+    savedTheme,
+    plexUrl,
+    plexToken,
+    savedSettings,
+    loading,
+    saving,
+    error,
+    applyTheme,
+    updateSettings,
+    saveSettings,
+    revertSettings,
+  } = useTheme();
   const [status, setStatus] = useState(null);
-  const [saving, setSaving] = useState(false);
-
-  useEffect(() => {
-    setSelectedTheme(theme);
-  }, [theme]);
+  const savedPlexUrl = savedSettings?.plexUrl || '';
+  const savedPlexToken = savedSettings?.plexToken || '';
 
   useEffect(() => {
     if (error) {
@@ -19,32 +28,42 @@ function SettingsPage() {
   }, [error]);
 
   const busy = loading || saving;
-  const isDirty = useMemo(() => selectedTheme !== savedTheme, [selectedTheme, savedTheme]);
+  const isDirty = useMemo(() => {
+    return (
+      theme !== savedTheme || plexUrl !== savedPlexUrl || plexToken !== savedPlexToken
+    );
+  }, [theme, savedTheme, plexUrl, savedPlexUrl, plexToken, savedPlexToken]);
 
   const handleThemeChange = (event) => {
     const next = event.target.value;
-    setSelectedTheme(next);
     applyTheme(next);
+    setStatus(null);
+  };
+
+  const handlePlexUrlChange = (event) => {
+    updateSettings({ plexUrl: event.target.value });
+    setStatus(null);
+  };
+
+  const handlePlexTokenChange = (event) => {
+    updateSettings({ plexToken: event.target.value });
     setStatus(null);
   };
 
   const handleSubmit = async (event) => {
     event.preventDefault();
     if (!isDirty) {
-      setStatus({ type: 'success', message: 'Theme is already up to date.' });
+      setStatus({ type: 'success', message: 'Settings are already up to date.' });
       return;
     }
-    setSaving(true);
     setStatus(null);
     try {
-      await saveTheme(selectedTheme);
-      setStatus({ type: 'success', message: 'Theme preference saved.' });
+      await saveSettings();
+      setStatus({ type: 'success', message: 'Settings saved successfully.' });
     } catch (err) {
-      const message = err?.message || 'Failed to save theme preference.';
-      revertTheme();
+      const message = err?.message || 'Failed to save settings.';
+      revertSettings();
       setStatus({ type: 'error', message });
-    } finally {
-      setSaving(false);
     }
   };
 
@@ -70,7 +89,7 @@ function SettingsPage() {
                   type="radio"
                   name="theme"
                   value="dark"
-                  checked={selectedTheme === 'dark'}
+                  checked={theme === 'dark'}
                   onChange={handleThemeChange}
                 />
                 <span>Dark</span>
@@ -80,12 +99,42 @@ function SettingsPage() {
                   type="radio"
                   name="theme"
                   value="light"
-                  checked={selectedTheme === 'light'}
+                  checked={theme === 'light'}
                   onChange={handleThemeChange}
                 />
                 <span>Light</span>
               </label>
             </fieldset>
+            <div className="settings-section">
+              <h3>Plex</h3>
+              <p className="settings-description">
+                Provide your Plex URL and token to enable Plex integrations in KAM.
+              </p>
+              <label className="settings-input">
+                <span>Plex URL</span>
+                <input
+                  type="url"
+                  name="plexUrl"
+                  value={plexUrl}
+                  onChange={handlePlexUrlChange}
+                  placeholder="http://plex.local:32400"
+                  autoComplete="off"
+                  disabled={busy}
+                />
+              </label>
+              <label className="settings-input">
+                <span>Plex Token (sensitive)</span>
+                <input
+                  type="password"
+                  name="plexToken"
+                  value={plexToken}
+                  onChange={handlePlexTokenChange}
+                  placeholder="Enter your Plex token"
+                  autoComplete="new-password"
+                  disabled={busy}
+                />
+              </label>
+            </div>
             <div className="settings-actions">
               <button type="submit" className="btn" disabled={busy || !isDirty}>
                 Save Changes

--- a/frontend/src/theme/ThemeProvider.jsx
+++ b/frontend/src/theme/ThemeProvider.jsx
@@ -2,11 +2,22 @@ import { createContext, useCallback, useContext, useEffect, useMemo, useRef, use
 import { responseErrorMessage, safeJson } from '../utils/api.js';
 
 const ThemeContext = createContext({
+  settings: { theme: 'dark', plexUrl: '', plexToken: '' },
+  savedSettings: { theme: 'dark', plexUrl: '', plexToken: '' },
   theme: 'dark',
   savedTheme: 'dark',
+  plexUrl: '',
+  plexToken: '',
+  savedPlexUrl: '',
+  savedPlexToken: '',
   loading: false,
+  saving: false,
   error: null,
   applyTheme: () => {},
+  updateSettings: () => {},
+  saveSettings: async () => ({ theme: 'dark', plexUrl: '', plexToken: '' }),
+  refreshSettings: async () => ({ theme: 'dark', plexUrl: '', plexToken: '' }),
+  revertSettings: () => {},
   saveTheme: async () => 'dark',
   refreshTheme: async () => 'dark',
   revertTheme: () => {},
@@ -14,10 +25,33 @@ const ThemeContext = createContext({
 
 const normalizeTheme = (value) => (value === 'light' ? 'light' : 'dark');
 
+const sanitizeSettings = (raw = {}) => {
+  const themeValue = normalizeTheme(raw.theme);
+  const plexUrlValue = raw.plexUrl;
+  const plexTokenValue = raw.plexToken;
+
+  return {
+    theme: themeValue,
+    plexUrl:
+      typeof plexUrlValue === 'string'
+        ? plexUrlValue.trim()
+        : plexUrlValue
+        ? String(plexUrlValue)
+        : '',
+    plexToken:
+      typeof plexTokenValue === 'string'
+        ? plexTokenValue.trim()
+        : plexTokenValue
+        ? String(plexTokenValue)
+        : '',
+  };
+};
+
 export function ThemeProvider({ children }) {
-  const [theme, setTheme] = useState('dark');
-  const [savedTheme, setSavedTheme] = useState('dark');
+  const [settings, setSettings] = useState(() => sanitizeSettings());
+  const [savedSettings, setSavedSettings] = useState(() => sanitizeSettings());
   const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
   const [error, setError] = useState(null);
   const isMountedRef = useRef(true);
 
@@ -30,14 +64,19 @@ export function ThemeProvider({ children }) {
 
   useEffect(() => {
     if (typeof document === 'undefined') return;
-    document.documentElement.setAttribute('data-theme', normalizeTheme(theme));
-  }, [theme]);
+    document.documentElement.setAttribute('data-theme', normalizeTheme(settings.theme));
+  }, [settings.theme]);
 
-  const applyTheme = useCallback((value) => {
-    setTheme(normalizeTheme(value));
+  const updateSettings = useCallback((updates) => {
+    if (!isMountedRef.current) return;
+    setSettings((prev) => sanitizeSettings({ ...prev, ...updates }));
   }, []);
 
-  const refreshTheme = useCallback(async () => {
+  const applyTheme = useCallback((value) => {
+    updateSettings({ theme: value });
+  }, [updateSettings]);
+
+  const refreshSettings = useCallback(async () => {
     if (isMountedRef.current) {
       setLoading(true);
       setError(null);
@@ -48,12 +87,12 @@ export function ThemeProvider({ children }) {
       if (!response.ok) {
         throw new Error(responseErrorMessage(response, data));
       }
-      const nextTheme = normalizeTheme(data?.theme);
+      const next = sanitizeSettings(data);
       if (isMountedRef.current) {
-        setSavedTheme(nextTheme);
-        setTheme(nextTheme);
+        setSavedSettings(next);
+        setSettings(next);
       }
-      return nextTheme;
+      return next;
     } catch (err) {
       const message = err?.message || 'Failed to load settings';
       if (isMountedRef.current) {
@@ -67,28 +106,29 @@ export function ThemeProvider({ children }) {
     }
   }, []);
 
-  const saveTheme = useCallback(
-    async (value) => {
-      const nextTheme = normalizeTheme(value);
+  const saveSettings = useCallback(
+    async (overrides = null) => {
+      const payload = sanitizeSettings({ ...settings, ...(overrides ?? {}) });
       if (isMountedRef.current) {
-        setLoading(true);
+        setSaving(true);
         setError(null);
       }
       try {
         const response = await fetch('/api/settings', {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ theme: nextTheme }),
+          body: JSON.stringify(payload),
         });
         const data = await safeJson(response);
         if (!response.ok) {
           throw new Error(responseErrorMessage(response, data));
         }
+        const next = sanitizeSettings(data);
         if (isMountedRef.current) {
-          setSavedTheme(nextTheme);
-          setTheme(nextTheme);
+          setSavedSettings(next);
+          setSettings(next);
         }
-        return nextTheme;
+        return next;
       } catch (err) {
         const message = err?.message || 'Failed to save settings';
         if (isMountedRef.current) {
@@ -97,34 +137,76 @@ export function ThemeProvider({ children }) {
         throw new Error(message);
       } finally {
         if (isMountedRef.current) {
-          setLoading(false);
+          setSaving(false);
         }
       }
     },
-    []
+    [settings]
   );
 
   useEffect(() => {
-    refreshTheme().catch(() => {});
-  }, [refreshTheme]);
+    refreshSettings().catch(() => {});
+  }, [refreshSettings]);
+
+  const revertSettings = useCallback(() => {
+    if (!isMountedRef.current) return;
+    setSettings(sanitizeSettings(savedSettings));
+  }, [savedSettings]);
+
+  const saveTheme = useCallback(
+    async (value) => {
+      const result = await saveSettings({ theme: value });
+      return result.theme;
+    },
+    [saveSettings]
+  );
+
+  const refreshTheme = useCallback(async () => {
+    const result = await refreshSettings();
+    return result.theme;
+  }, [refreshSettings]);
 
   const revertTheme = useCallback(() => {
-    if (!isMountedRef.current) return;
-    setTheme(normalizeTheme(savedTheme));
-  }, [savedTheme]);
+    revertSettings();
+  }, [revertSettings]);
 
   const value = useMemo(
     () => ({
-      theme,
-      savedTheme,
+      settings,
+      savedSettings,
+      theme: settings.theme,
+      savedTheme: savedSettings.theme,
+      plexUrl: settings.plexUrl,
+      plexToken: settings.plexToken,
+      savedPlexUrl: savedSettings.plexUrl,
+      savedPlexToken: savedSettings.plexToken,
       loading,
+      saving,
       error,
       applyTheme,
+      updateSettings,
+      saveSettings,
+      refreshSettings,
+      revertSettings,
       saveTheme,
       refreshTheme,
       revertTheme,
     }),
-    [theme, savedTheme, loading, error, applyTheme, saveTheme, refreshTheme, revertTheme]
+    [
+      settings,
+      savedSettings,
+      loading,
+      saving,
+      error,
+      applyTheme,
+      updateSettings,
+      saveSettings,
+      refreshSettings,
+      revertSettings,
+      saveTheme,
+      refreshTheme,
+      revertTheme,
+    ]
   );
 
   return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;

--- a/tests/test_settings_route.py
+++ b/tests/test_settings_route.py
@@ -16,6 +16,8 @@ if str(ROOT) not in sys.path:
 def settings_modules(tmp_path, monkeypatch):
     settings_path = tmp_path / "state" / "settings.json"
     monkeypatch.setenv("KAM_SETTINGS_PATH", str(settings_path))
+    monkeypatch.setenv("PLEX_URL", "http://plex.example:32400")
+    monkeypatch.setenv("PLEX_TOKEN", "initial-token")
 
     settings_service = importlib.reload(importlib.import_module("app.services.settings"))
     settings_router = importlib.reload(importlib.import_module("app.routers.settings"))
@@ -27,21 +29,41 @@ def test_get_settings_returns_defaults(settings_modules):
     router, _, _ = settings_modules
 
     resp = router.get_settings()
-    assert resp.model_dump() == {"theme": "dark"}
+    assert resp.model_dump() == {
+        "theme": "dark",
+        "plexUrl": "http://plex.example:32400",
+        "plexToken": "initial-token",
+    }
 
 
 def test_put_settings_updates_file(settings_modules):
     router, service, path = settings_modules
 
-    payload = router.SettingsPayload(theme="light")
+    payload = router.SettingsPayload(
+        theme="light",
+        plexUrl="http://plex.changed",  # domain only is fine for HttpUrl
+        plexToken="  updated-token  ",
+    )
     resp = router.update_settings(payload)
-    assert resp.model_dump() == {"theme": "light"}
+    assert resp.model_dump() == {
+        "theme": "light",
+        "plexUrl": "http://plex.changed",
+        "plexToken": "updated-token",
+    }
 
     stored = json.loads(path.read_text(encoding="utf-8"))
-    assert stored == {"theme": "light"}
+    assert stored == {
+        "theme": "light",
+        "plexUrl": "http://plex.changed",
+        "plexToken": "updated-token",
+    }
 
     # Ensure the service merges persisted values with defaults
-    assert service.load_settings() == {"theme": "light"}
+    assert service.load_settings() == {
+        "theme": "light",
+        "plexUrl": "http://plex.changed",
+        "plexToken": "updated-token",
+    }
 
 
 def test_put_settings_rejects_invalid_theme(settings_modules):
@@ -49,3 +71,10 @@ def test_put_settings_rejects_invalid_theme(settings_modules):
 
     with pytest.raises(ValidationError):
         router.SettingsPayload(theme="blue")
+
+
+def test_put_settings_rejects_invalid_plex_url(settings_modules):
+    router, _, _ = settings_modules
+
+    with pytest.raises(ValidationError):
+        router.SettingsPayload(theme="dark", plexUrl="not-a-url")


### PR DESCRIPTION
## Summary
- extend backend settings defaults to include Plex URL/token with validation and updated tests
- refactor settings provider and page to manage Plex and theme fields together and add Plex form inputs with styling

## Testing
- pytest tests/test_settings_route.py

------
https://chatgpt.com/codex/tasks/task_e_68e1c461fc308330afe0af556b2d3cac