### PR TITLE
Refactor Plex configuration lookup

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,7 +1,8 @@
 import os
+from typing import List
 
-PLEX_URL = os.environ.get("PLEX_URL")
-PLEX_TOKEN = os.environ.get("PLEX_TOKEN")
+from .services import plex_settings
+
 PORT = int(os.environ.get("PORT", "8080"))
 
 LIBRARY_MAPPINGS = {}
@@ -12,8 +13,12 @@ for e in filter(None, (x.strip() for x in raw.split(","))):
         name, path = e.split(":", 1)
         LIBRARY_MAPPINGS[name.strip()] = path.strip()
 
-CONFIG_ERRORS = []
-if not PLEX_URL: CONFIG_ERRORS.append("Missing PLEX_URL")
-if not PLEX_TOKEN: CONFIG_ERRORS.append("Missing PLEX_TOKEN")
-if not LIBRARY_MAPPINGS:
-    CONFIG_ERRORS.append("Missing LIBRARIES (e.g. Movies:/assets/Movies,Collections:/assets/Collections)")
+def get_config_errors() -> List[str]:
+    errors: List[str] = []
+    if not plex_settings.get_plex_url():
+        errors.append("Missing PLEX_URL")
+    if not plex_settings.get_plex_token():
+        errors.append("Missing PLEX_TOKEN")
+    if not LIBRARY_MAPPINGS:
+        errors.append("Missing LIBRARIES (e.g. Movies:/assets/Movies,Collections:/assets/Collections)")
+    return errors

--- a/app/routers/collections.py
+++ b/app/routers/collections.py
@@ -3,6 +3,7 @@ from math import ceil
 from typing import Optional, List, Dict, Any, Tuple
 from ..services.plex import get_plex
 from ..services import folder_overrides
+from ..services import plex_settings
 from ..services.assets import sanitize_name
 from .. import config
 
@@ -128,6 +129,9 @@ def collections(
     not_ready_only: bool = Query(False, alias="not_ready_only"),
 ):
     plex = get_plex()
+    cfg = plex_settings.get_plex_config()
+    plex_url = cfg.url
+    plex_token = cfg.token
     rows: List[Dict[str, Any]] = []
 
     # Gather collections from all libraries
@@ -138,7 +142,9 @@ def collections(
                 title = (getattr(coll, "title", None) or "").strip()
 
                 # Plex art
-                poster_plex = f"{config.PLEX_URL}/library/metadata/{rk}/thumb?X-Plex-Token={config.PLEX_TOKEN}"
+                poster_plex = None
+                if plex_url and plex_token:
+                    poster_plex = f"{plex_url}/library/metadata/{rk}/thumb?X-Plex-Token={plex_token}"
 
                 override_folder = folder_overrides.get_override("Collections", str(rk)) if rk else None
 

--- a/app/routers/imports.py
+++ b/app/routers/imports.py
@@ -2,17 +2,16 @@
 import logging
 import os
 import xml.etree.ElementTree as ET
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import requests
 from fastapi import APIRouter, Form, HTTPException, Query
 
+from ..services import plex_settings
 from ..services.resolve import resolve_existing_dir_or_422
 
 router = APIRouter()
 
-PLEX_URL        = os.environ.get("PLEX_URL", "").rstrip("/")
-PLEX_TOKEN      = os.environ.get("PLEX_TOKEN", "")
 # Allow opting out for self-signed Plex certs: export PLEX_VERIFY_SSL=false
 PLEX_VERIFY_SSL = os.environ.get("PLEX_VERIFY_SSL", "true").lower() != "false"
 
@@ -21,9 +20,10 @@ TOKEN_MASK = "***"
 
 
 def _mask_token(value: Optional[str]) -> Optional[str]:
-    if not value or not PLEX_TOKEN:
+    plex_token = plex_settings.get_plex_token()
+    if not value or not plex_token:
         return value
-    return value.replace(PLEX_TOKEN, TOKEN_MASK)
+    return value.replace(plex_token, TOKEN_MASK)
 
 
 def _safe_url(url: Optional[str]) -> Optional[str]:
@@ -51,10 +51,12 @@ def _safe_headers(headers: Optional[dict]) -> Optional[dict]:
         safe[token_key] = TOKEN_MASK
     return safe
 
-def _require_plex():
-    if not PLEX_URL or not PLEX_TOKEN:
+def _require_plex() -> Tuple[str, str]:
+    cfg = plex_settings.get_plex_config()
+    if not cfg.url or not cfg.token:
         logger.error("Plex configuration missing (PLEX_URL or PLEX_TOKEN)")
         raise HTTPException(status_code=500, detail="PLEX_URL or PLEX_TOKEN not set")
+    return cfg.url, cfg.token
 
 def _dest_dir_or_422(library: str, folderName: str) -> str:
     try:
@@ -124,11 +126,11 @@ def _json_or_xml(path: str) -> Dict[str, Any] | str:
     """
     Return JSON dict if server answered JSON; otherwise return XML text.
     """
-    _require_plex()
-    url = f"{PLEX_URL}{path}"
-    headers = {"Accept": "application/json", "X-Plex-Token": PLEX_TOKEN}
+    plex_url, plex_token = _require_plex()
+    url = f"{plex_url}{path}"
+    headers = {"Accept": "application/json", "X-Plex-Token": plex_token}
     logger.debug("Requesting Plex metadata from %s", _safe_url(url))
-    r = _get(url, params={"X-Plex-Token": PLEX_TOKEN}, headers=headers)
+    r = _get(url, params={"X-Plex-Token": plex_token}, headers=headers)
     ctype = (r.headers.get("Content-Type") or "").lower()
     if "application/json" in ctype:
         logger.debug("Received JSON metadata for %s", path)
@@ -173,8 +175,8 @@ def _resolve_art_path_from_metadata(rating_key: str) -> Optional[str]:
     return None
 
 def _poster_url_for_rating_key(rating_key: str) -> str:
-    _require_plex()
-    direct = f"{PLEX_URL}/library/metadata/{rating_key}/thumb?X-Plex-Token={PLEX_TOKEN}"
+    plex_url, plex_token = _require_plex()
+    direct = f"{plex_url}/library/metadata/{rating_key}/thumb?X-Plex-Token={plex_token}"
     try:
         logger.debug(
             "Attempting direct poster URL for ratingKey=%s: %s",
@@ -189,11 +191,11 @@ def _poster_url_for_rating_key(rating_key: str) -> str:
         if not thumb_path:
             logger.warning("Poster path resolution failed for ratingKey=%s", rating_key)
             raise HTTPException(status_code=502, detail=f"Could not resolve poster path for ratingKey={rating_key}")
-        return f"{PLEX_URL}{thumb_path}?X-Plex-Token={PLEX_TOKEN}"
+        return f"{plex_url}{thumb_path}?X-Plex-Token={plex_token}"
 
 def _art_url_for_rating_key(rating_key: str) -> str:
-    _require_plex()
-    direct = f"{PLEX_URL}/library/metadata/{rating_key}/art?X-Plex-Token={PLEX_TOKEN}"
+    plex_url, plex_token = _require_plex()
+    direct = f"{plex_url}/library/metadata/{rating_key}/art?X-Plex-Token={plex_token}"
     try:
         logger.debug(
             "Attempting direct background URL for ratingKey=%s: %s",
@@ -208,7 +210,7 @@ def _art_url_for_rating_key(rating_key: str) -> str:
         if not art_path:
             logger.warning("Background path resolution failed for ratingKey=%s", rating_key)
             raise HTTPException(status_code=502, detail=f"Could not resolve background path for ratingKey={rating_key}")
-        return f"{PLEX_URL}{art_path}?X-Plex-Token={PLEX_TOKEN}"
+        return f"{plex_url}{art_path}?X-Plex-Token={plex_token}"
 
 def _children_for_show(rating_key: str) -> List[Dict[str, Any]]:
     logger.debug("Fetching seasons for show ratingKey=%s", rating_key)
@@ -269,12 +271,13 @@ def _season_poster_url(show_rating_key: str, season_index: int) -> str:
             show_rating_key,
         )
         raise HTTPException(status_code=404, detail=f"Season {season_index} not found in Plex")
+    plex_url, plex_token = _require_plex()
     thumb = target.get("thumb")
     rk    = target.get("ratingKey")
     if thumb:
-        return f"{PLEX_URL}{thumb}?X-Plex-Token={PLEX_TOKEN}"
+        return f"{plex_url}{thumb}?X-Plex-Token={plex_token}"
     if rk:
-        return f"{PLEX_URL}/library/metadata/{rk}/thumb?X-Plex-Token={PLEX_TOKEN}"
+        return f"{plex_url}/library/metadata/{rk}/thumb?X-Plex-Token={plex_token}"
     logger.warning(
         "Season poster URL unavailable for show %s season %s", show_rating_key, season_index
     )

--- a/app/routers/items.py
+++ b/app/routers/items.py
@@ -1,31 +1,37 @@
 # app/routers/items.py
 from fastapi import APIRouter, HTTPException, Query
-from typing import Dict, Any, List, Optional
+from typing import Dict, Any, List, Optional, Tuple
 import os
 import requests
 import xml.etree.ElementTree as ET
 from urllib.parse import quote
 
 from ..services import folder_overrides
+from ..services import plex_settings
 from ..services.resolve import resolve_existing_dir_or_422
 
 router = APIRouter()
 
-PLEX_URL    = os.environ.get("PLEX_URL", "").rstrip("/")
-PLEX_TOKEN  = os.environ.get("PLEX_TOKEN", "")
 ASSETS_ROOT = os.environ.get("KAM_ASSETS_ROOT", "/assets")
 
 # ---------- Plex helpers ----------
 
-def _require_plex():
-    if not PLEX_URL or not PLEX_TOKEN:
+def _require_plex() -> Tuple[str, str]:
+    cfg = plex_settings.get_plex_config()
+    if not cfg.url or not cfg.token:
         raise HTTPException(status_code=500, detail="PLEX_URL or PLEX_TOKEN not set")
+    return cfg.url, cfg.token
 
 def _plex_sections_raw():
-    _require_plex()
-    url = f"{PLEX_URL}/library/sections"
-    headers = {"Accept": "application/json", "X-Plex-Token": PLEX_TOKEN}
-    r = requests.get(url, headers=headers, params={"X-Plex-Token": PLEX_TOKEN}, timeout=20)
+    plex_url, plex_token = _require_plex()
+    url = f"{plex_url}/library/sections"
+    headers = {"Accept": "application/json", "X-Plex-Token": plex_token}
+    r = requests.get(
+        url,
+        headers=headers,
+        params={"X-Plex-Token": plex_token},
+        timeout=20,
+    )
     r.raise_for_status()
     return r
 
@@ -50,11 +56,11 @@ def _section_key_by_name(lib_name: str) -> str:
     raise HTTPException(status_code=404, detail=f"Plex library not found: {lib_name}")
 
 def _plex_list(path: str, params: Optional[dict] = None) -> List[Dict[str, Any]]:
-    _require_plex()
-    url = f"{PLEX_URL}{path}"
+    plex_url, plex_token = _require_plex()
+    url = f"{plex_url}{path}"
     params = dict(params or {})
-    params["X-Plex-Token"] = PLEX_TOKEN
-    headers = {"Accept": "application/json", "X-Plex-Token": PLEX_TOKEN}
+    params["X-Plex-Token"] = plex_token
+    headers = {"Accept": "application/json", "X-Plex-Token": plex_token}
     r = requests.get(url, params=params, headers=headers, timeout=25)
     r.raise_for_status()
     if (r.headers.get("Content-Type") or "").lower().startswith("application/json"):
@@ -115,10 +121,11 @@ def _fileproxy_poster_url(library: str, folder: str) -> str:
     return f"/fileproxy?path=/assets/{lib_enc}/{fol_enc}/poster.jpg&t=0"
 
 def _plex_poster_url(rating_key: Optional[str], thumb: Optional[str]) -> str:
+    plex_url, plex_token = _require_plex()
     path = thumb or (f"/library/metadata/{rating_key}/thumb" if rating_key else None)
     if not path:
         return "/fallback.png"
-    return f"{PLEX_URL}{path}?X-Plex-Token={PLEX_TOKEN}"
+    return f"{plex_url}{path}?X-Plex-Token={plex_token}"
 
 # ---------- API ----------
 

--- a/app/routers/movie.py
+++ b/app/routers/movie.py
@@ -1,8 +1,9 @@
 from fastapi import APIRouter, HTTPException, Query
 import os
-from typing import Optional
+from typing import Optional, Tuple
 
 from ..services import folder_overrides
+from ..services import plex_settings
 from ..services.plex import get_plex
 from ..services.assets import folder_name_for
 from ..services.resolve import resolve_existing_dir_or_422
@@ -43,6 +44,13 @@ def _resolve_existing_folder_basename(library: str, title: Optional[str], year: 
         if resolved:
             return os.path.basename(resolved.rstrip(os.sep))
     return None
+
+def _plex_url_parts() -> Tuple[str, str]:
+    cfg = plex_settings.get_plex_config()
+    if not cfg.url or not cfg.token:
+        raise HTTPException(status_code=500, detail="PLEX_URL or PLEX_TOKEN not set")
+    return cfg.url, cfg.token
+
 
 @router.get("/movie", summary="Single movie details")
 def movie(library: str = Query(...), ratingKey: int = Query(...)):
@@ -96,6 +104,8 @@ def movie(library: str = Query(...), ratingKey: int = Query(...)):
                 ts2 = None
             background_url_local = "/fileproxy?path=" + b + (("&t=" + str(ts2)) if ts2 else "")
 
+    plex_url, plex_token = _plex_url_parts()
+
     return {
         "library": library,
         "title": title,
@@ -106,9 +116,9 @@ def movie(library: str = Query(...), ratingKey: int = Query(...)):
         "posterExists": poster_exists,
         "backgroundExists": background_exists,
         "posterUrl": poster_url_local,
-        "posterUrlPlex": f"{config.PLEX_URL}/library/metadata/{int(ratingKey)}/thumb?X-Plex-Token={config.PLEX_TOKEN}",
+        "posterUrlPlex": f"{plex_url}/library/metadata/{int(ratingKey)}/thumb?X-Plex-Token={plex_token}",
         "backgroundUrl": background_url_local,
-        "backgroundUrlPlex": f"{config.PLEX_URL}/library/metadata/{int(ratingKey)}/art?X-Plex-Token={config.PLEX_TOKEN}",
+        "backgroundUrlPlex": f"{plex_url}/library/metadata/{int(ratingKey)}/art?X-Plex-Token={plex_token}",
     }
 
 @router.get("/api/movie", summary="Single movie details (alias)")

--- a/app/routers/tv.py
+++ b/app/routers/tv.py
@@ -1,30 +1,36 @@
 # app/routers/tv.py
 from fastapi import APIRouter, HTTPException, Query
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 import os
 import requests
 import xml.etree.ElementTree as ET
 from urllib.parse import quote
 
 from ..services import folder_overrides
+from ..services import plex_settings
 from ..services.resolve import resolve_existing_dir_or_422
 from ..services.sanitize import kometa_sanitize_folder
 
 router = APIRouter()
 
-PLEX_URL    = os.environ.get("PLEX_URL", "").rstrip("/")
-PLEX_TOKEN  = os.environ.get("PLEX_TOKEN", "")
 ASSETS_ROOT = os.environ.get("KAM_ASSETS_ROOT", "/assets")
 
-def _require_plex():
-    if not PLEX_URL or not PLEX_TOKEN:
+def _require_plex() -> Tuple[str, str]:
+    cfg = plex_settings.get_plex_config()
+    if not cfg.url or not cfg.token:
         raise HTTPException(status_code=500, detail="PLEX_URL or PLEX_TOKEN not set")
+    return cfg.url, cfg.token
 
 def _plex_json_or_xml(path: str):
-    _require_plex()
-    url = f"{PLEX_URL}{path}"
-    headers = {"Accept": "application/json", "X-Plex-Token": PLEX_TOKEN}
-    r = requests.get(url, headers=headers, params={"X-Plex-Token": PLEX_TOKEN}, timeout=25)
+    plex_url, plex_token = _require_plex()
+    url = f"{plex_url}{path}"
+    headers = {"Accept": "application/json", "X-Plex-Token": plex_token}
+    r = requests.get(
+        url,
+        headers=headers,
+        params={"X-Plex-Token": plex_token},
+        timeout=25,
+    )
     r.raise_for_status()
     return r
 
@@ -120,12 +126,14 @@ def _fileproxy_abs_path(library: str, folder: str, filename: str, bust: int = 0)
 def _plex_thumb_url(thumb: Optional[str], rk: Optional[str]) -> Optional[str]:
     path = thumb or (f"/library/metadata/{rk}/thumb" if rk else None)
     if not path: return None
-    return f"{PLEX_URL}{path}?X-Plex-Token={PLEX_TOKEN}"
+    plex_url, plex_token = _require_plex()
+    return f"{plex_url}{path}?X-Plex-Token={plex_token}"
 
 def _plex_art_url(art: Optional[str], rk: Optional[str]) -> Optional[str]:
     path = art or (f"/library/metadata/{rk}/art" if rk else None)
     if not path: return None
-    return f"{PLEX_URL}{path}?X-Plex-Token={PLEX_TOKEN}"
+    plex_url, plex_token = _require_plex()
+    return f"{plex_url}{path}?X-Plex-Token={plex_token}"
 
 @router.get("/api/show")
 def get_show(library: str = Query(...), ratingKey: str = Query(...)):

--- a/app/services/plex.py
+++ b/app/services/plex.py
@@ -1,16 +1,25 @@
 from plexapi.server import PlexServer
 from fastapi import HTTPException
+
 from .. import config
+from . import plex_settings
 
 _plex = None
+_last_creds = (None, None)
+
 
 def get_plex():
-    global _plex
-    if _plex is None:
-        if config.CONFIG_ERRORS:
-            raise HTTPException(status_code=500, detail="; ".join(config.CONFIG_ERRORS))
+    global _plex, _last_creds
+    errors = config.get_config_errors()
+    if errors:
+        raise HTTPException(status_code=500, detail="; ".join(errors))
+
+    cfg = plex_settings.get_plex_config()
+    creds = (cfg.url, cfg.token)
+    if _plex is None or creds != _last_creds:
         try:
-            _plex = PlexServer(config.PLEX_URL, config.PLEX_TOKEN)
+            _plex = PlexServer(cfg.url, cfg.token)
+            _last_creds = creds
         except Exception as e:
             raise HTTPException(status_code=500, detail=f"Plex connect failed: {e}")
     return _plex

--- a/app/services/plex_settings.py
+++ b/app/services/plex_settings.py
@@ -1,0 +1,78 @@
+"""Helpers for resolving Plex connection details from persisted settings."""
+from __future__ import annotations
+
+import os
+import threading
+from dataclasses import dataclass
+from typing import Optional
+
+from . import settings as settings_service
+
+
+@dataclass(frozen=True)
+class PlexConfig:
+    """Resolved Plex configuration."""
+
+    url: str
+    token: str
+
+
+_TOKEN_KEYS = ("plexToken", "plex_token")
+_URL_KEYS = ("plexUrl", "plex_url")
+
+_LOCK = threading.Lock()
+_CACHE: Optional[PlexConfig] = None
+
+
+def _coalesce_setting(data: dict[str, object], keys: tuple[str, ...]) -> str:
+    for key in keys:
+        value = data.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
+def _normalize_url(url: str) -> str:
+    url = url.strip()
+    if not url:
+        return ""
+    return url.rstrip("/")
+
+
+def _resolve_uncached() -> PlexConfig:
+    data = settings_service.load_settings()
+    url = _coalesce_setting(data, _URL_KEYS) or os.environ.get("PLEX_URL", "")
+    token = _coalesce_setting(data, _TOKEN_KEYS) or os.environ.get("PLEX_TOKEN", "")
+    return PlexConfig(url=_normalize_url(url), token=token.strip())
+
+
+def get_plex_config(*, force_refresh: bool = False) -> PlexConfig:
+    """Return the current Plex configuration, optionally forcing a refresh."""
+    global _CACHE
+    if force_refresh:
+        with _LOCK:
+            cfg = _resolve_uncached()
+            _CACHE = cfg
+            return cfg
+
+    if _CACHE is None:
+        with _LOCK:
+            if _CACHE is None:
+                _CACHE = _resolve_uncached()
+    assert _CACHE is not None
+    return _CACHE
+
+
+def clear_cache() -> None:
+    """Clear any cached Plex configuration."""
+    global _CACHE
+    with _LOCK:
+        _CACHE = None
+
+
+def get_plex_url(*, force_refresh: bool = False) -> str:
+    return get_plex_config(force_refresh=force_refresh).url
+
+
+def get_plex_token(*, force_refresh: bool = False) -> str:
+    return get_plex_config(force_refresh=force_refresh).token

--- a/app/services/settings.py
+++ b/app/services/settings.py
@@ -10,7 +10,11 @@ from typing import Any, Dict
 
 logger = logging.getLogger(__name__)
 
-_DEFAULT_SETTINGS: Dict[str, Any] = {"theme": "dark"}
+_DEFAULT_SETTINGS: Dict[str, Any] = {
+    "theme": "dark",
+    "plexUrl": None,
+    "plexToken": None,
+}
 
 _DEF_BASE = (
     os.environ.get("KAM_STATE_ROOT")
@@ -46,6 +50,7 @@ def save_settings(data: Dict[str, Any]) -> Dict[str, Any]:
     with _LOCK:
         merged = _merge_with_defaults(data)
         _write_locked(merged)
+        _clear_plex_cache()
         return merged
 
 
@@ -88,3 +93,12 @@ def _write_locked(data: Dict[str, Any]) -> None:
         json.dumps(data, indent=2, sort_keys=True), encoding="utf-8"
     )
     tmp_path.replace(path)
+
+
+def _clear_plex_cache() -> None:
+    try:
+        from . import plex_settings  # Local import to avoid circular dependency
+
+        plex_settings.clear_cache()
+    except Exception:
+        logger.debug("Unable to clear Plex settings cache", exc_info=True)

--- a/tests/test_collections_route.py
+++ b/tests/test_collections_route.py
@@ -49,9 +49,18 @@ def collections_env(tmp_path, monkeypatch):
 
     from app import config
 
-    monkeypatch.setattr(config, "PLEX_URL", "http://plex.test")
-    monkeypatch.setattr(config, "PLEX_TOKEN", "token")
-    monkeypatch.setattr(config, "CONFIG_ERRORS", [])
+    settings_module = importlib.import_module("app.services.settings")
+    monkeypatch.setattr(
+        settings_module,
+        "load_settings",
+        lambda: {
+            "theme": "dark",
+            "plexUrl": "http://plex.test",
+            "plexToken": "token",
+        },
+    )
+    plex_settings = importlib.reload(importlib.import_module("app.services.plex_settings"))
+    plex_settings.clear_cache()
 
     monkeypatch.setenv("KAM_ASSETS_ROOT", str(assets_root))
     monkeypatch.setenv("COLLECTIONS_ROOT", str(collections_root))
@@ -102,6 +111,7 @@ def test_collections_route_marks_asset_readiness(collections_env):
     missing = items["Missing Assets"]
     assert missing["assetReady"] is False
     assert missing["folderName"] == "Missing Assets"
+    assert missing["posterUrlPlex"].startswith("http://plex.test")
 
 
 INDEX_HTML = ROOT / "app" / "web" / "index.html"

--- a/tests/test_items_route.py
+++ b/tests/test_items_route.py
@@ -17,8 +17,19 @@ def items_env(tmp_path, monkeypatch):
 
     monkeypatch.setenv("KAM_ASSETS_ROOT", str(assets_root))
     monkeypatch.setenv("KAM_FOLDER_OVERRIDES_PATH", str(overrides_path))
-    monkeypatch.setenv("PLEX_URL", "http://plex.test")
-    monkeypatch.setenv("PLEX_TOKEN", "token")
+
+    settings_module = importlib.import_module("app.services.settings")
+    monkeypatch.setattr(
+        settings_module,
+        "load_settings",
+        lambda: {
+            "theme": "dark",
+            "plexUrl": "http://plex.test",
+            "plexToken": "token",
+        },
+    )
+    plex_settings = importlib.reload(importlib.import_module("app.services.plex_settings"))
+    plex_settings.clear_cache()
 
     from app import config
 
@@ -94,6 +105,7 @@ def test_items_route_reports_not_ready_count_and_filters(items_env):
 
     by_key = {it["ratingKey"]: it for it in data["items"]}
     assert by_key["22"]["assetReady"] is False
+    assert by_key["22"]["posterUrl"].startswith("http://plex.test")
 
     filtered = items_env.call(not_ready_only=True)
 

--- a/tests/test_movie_route.py
+++ b/tests/test_movie_route.py
@@ -56,9 +56,19 @@ def movie_env(tmp_path, monkeypatch):
     from app import config
 
     monkeypatch.setattr(config, "LIBRARY_MAPPINGS", {library: str(library_path)})
-    monkeypatch.setattr(config, "PLEX_URL", "http://plex.test")
-    monkeypatch.setattr(config, "PLEX_TOKEN", "token")
-    monkeypatch.setattr(config, "CONFIG_ERRORS", [])
+
+    settings_module = importlib.import_module("app.services.settings")
+    monkeypatch.setattr(
+        settings_module,
+        "load_settings",
+        lambda: {
+            "theme": "dark",
+            "plexUrl": "http://plex.test",
+            "plexToken": "token",
+        },
+    )
+    plex_settings = importlib.reload(importlib.import_module("app.services.plex_settings"))
+    plex_settings.clear_cache()
 
     monkeypatch.setenv("KAM_ASSETS_ROOT", str(assets_root))
     overrides_path = tmp_path / "overrides.json"
@@ -115,3 +125,5 @@ def test_movie_route_prefers_override(movie_env):
     assert data["folderExists"] is True
     assert data["posterExists"] is True
     assert data["backgroundExists"] is True
+    assert data["posterUrlPlex"].startswith("http://plex.test")
+    assert data["backgroundUrlPlex"].startswith("http://plex.test")

--- a/tests/test_settings_route.py
+++ b/tests/test_settings_route.py
@@ -38,10 +38,18 @@ def test_put_settings_updates_file(settings_modules):
     assert resp.model_dump() == {"theme": "light"}
 
     stored = json.loads(path.read_text(encoding="utf-8"))
-    assert stored == {"theme": "light"}
+    assert stored == {
+        "plexToken": None,
+        "plexUrl": None,
+        "theme": "light",
+    }
 
     # Ensure the service merges persisted values with defaults
-    assert service.load_settings() == {"theme": "light"}
+    assert service.load_settings() == {
+        "plexToken": None,
+        "plexUrl": None,
+        "theme": "light",
+    }
 
 
 def test_put_settings_rejects_invalid_theme(settings_modules):

--- a/tests/test_tv_route.py
+++ b/tests/test_tv_route.py
@@ -32,8 +32,19 @@ def tv_env(tmp_path, monkeypatch):
 
     monkeypatch.setenv("KAM_ASSETS_ROOT", str(assets_root))
     monkeypatch.setenv("KAM_FOLDER_OVERRIDES_PATH", str(overrides_path))
-    monkeypatch.setenv("PLEX_URL", "http://plex.test")
-    monkeypatch.setenv("PLEX_TOKEN", "token")
+
+    settings_module = importlib.import_module("app.services.settings")
+    monkeypatch.setattr(
+        settings_module,
+        "load_settings",
+        lambda: {
+            "theme": "dark",
+            "plexUrl": "http://plex.test",
+            "plexToken": "token",
+        },
+    )
+    plex_settings = importlib.reload(importlib.import_module("app.services.plex_settings"))
+    plex_settings.clear_cache()
 
     from app import config
 
@@ -100,3 +111,5 @@ def test_tv_route_prefers_override(tv_env):
     assert data["posterUrl"].startswith("/fileproxy")
     assert data["backgroundUrl"].startswith("/fileproxy")
     assert data["seasons"][0]["posterUrl"].startswith("/fileproxy")
+    assert data["plexPosterUrl"].startswith("http://plex.test")
+    assert data["plexBackgroundUrl"].startswith("http://plex.test")


### PR DESCRIPTION
## Summary
- add a shared Plex settings helper that resolves credentials from persisted settings and environment variables
- update Plex-dependent routers and services to fetch credentials per request using the helper
- refresh tests to mock persisted settings and assert Plex URLs update without relying on environment variables

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e1c46551c4833087d99f10cef0dc5c