### PR TITLE
Add structured library mapping settings

### DIFF
--- a/app/routers/settings.py
+++ b/app/routers/settings.py
@@ -3,12 +3,47 @@ from __future__ import annotations
 
 from fastapi import APIRouter
 from pydantic import BaseModel, ConfigDict, Field, field_validator
-from typing import Literal
+from typing import List, Literal
 from urllib.parse import urlparse
 
-from ..services import settings as settings_service
+from ..services import (
+    library_mappings as library_mappings_service,
+    settings as settings_service,
+)
 
 router = APIRouter()
+
+
+class LibraryMappingPayload(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    library: str
+    assetPath: str
+    collectionsPath: str | None = None
+
+    @field_validator("library", mode="before")
+    @classmethod
+    def _validate_library(cls, value: str | None) -> str:
+        if value in (None, ""):
+            raise ValueError("Library name is required")
+        text = str(value).strip()
+        if not text:
+            raise ValueError("Library name is required")
+        return text
+
+    @field_validator("assetPath", mode="before")
+    @classmethod
+    def _validate_asset_path(cls, value: str | None) -> str:
+        normalized = library_mappings_service.normalize_path(value)
+        if not normalized:
+            raise ValueError("Asset path is required")
+        return normalized
+
+    @field_validator("collectionsPath", mode="before")
+    @classmethod
+    def _validate_collections_path(cls, value: str | None) -> str | None:
+        normalized = library_mappings_service.normalize_path(value)
+        return normalized or None
 
 
 class SettingsPayload(BaseModel):
@@ -17,6 +52,17 @@ class SettingsPayload(BaseModel):
     theme: Literal["light", "dark"]
     plexUrl: str = Field(default="")
     plexToken: str = Field(default="")
+    libraryMappings: List[LibraryMappingPayload] = Field(default_factory=list)
+
+    @field_validator("libraryMappings", mode="after")
+    @classmethod
+    def _dedupe_mappings(cls, value: List[LibraryMappingPayload]) -> List[LibraryMappingPayload]:
+        if not value:
+            return []
+        sanitized = library_mappings_service.sanitize_library_mappings(
+            [item.model_dump() for item in value]
+        )
+        return [LibraryMappingPayload(**item) for item in sanitized]
 
     @field_validator("plexUrl", mode="before")
     @classmethod

--- a/app/services/library_mappings.py
+++ b/app/services/library_mappings.py
@@ -1,0 +1,111 @@
+"""Helpers for working with library mapping settings and caching."""
+from __future__ import annotations
+
+import copy
+import os
+import threading
+from typing import Any, Dict, Iterable, List, Optional
+
+__all__ = [
+    "normalize_path",
+    "sanitize_library_mappings",
+    "seed_from_env",
+    "set_cached_mappings",
+    "get_cached_mappings",
+    "clear_cache",
+]
+
+_CACHE: Optional[List[Dict[str, Any]]] = None
+_LOCK = threading.Lock()
+
+
+def normalize_path(value: Any) -> str:
+    """Return a trimmed, normalized path or an empty string."""
+    if value in (None, ""):
+        return ""
+    text = str(value).strip()
+    if not text:
+        return ""
+    normalized = os.path.normpath(text)
+    if normalized in (".", ""):
+        return ""
+    return normalized.replace("\\", "/")
+
+
+def sanitize_library_mappings(raw: Any) -> List[Dict[str, Any]]:
+    """Normalize arbitrary input into a deterministic list of mappings."""
+    if not raw:
+        return []
+
+    items: Iterable[Dict[str, Any]]
+    if isinstance(raw, dict):
+        items = (
+            {
+                "library": key,
+                "assetPath": value,
+                "collectionsPath": None,
+            }
+            for key, value in raw.items()
+        )
+    elif isinstance(raw, list):
+        items = (item for item in raw if isinstance(item, dict))
+    else:
+        return []
+
+    ordered: Dict[str, Dict[str, Any]] = {}
+    for item in items:
+        library = str(item.get("library", "")) if item.get("library") is not None else ""
+        library = library.strip()
+        asset_path = normalize_path(item.get("assetPath"))
+        collections_path = normalize_path(item.get("collectionsPath"))
+
+        if not library or not asset_path:
+            continue
+
+        ordered[library] = {
+            "library": library,
+            "assetPath": asset_path,
+            "collectionsPath": collections_path or None,
+        }
+
+    return [copy.deepcopy(value) for value in ordered.values()]
+
+
+def seed_from_env() -> List[Dict[str, Any]]:
+    """Return library mappings derived from the LIBRARIES/COLLECTIONS_ROOT envs."""
+    env_raw = os.environ.get("LIBRARIES", "")
+    collection_root = normalize_path(os.environ.get("COLLECTIONS_ROOT"))
+
+    candidates = []
+    for part in env_raw.split(","):
+        part = part.strip()
+        if not part or ":" not in part:
+            continue
+        name, path = part.split(":", 1)
+        candidates.append(
+            {
+                "library": name,
+                "assetPath": path,
+                "collectionsPath": collection_root or None,
+            }
+        )
+
+    return sanitize_library_mappings(candidates)
+
+
+def set_cached_mappings(mappings: List[Dict[str, Any]] | None) -> None:
+    """Persist a copy of the mappings in memory for fast reuse."""
+    global _CACHE
+    with _LOCK:
+        _CACHE = copy.deepcopy(mappings) if mappings is not None else None
+
+
+def get_cached_mappings() -> Optional[List[Dict[str, Any]]]:
+    """Return the cached mappings (if any)."""
+    with _LOCK:
+        return copy.deepcopy(_CACHE) if _CACHE is not None else None
+
+
+def clear_cache() -> None:
+    """Clear the cached mappings."""
+    set_cached_mappings(None)

--- a/app/services/settings.py
+++ b/app/services/settings.py
@@ -1,12 +1,15 @@
 """Helpers for persisting simple UI settings."""
 from __future__ import annotations
 
+import copy
 import json
 import logging
 import os
 import threading
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, List
+
+from . import library_mappings
 
 logger = logging.getLogger(__name__)
 
@@ -14,6 +17,7 @@ _DEFAULT_SETTINGS: Dict[str, Any] = {
     "theme": "dark",
     "plexUrl": os.environ.get("PLEX_URL") or "",
     "plexToken": os.environ.get("PLEX_TOKEN") or "",
+    "libraryMappings": library_mappings.seed_from_env(),
 }
 
 _DEF_BASE = (
@@ -48,18 +52,40 @@ def load_settings() -> Dict[str, Any]:
 def save_settings(data: Dict[str, Any]) -> Dict[str, Any]:
     """Persist settings and return the stored payload merged with defaults."""
     with _LOCK:
-        merged = _merge_with_defaults(data)
+        sanitized = _sanitize_payload(data)
+        merged = _merge_with_defaults(sanitized)
         _write_locked(merged)
         _clear_plex_cache()
+        _clear_library_mapping_cache()
         return merged
 
 
 def _merge_with_defaults(data: Dict[str, Any] | None) -> Dict[str, Any]:
-    merged = dict(_DEFAULT_SETTINGS)
+    merged = copy.deepcopy(_DEFAULT_SETTINGS)
     if data:
         for key, value in data.items():
-            merged[key] = value
+            if key == "libraryMappings" and isinstance(value, list):
+                merged[key] = _clone_mappings(value)
+            else:
+                merged[key] = value
     return merged
+
+
+def _sanitize_payload(data: Dict[str, Any] | None) -> Dict[str, Any]:
+    if not isinstance(data, dict):
+        return {}
+
+    sanitized: Dict[str, Any] = {}
+    for key in ("theme", "plexUrl", "plexToken"):
+        if key in data:
+            sanitized[key] = data[key]
+
+    if "libraryMappings" in data:
+        sanitized["libraryMappings"] = library_mappings.sanitize_library_mappings(
+            data.get("libraryMappings")
+        )
+
+    return sanitized
 
 
 def _load_locked() -> Dict[str, Any]:
@@ -67,10 +93,10 @@ def _load_locked() -> Dict[str, Any]:
     try:
         raw = path.read_text(encoding="utf-8")
     except FileNotFoundError:
-        return dict(_DEFAULT_SETTINGS)
+        return copy.deepcopy(_DEFAULT_SETTINGS)
     except Exception as exc:
         logger.warning("Unable to read settings file %s: %s", path, exc)
-        return dict(_DEFAULT_SETTINGS)
+        return copy.deepcopy(_DEFAULT_SETTINGS)
 
     try:
         data = json.loads(raw) or {}
@@ -78,7 +104,8 @@ def _load_locked() -> Dict[str, Any]:
         logger.warning("Invalid JSON in settings file %s: %s", path, exc)
         data = {}
 
-    return _merge_with_defaults(data if isinstance(data, dict) else {})
+    sanitized = _sanitize_payload(data if isinstance(data, dict) else {})
+    return _merge_with_defaults(sanitized)
 
 
 def _write_locked(data: Dict[str, Any]) -> None:
@@ -102,3 +129,14 @@ def _clear_plex_cache() -> None:
         plex_settings.clear_cache()
     except Exception:
         logger.debug("Unable to clear Plex settings cache", exc_info=True)
+
+
+def _clear_library_mapping_cache() -> None:
+    try:
+        library_mappings.clear_cache()
+    except Exception:
+        logger.debug("Unable to clear library mapping cache", exc_info=True)
+
+
+def _clone_mappings(mappings: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    return [dict(item) for item in mappings]

--- a/tests/test_settings_route.py
+++ b/tests/test_settings_route.py
@@ -18,37 +18,81 @@ def settings_modules(tmp_path, monkeypatch):
     monkeypatch.setenv("KAM_SETTINGS_PATH", str(settings_path))
     monkeypatch.setenv("PLEX_URL", "http://plex.example:32400")
     monkeypatch.setenv("PLEX_TOKEN", "initial-token")
+    monkeypatch.setenv(
+        "LIBRARIES",
+        "Movies:/assets/Movies,TV Shows:/assets/TV Shows",
+    )
+    monkeypatch.setenv("COLLECTIONS_ROOT", " /assets/Collections ")
 
+    library_module = importlib.reload(
+        importlib.import_module("app.services.library_mappings")
+    )
     settings_service = importlib.reload(importlib.import_module("app.services.settings"))
     settings_router = importlib.reload(importlib.import_module("app.routers.settings"))
 
-    return settings_router, settings_service, settings_path
+    return settings_router, settings_service, settings_path, library_module
 
 
 def test_get_settings_returns_defaults(settings_modules):
-    router, _, _ = settings_modules
+    router, _, _, _ = settings_modules
 
     resp = router.get_settings()
     assert resp.model_dump() == {
         "theme": "dark",
         "plexUrl": "http://plex.example:32400",
         "plexToken": "initial-token",
+        "libraryMappings": [
+            {
+                "library": "Movies",
+                "assetPath": "/assets/Movies",
+                "collectionsPath": "/assets/Collections",
+            },
+            {
+                "library": "TV Shows",
+                "assetPath": "/assets/TV Shows",
+                "collectionsPath": "/assets/Collections",
+            },
+        ],
     }
 
 
 def test_put_settings_updates_file(settings_modules):
-    router, service, path = settings_modules
+    router, service, path, _ = settings_modules
 
     payload = router.SettingsPayload(
         theme="light",
-        plexUrl="http://plex.changed",  # domain only is fine for HttpUrl
+        plexUrl="http://plex.changed",
         plexToken="  updated-token  ",
+        libraryMappings=[
+            {
+                "library": "Movies",
+                "assetPath": "/assets/New Movies/",
+                "collectionsPath": "",
+            },
+            {
+                "library": "TV Shows",
+                "assetPath": " /assets/TV Shows ",
+                "collectionsPath": "/assets/Collections/Shows",
+            },
+        ],
     )
     resp = router.update_settings(payload)
     assert resp.model_dump() == {
         "theme": "light",
         "plexUrl": "http://plex.changed",
         "plexToken": "updated-token",
+        "libraryMappings": [
+            {
+                "library": "Movies",
+                "assetPath": "/assets/New Movies",
+                "collectionsPath": None,
+            },
+            {
+                "library": "TV Shows",
+                "assetPath": "/assets/TV Shows",
+                "collectionsPath": "/assets/Collections/Shows",
+            },
+        ],
     }
 
     stored = json.loads(path.read_text(encoding="utf-8"))
@@ -56,6 +100,18 @@ def test_put_settings_updates_file(settings_modules):
         "theme": "light",
         "plexUrl": "http://plex.changed",
         "plexToken": "updated-token",
+        "libraryMappings": [
+            {
+                "library": "Movies",
+                "assetPath": "/assets/New Movies",
+                "collectionsPath": None,
+            },
+            {
+                "library": "TV Shows",
+                "assetPath": "/assets/TV Shows",
+                "collectionsPath": "/assets/Collections/Shows",
+            },
+        ],
     }
 
     # Ensure the service merges persisted values with defaults
@@ -63,18 +119,92 @@ def test_put_settings_updates_file(settings_modules):
         "theme": "light",
         "plexUrl": "http://plex.changed",
         "plexToken": "updated-token",
+        "libraryMappings": [
+            {
+                "library": "Movies",
+                "assetPath": "/assets/New Movies",
+                "collectionsPath": None,
+            },
+            {
+                "library": "TV Shows",
+                "assetPath": "/assets/TV Shows",
+                "collectionsPath": "/assets/Collections/Shows",
+            },
+        ],
     }
 
 
 def test_put_settings_rejects_invalid_theme(settings_modules):
-    router, _, _ = settings_modules
+    router, _, _, _ = settings_modules
 
     with pytest.raises(ValidationError):
         router.SettingsPayload(theme="blue")
 
 
 def test_put_settings_rejects_invalid_plex_url(settings_modules):
-    router, _, _ = settings_modules
+    router, _, _, _ = settings_modules
 
     with pytest.raises(ValidationError):
         router.SettingsPayload(theme="dark", plexUrl="not-a-url")
+
+
+def test_put_settings_rejects_invalid_library_mapping(settings_modules):
+    router, _, _, _ = settings_modules
+
+    with pytest.raises(ValidationError):
+        router.SettingsPayload(
+            theme="dark",
+            libraryMappings=[{"library": "", "assetPath": ""}],
+        )
+
+
+def test_save_settings_sanitizes_library_mappings(settings_modules):
+    _, service, path, _ = settings_modules
+
+    stored = service.save_settings(
+        {
+            "libraryMappings": [
+                {
+                    "library": " Movies ",
+                    "assetPath": "/assets/Movies/",
+                    "collectionsPath": "  ",
+                },
+                {
+                    "library": "Movies",
+                    "assetPath": "/assets/Movies Updated",
+                    "collectionsPath": "/collections/movies",
+                },
+                {"library": "", "assetPath": "/invalid"},
+            ]
+        }
+    )
+
+    assert stored["libraryMappings"] == [
+        {
+            "library": "Movies",
+            "assetPath": "/assets/Movies Updated",
+            "collectionsPath": "/collections/movies",
+        }
+    ]
+
+    persisted = json.loads(path.read_text(encoding="utf-8"))
+    assert persisted["libraryMappings"] == [
+        {
+            "library": "Movies",
+            "assetPath": "/assets/Movies Updated",
+            "collectionsPath": "/collections/movies",
+        }
+    ]
+
+
+def test_save_settings_clears_library_mapping_cache(settings_modules):
+    _, service, _, library_module = settings_modules
+
+    library_module.set_cached_mappings(
+        [{"library": "Movies", "assetPath": "/assets/Movies", "collectionsPath": None}]
+    )
+    assert library_module.get_cached_mappings() is not None
+
+    service.save_settings({})
+
+    assert library_module.get_cached_mappings() is None


### PR DESCRIPTION
## Summary
- add a library mapping service that normalizes paths, seeds defaults from existing environment variables, and manages cache invalidation
- persist library mapping settings alongside existing values and clear related caches after updates
- validate and round-trip library mapping data through the settings API with extended tests

## Testing
- pytest tests/test_settings_route.py

------
https://chatgpt.com/codex/tasks/task_e_68e1cac62dac8330bbe134ead0480f6d