### PR TITLE
Add Plex library settings endpoints and unmapped asset browsing

### DIFF
--- a/app/routers/assets.py
+++ b/app/routers/assets.py
@@ -25,15 +25,31 @@ def _library_root(library: str) -> Path:
         raise HTTPException(status_code=422, detail="Missing library")
     if library == "Collections":
         base = config.COLLECTIONS_ROOT
+        if not base:
+            raise HTTPException(
+                status_code=404, detail="No assets mapping for library 'Collections'"
+            )
+        root = Path(base)
     else:
-        base = config.LIBRARY_MAPPINGS.get(library)
-        if not base and ASSETS_ROOT:
-            base = os.path.join(ASSETS_ROOT, library)
-    if not base:
-        raise HTTPException(status_code=404, detail=f"No assets mapping for library '{library}'")
-    root = Path(base)
+        mapped = config.LIBRARY_MAPPINGS.get(library)
+        if mapped:
+            root = Path(mapped)
+        else:
+            if not ASSETS_ROOT:
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"No assets mapping for library '{library}'",
+                )
+            assets_root = Path(ASSETS_ROOT)
+            if not assets_root.is_dir():
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"Assets library not found: {assets_root}",
+                )
+            candidate = assets_root / library
+            root = candidate if candidate.is_dir() else assets_root
     if not root.is_dir():
-        raise HTTPException(status_code=404, detail=f"Assets library not found: {base}")
+        raise HTTPException(status_code=404, detail=f"Assets library not found: {root}")
     return root
 
 

--- a/app/routers/libraries.py
+++ b/app/routers/libraries.py
@@ -9,6 +9,7 @@ Env format (in your .env):
 from __future__ import annotations
 
 from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel
 from typing import Dict, List, Optional
 import os
 
@@ -103,3 +104,55 @@ def get_library_path(name: str = Query(..., description="Mapped library name")) 
     if not path:
         raise HTTPException(status_code=404, detail=f"Library '{name}' is not mapped.")
     return {"name": name, "path": path}
+
+
+class LibrarySectionInfo(BaseModel):
+    name: str
+    type: Optional[str] = None
+    key: Optional[str] = None
+    assetPath: Optional[str] = None
+    collectionsPath: Optional[str] = None
+
+
+@router.get("/api/settings/libraries", response_model=List[LibrarySectionInfo])
+def list_available_libraries() -> List[LibrarySectionInfo]:
+    """Return Plex libraries alongside any stored mapping metadata."""
+    from ..services import (
+        library_mappings as library_mappings_service,
+        plex_settings,
+        settings as settings_service,
+    )
+    from ..services.plex import get_plex
+
+    # Ensure Plex credentials are available (raises HTTPException when invalid)
+    plex_settings.get_plex_config()
+
+    plex = get_plex()
+    try:
+        sections = plex.library.sections()
+    except Exception as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=500, detail=f"Unable to list Plex libraries: {exc}")
+
+    stored = settings_service.load_settings().get("libraryMappings", [])
+    mappings = library_mappings_service.sanitize_library_mappings(stored)
+    mapping_lookup = {item["library"]: item for item in mappings}
+
+    results: List[LibrarySectionInfo] = []
+    for section in sections:
+        name = str(getattr(section, "title", "") or "")
+        key_value = getattr(section, "key", None)
+        key_str = str(key_value) if key_value not in (None, "") else None
+        entry = {
+            "name": name,
+            "type": getattr(section, "type", None) or None,
+            "key": key_str,
+            "assetPath": None,
+            "collectionsPath": None,
+        }
+        mapping = mapping_lookup.get(name)
+        if mapping:
+            entry["assetPath"] = mapping.get("assetPath") or None
+            entry["collectionsPath"] = mapping.get("collectionsPath") or None
+        results.append(LibrarySectionInfo(**entry))
+
+    return results

--- a/app/routers/settings.py
+++ b/app/routers/settings.py
@@ -99,3 +99,28 @@ def get_settings() -> SettingsPayload:
 def update_settings(payload: SettingsPayload) -> SettingsPayload:
     stored = settings_service.save_settings(payload.model_dump())
     return SettingsPayload(**stored)
+
+
+class LibraryMappingsUpdatePayload(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    libraryMappings: List[LibraryMappingPayload] = Field(default_factory=list)
+
+    @field_validator("libraryMappings", mode="after")
+    @classmethod
+    def _dedupe(cls, value: List[LibraryMappingPayload]) -> List[LibraryMappingPayload]:
+        if not value:
+            return []
+        sanitized = library_mappings_service.sanitize_library_mappings(
+            [item.model_dump() for item in value]
+        )
+        return [LibraryMappingPayload(**item) for item in sanitized]
+
+
+@router.put("/api/settings/library-mappings", response_model=List[LibraryMappingPayload])
+def update_library_mappings(payload: LibraryMappingsUpdatePayload) -> List[LibraryMappingPayload]:
+    stored = settings_service.save_library_mappings(
+        [item.model_dump() for item in payload.libraryMappings]
+    )
+    mappings = stored.get("libraryMappings", [])
+    return [LibraryMappingPayload(**item) for item in mappings]

--- a/app/services/settings.py
+++ b/app/services/settings.py
@@ -60,6 +60,18 @@ def save_settings(data: Dict[str, Any]) -> Dict[str, Any]:
         return merged
 
 
+def save_library_mappings(mappings: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Persist only the library mappings while preserving other settings."""
+    with _LOCK:
+        sanitized = library_mappings.sanitize_library_mappings(mappings)
+        current = _load_locked()
+        current["libraryMappings"] = _clone_mappings(sanitized)
+        _write_locked(current)
+        _clear_plex_cache()
+        _clear_library_mapping_cache()
+        return copy.deepcopy(current)
+
+
 def _merge_with_defaults(data: Dict[str, Any] | None) -> Dict[str, Any]:
     merged = copy.deepcopy(_DEFAULT_SETTINGS)
     if data:

--- a/tests/test_folder_overrides.py
+++ b/tests/test_folder_overrides.py
@@ -20,6 +20,10 @@ def overrides_env(tmp_path, monkeypatch):
     collections_dir.mkdir()
     (collections_dir / "Override Collection").mkdir()
 
+    loose_dir = assets_root / "LooseAssets"
+    loose_dir.mkdir()
+    (loose_dir / "Clips").mkdir()
+
     overrides_path = tmp_path / "overrides.json"
 
     monkeypatch.setenv("KAM_ASSETS_ROOT", str(assets_root))
@@ -45,6 +49,7 @@ def overrides_env(tmp_path, monkeypatch):
         movie_folder=movie_folder,
         movies_dir=movies_dir,
         collections_dir=collections_dir,
+        loose_dir=loose_dir,
     )
 
 
@@ -102,3 +107,22 @@ def test_list_asset_folders(overrides_env):
 
     with pytest.raises(HTTPException):
         router.list_asset_folders(library="Movies", parent="../..")
+
+
+def test_unmapped_library_navigation(overrides_env):
+    router = overrides_env.assets_router
+
+    listing = router.list_asset_folders(library="Documentaries")
+    assert listing["parent"] == ""
+    names = {item["name"] for item in listing["items"]}
+    assert overrides_env.loose_dir.name in names
+    assert overrides_env.movies_dir.name in names
+
+    nested = router.list_asset_folders(
+        library="Documentaries", parent=overrides_env.loose_dir.name
+    )
+    nested_names = {item["name"] for item in nested["items"]}
+    assert "Clips" in nested_names
+
+    with pytest.raises(HTTPException):
+        router.list_asset_folders(library="Documentaries", parent="../Collections")

--- a/tests/test_libraries_settings_endpoints.py
+++ b/tests/test_libraries_settings_endpoints.py
@@ -1,0 +1,233 @@
+import importlib
+from dataclasses import dataclass
+from typing import List
+
+import pytest
+
+pytest.importorskip("httpx")
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+@dataclass
+class _DummySection:
+    title: str
+    type: str
+    key: str
+
+
+class _DummyLibrary:
+    def __init__(self, sections: List[_DummySection]):
+        self._sections = sections
+
+    def sections(self) -> List[_DummySection]:
+        return list(self._sections)
+
+
+class _DummyPlex:
+    def __init__(self, sections: List[_DummySection]):
+        self.library = _DummyLibrary(sections)
+
+
+def _create_libraries_client(
+    monkeypatch: pytest.MonkeyPatch,
+    load_settings_payload: dict,
+    sections: List[_DummySection] | None = None,
+) -> TestClient:
+    settings_module = importlib.reload(importlib.import_module("app.services.settings"))
+    monkeypatch.setattr(settings_module, "load_settings", lambda: load_settings_payload)
+
+    plex_settings_module = importlib.reload(importlib.import_module("app.services.plex_settings"))
+    plex_settings_module.clear_cache()
+
+    default_sections = sections or [
+        _DummySection("Movies", "movie", "1"),
+        _DummySection("TV Shows", "show", "2"),
+    ]
+
+    plex_module = importlib.reload(importlib.import_module("app.services.plex"))
+    monkeypatch.setattr(plex_module, "get_plex", lambda: _DummyPlex(default_sections))
+
+    router_module = importlib.reload(importlib.import_module("app.routers.libraries"))
+
+    app = FastAPI()
+    app.include_router(router_module.router)
+
+    return TestClient(app)
+
+
+def test_settings_libraries_endpoint_lists_sections(monkeypatch):
+    client = _create_libraries_client(
+        monkeypatch,
+        {
+            "theme": "dark",
+            "plexUrl": "http://plex.example:32400",
+            "plexToken": "token",
+            "libraryMappings": [
+                {
+                    "library": "Movies",
+                    "assetPath": "/assets/Movies",
+                    "collectionsPath": "/collections/movies",
+                }
+            ],
+        },
+    )
+
+    resp = client.get("/api/settings/libraries")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data == [
+        {
+            "name": "Movies",
+            "type": "movie",
+            "key": "1",
+            "assetPath": "/assets/Movies",
+            "collectionsPath": "/collections/movies",
+        },
+        {
+            "name": "TV Shows",
+            "type": "show",
+            "key": "2",
+            "assetPath": None,
+            "collectionsPath": None,
+        },
+    ]
+
+
+def test_update_library_mappings_endpoint(monkeypatch):
+    settings_module = importlib.reload(importlib.import_module("app.services.settings"))
+
+    captured = {}
+
+    def _save_library_mappings(payload):
+        captured["payload"] = payload
+        return {
+            "theme": "dark",
+            "plexUrl": "http://plex.example",
+            "plexToken": "token",
+            "libraryMappings": payload,
+        }
+
+    monkeypatch.setattr(settings_module, "save_library_mappings", _save_library_mappings)
+
+    router_module = importlib.reload(importlib.import_module("app.routers.settings"))
+
+    app = FastAPI()
+    app.include_router(router_module.router)
+
+    client = TestClient(app)
+
+    resp = client.put(
+        "/api/settings/library-mappings",
+        json={
+            "libraryMappings": [
+                {
+                    "library": " Movies ",
+                    "assetPath": " /assets/Movies ",
+                    "collectionsPath": "",
+                },
+                {
+                    "library": "Movies",
+                    "assetPath": "/assets/Movies",
+                    "collectionsPath": None,
+                },
+            ]
+        },
+    )
+
+    assert resp.status_code == 200
+    assert resp.json() == [
+        {
+            "library": "Movies",
+            "assetPath": "/assets/Movies",
+            "collectionsPath": None,
+        }
+    ]
+
+    assert captured["payload"] == [
+        {
+            "library": "Movies",
+            "assetPath": "/assets/Movies",
+            "collectionsPath": None,
+        }
+    ]
+
+
+def test_settings_libraries_endpoint_handles_empty_mappings(monkeypatch):
+    client = _create_libraries_client(
+        monkeypatch,
+        {
+            "theme": "dark",
+            "plexUrl": "http://plex.example:32400",
+            "plexToken": "token",
+            "libraryMappings": [],
+        },
+    )
+
+    resp = client.get("/api/settings/libraries")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data == [
+        {
+            "name": "Movies",
+            "type": "movie",
+            "key": "1",
+            "assetPath": None,
+            "collectionsPath": None,
+        },
+        {
+            "name": "TV Shows",
+            "type": "show",
+            "key": "2",
+            "assetPath": None,
+            "collectionsPath": None,
+        },
+    ]
+
+
+def test_asset_folders_unmapped_library(tmp_path, monkeypatch):
+    assets_root = tmp_path / "assets"
+    assets_root.mkdir()
+    (assets_root / "Movies").mkdir()
+    loose = assets_root / "LooseAssets"
+    loose.mkdir()
+    (loose / "Clips").mkdir()
+
+    monkeypatch.setenv("KAM_ASSETS_ROOT", str(assets_root))
+
+    resolve_module = importlib.reload(importlib.import_module("app.services.resolve"))
+    resolve_module.ASSETS_ROOT = str(assets_root)
+
+    from app import config
+
+    monkeypatch.setattr(config, "LIBRARY_MAPPINGS", {"Movies": str(assets_root / "Movies")})
+    monkeypatch.setattr(config, "COLLECTIONS_ROOT", str(assets_root / "Collections"))
+
+    assets_router = importlib.reload(importlib.import_module("app.routers.assets"))
+
+    app = FastAPI()
+    app.include_router(assets_router.router)
+
+    client = TestClient(app)
+
+    resp = client.get("/api/asset-folders", params={"library": "Documentaries"})
+    assert resp.status_code == 200
+    data = resp.json()
+    names = {item["name"] for item in data["items"]}
+    assert "LooseAssets" in names
+    assert "Movies" in names
+
+    nested = client.get(
+        "/api/asset-folders",
+        params={"library": "Documentaries", "parent": "LooseAssets"},
+    )
+    assert nested.status_code == 200
+    nested_data = nested.json()
+    nested_names = {item["name"] for item in nested_data["items"]}
+    assert "Clips" in nested_names
+
+    invalid = client.get(
+        "/api/asset-folders", params={"library": "Documentaries", "parent": "../"}
+    )
+    assert invalid.status_code == 400

--- a/tests/test_settings_route.py
+++ b/tests/test_settings_route.py
@@ -208,3 +208,71 @@ def test_save_settings_clears_library_mapping_cache(settings_modules):
     service.save_settings({})
 
     assert library_module.get_cached_mappings() is None
+
+
+def test_save_library_mappings_updates_only_mapping_data(settings_modules):
+    _, service, path, library_module = settings_modules
+
+    service.save_settings(
+        {
+            "theme": "light",
+            "plexUrl": "http://plex.custom", 
+            "libraryMappings": [
+                {
+                    "library": "Movies",
+                    "assetPath": "/assets/Movies",
+                    "collectionsPath": None,
+                }
+            ],
+        }
+    )
+
+    library_module.set_cached_mappings(
+        [{"library": "Movies", "assetPath": "/assets/Movies", "collectionsPath": None}]
+    )
+
+    updated = service.save_library_mappings(
+        [
+            {
+                "library": "Movies",
+                "assetPath": "/assets/New Movies",
+                "collectionsPath": "",
+            },
+            {
+                "library": "TV Shows",
+                "assetPath": "/assets/TV Shows",
+                "collectionsPath": "/collections/tv",
+            },
+        ]
+    )
+
+    assert updated["theme"] == "light"
+    assert updated["plexUrl"] == "http://plex.custom"
+    assert updated["libraryMappings"] == [
+        {
+            "library": "Movies",
+            "assetPath": "/assets/New Movies",
+            "collectionsPath": None,
+        },
+        {
+            "library": "TV Shows",
+            "assetPath": "/assets/TV Shows",
+            "collectionsPath": "/collections/tv",
+        },
+    ]
+
+    persisted = json.loads(path.read_text(encoding="utf-8"))
+    assert persisted["libraryMappings"] == [
+        {
+            "library": "Movies",
+            "assetPath": "/assets/New Movies",
+            "collectionsPath": None,
+        },
+        {
+            "library": "TV Shows",
+            "assetPath": "/assets/TV Shows",
+            "collectionsPath": "/collections/tv",
+        },
+    ]
+
+    assert library_module.get_cached_mappings() is None


### PR DESCRIPTION
## Summary
- add a settings-oriented libraries endpoint that surfaces Plex sections together with stored mapping metadata
- expose a focused API and service helper for updating library mappings without rewriting the full settings payload
- allow asset folder browsing to fall back to the global assets root for unmapped libraries and cover the new behaviour with tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e1cc941e208330b115bdf042139fa3