### PR TITLE
Enhance settings UI and library mapping management

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -14,7 +15,12 @@
     "react-router-dom": "^6.22.3"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/user-event": "^14.5.2",
     "@vitejs/plugin-react": "^4.2.1",
+    "jsdom": "^23.2.0",
+    "vitest": "^1.4.0",
     "vite": "^5.2.0"
   }
 }

--- a/frontend/src/components/FolderFinderModal.jsx
+++ b/frontend/src/components/FolderFinderModal.jsx
@@ -30,11 +30,54 @@ function makeBreadcrumbs(currentPath, query) {
   return crumbs;
 }
 
-function FolderFinderModal({ isOpen, library, item, onClose, onFolderAssigned }) {
-  const effectiveLibrary = item?.library || library;
+const normalizeText = (value) => {
+  if (value == null) return '';
+  const text = String(value).trim();
+  return text;
+};
+
+const formatLibraryList = (libraries) => {
+  if (!libraries?.length) return 'No libraries selected';
+  if (libraries.length === 1) return libraries[0];
+  if (libraries.length === 2) return `${libraries[0]} and ${libraries[1]}`;
+  const [first, second, ...rest] = libraries;
+  return `${first}, ${second}, +${rest.length} more`;
+};
+
+function FolderFinderModal({
+  isOpen,
+  library,
+  item,
+  onClose,
+  onFolderAssigned,
+  context = 'library',
+  settingsLibraries = [],
+  defaultTarget = 'asset',
+  settingsIntent = 'asset',
+  initialAssetPath = '',
+  initialCollectionsPath = '',
+  onSettingsConfirm,
+}) {
+  const isSettingsMode = context === 'settings';
+  const normalizedInitialAsset = normalizeText(initialAssetPath);
+  const normalizedInitialCollections = normalizeText(initialCollectionsPath);
+  const effectiveLibrary = useMemo(() => {
+    if (isSettingsMode) {
+      const provided = normalizeText(library);
+      if (provided) return provided;
+      const first = settingsLibraries.map(normalizeText).find((name) => name);
+      if (first) return first;
+    }
+    const fromItem = normalizeText(item?.library);
+    if (fromItem) return fromItem;
+    return normalizeText(library);
+  }, [isSettingsMode, library, settingsLibraries, item]);
   const [currentPath, setCurrentPath] = useState('');
   const [results, setResults] = useState([]);
   const [selection, setSelection] = useState(null);
+  const [assetSelection, setAssetSelection] = useState(null);
+  const [collectionsSelection, setCollectionsSelection] = useState(null);
+  const [target, setTarget] = useState(defaultTarget === 'collections' ? 'collections' : 'asset');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [searchInput, setSearchInput] = useState('');
@@ -52,21 +95,71 @@ function FolderFinderModal({ isOpen, library, item, onClose, onFolderAssigned })
     setSearchInput('');
     setSearchTerm('');
     setSelection(null);
+    setAssetSelection(null);
+    setCollectionsSelection(null);
     setError('');
-    const initialFolder = item?.folderName || item?.folder || '';
-    setCurrentFolder(initialFolder || '');
-  }, [isOpen, effectiveLibrary, item]);
+    if (isSettingsMode) {
+      const initial =
+        defaultTarget === 'collections'
+          ? normalizedInitialCollections
+          : normalizedInitialAsset;
+      setCurrentFolder(initial || '');
+    } else {
+      const initialFolder = item?.folderName || item?.folder || '';
+      setCurrentFolder(normalizeText(initialFolder));
+    }
+  }, [
+    isOpen,
+    effectiveLibrary,
+    item,
+    isSettingsMode,
+    defaultTarget,
+    normalizedInitialAsset,
+    normalizedInitialCollections,
+  ]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setTarget(defaultTarget === 'collections' ? 'collections' : 'asset');
+  }, [isOpen, defaultTarget]);
+
+  useEffect(() => {
+    if (!isOpen || !isSettingsMode) return;
+    if (target === 'collections') {
+      const text = normalizeText(collectionsSelection?.path ?? normalizedInitialCollections);
+      setCurrentFolder(text || '');
+    } else {
+      const text = normalizeText(assetSelection?.path ?? normalizedInitialAsset);
+      setCurrentFolder(text || '');
+    }
+  }, [
+    isOpen,
+    isSettingsMode,
+    target,
+    assetSelection,
+    collectionsSelection,
+    normalizedInitialAsset,
+    normalizedInitialCollections,
+  ]);
 
   const loadFolders = useCallback(
     async ({ path = '', query = '', preserveSelection = false } = {}) => {
       if (!effectiveLibrary) {
         setResults([]);
-        setError('No library mapping available for this item.');
+        setError(isSettingsMode ? 'Select a library before browsing folders.' : 'No library mapping available for this item.');
         return;
       }
       setLoading(true);
       if (!preserveSelection) {
-        setSelection(null);
+        if (isSettingsMode) {
+          if (target === 'collections') {
+            setCollectionsSelection(null);
+          } else {
+            setAssetSelection(null);
+          }
+        } else {
+          setSelection(null);
+        }
       }
       setError('');
       setIsSearching(Boolean(query));
@@ -98,7 +191,7 @@ function FolderFinderModal({ isOpen, library, item, onClose, onFolderAssigned })
         setLoading(false);
       }
     },
-    [effectiveLibrary]
+    [effectiveLibrary, isSettingsMode, target]
   );
 
   useEffect(() => {
@@ -120,16 +213,32 @@ function FolderFinderModal({ isOpen, library, item, onClose, onFolderAssigned })
     loadFolders({ path: currentPath, query: searchTerm, preserveSelection: false });
   }, [searchTerm, isOpen, currentPath, loadFolders]);
 
-  const breadcrumbs = useMemo(() => makeBreadcrumbs(currentPath, isSearching ? searchTerm : ''), [currentPath, isSearching, searchTerm]);
+  const breadcrumbs = useMemo(
+    () => makeBreadcrumbs(currentPath, isSearching ? searchTerm : ''),
+    [currentPath, isSearching, searchTerm]
+  );
 
   const contextLabel = useMemo(() => {
+    if (isSettingsMode) {
+      return `Libraries: ${formatLibraryList(settingsLibraries)}`;
+    }
     const title = item?.title || item?.name || '(Untitled)';
     if (!effectiveLibrary) return title;
     return `Library: ${effectiveLibrary} • Item: ${title}`;
-  }, [effectiveLibrary, item]);
+  }, [isSettingsMode, settingsLibraries, item, effectiveLibrary]);
+
+  const displayCurrentFolder = currentFolder ? currentFolder : '';
 
   const handleSelect = (entry) => {
-    setSelection(entry);
+    if (isSettingsMode) {
+      if (target === 'collections') {
+        setCollectionsSelection(entry);
+      } else {
+        setAssetSelection(entry);
+      }
+    } else {
+      setSelection(entry);
+    }
     setError('');
   };
 
@@ -146,9 +255,53 @@ function FolderFinderModal({ isOpen, library, item, onClose, onFolderAssigned })
     setSearchTerm('');
   };
 
+  const resolvedAssetPath = assetSelection?.path || normalizedInitialAsset;
+  const resolvedCollectionsPath = collectionsSelection?.path || normalizedInitialCollections;
+  const requireAsset = settingsIntent !== 'collections';
+  const requireCollections = settingsIntent === 'collections';
+  const canConfirmSettings = (
+    (!requireAsset || Boolean(resolvedAssetPath)) &&
+    (!requireCollections || Boolean(resolvedCollectionsPath))
+  );
+
+  const activeSelection = isSettingsMode
+    ? target === 'collections'
+      ? collectionsSelection
+      : assetSelection
+    : selection;
+
   const handleConfirm = async (event) => {
     event.preventDefault();
-    if (!selection) {
+    if (isSettingsMode) {
+      if (!onSettingsConfirm) {
+        onClose?.();
+        return;
+      }
+      if (requireAsset && !resolvedAssetPath) {
+        setError('Select an asset folder before confirming.');
+        return;
+      }
+      if (requireCollections && !resolvedCollectionsPath) {
+        setError('Select a collections folder before confirming.');
+        return;
+      }
+      const payload = {};
+      if (requireAsset && resolvedAssetPath) {
+        payload.assetPath = resolvedAssetPath;
+      } else if (!requireAsset && assetSelection?.path) {
+        payload.assetPath = assetSelection.path;
+      }
+      if (settingsIntent !== 'asset') {
+        if (requireCollections && resolvedCollectionsPath) {
+          payload.collectionsPath = resolvedCollectionsPath;
+        } else if (!requireCollections && collectionsSelection?.path) {
+          payload.collectionsPath = collectionsSelection.path;
+        }
+      }
+      onSettingsConfirm(payload, { assetSelection, collectionsSelection });
+      return;
+    }
+    if (!activeSelection) {
       setError('Select a folder before confirming.');
       return;
     }
@@ -159,7 +312,7 @@ function FolderFinderModal({ isOpen, library, item, onClose, onFolderAssigned })
     const ratingKey = item?.ratingKey ?? item?.key ?? item?.id;
     const payload = {
       library: effectiveLibrary,
-      folderName: selection.name,
+      folderName: activeSelection.name,
     };
     if (ratingKey != null) {
       payload.ratingKey = String(ratingKey);
@@ -177,8 +330,8 @@ function FolderFinderModal({ isOpen, library, item, onClose, onFolderAssigned })
         const message = data?.detail || data?.error || `${response.status} ${response.statusText}`;
         throw new Error(message);
       }
-      const folderName = data?.folderName || selection.name;
-      onFolderAssigned?.({ folderName, details: data, selection });
+      const folderName = data?.folderName || activeSelection.name;
+      onFolderAssigned?.({ folderName, details: data, selection: activeSelection });
     } catch (err) {
       setError(err.message || 'Failed to assign folder');
     } finally {
@@ -195,12 +348,41 @@ function FolderFinderModal({ isOpen, library, item, onClose, onFolderAssigned })
       <div className="dialog-panel folder-dlg" role="dialog" aria-modal="true" aria-labelledby="folderFinderHeading">
         <form onSubmit={handleConfirm}>
           <div className="dialog-body">
-            <h2 id="folderFinderHeading">Select Asset Folder</h2>
+            <h2 id="folderFinderHeading">
+              {isSettingsMode ? 'Select Library Folder' : 'Select Asset Folder'}
+            </h2>
             <p className="folder-context">{contextLabel}</p>
             <p className="folder-current" aria-live="polite">
-              Current folder:{' '}
-              {currentFolder ? <strong>{currentFolder}</strong> : <span>Not assigned</span>}
+              {isSettingsMode ? (
+                <>
+                  Current {target === 'collections' ? 'collections' : 'asset'} folder:{' '}
+                  {displayCurrentFolder ? <strong>{displayCurrentFolder}</strong> : <span>Not assigned</span>}
+                </>
+              ) : (
+                <>
+                  Current folder:{' '}
+                  {displayCurrentFolder ? <strong>{displayCurrentFolder}</strong> : <span>Not assigned</span>}
+                </>
+              )}
             </p>
+            {isSettingsMode ? (
+              <div className="folder-targets" role="group" aria-label="Folder type">
+                <button
+                  type="button"
+                  className={target === 'asset' ? 'is-active' : ''}
+                  onClick={() => setTarget('asset')}
+                >
+                  Asset folder
+                </button>
+                <button
+                  type="button"
+                  className={target === 'collections' ? 'is-active' : ''}
+                  onClick={() => setTarget('collections')}
+                >
+                  Collections folder
+                </button>
+              </div>
+            ) : null}
             <nav aria-label="Folder breadcrumbs">
               <ol className="breadcrumbs">
                 {breadcrumbs.map((crumb, index) => (
@@ -237,12 +419,15 @@ function FolderFinderModal({ isOpen, library, item, onClose, onFolderAssigned })
               {loading && <li className="folder-empty">Loading folders…</li>}
               {!loading && !results.length && (
                 <li className="folder-empty">
-                  {isSearching && searchTerm ? 'No folders matched your search.' : 'No folders available in this location.'}
+                  {isSearching && searchTerm
+                    ? 'No folders matched your search.'
+                    : 'No folders available in this location.'}
                 </li>
               )}
               {!loading &&
                 results.map((entry) => {
-                  const isSelected = selection?.path === entry.path && selection?.name === entry.name;
+                  const isSelected =
+                    activeSelection?.path === entry.path && activeSelection?.name === entry.name;
                   return (
                     <li
                       key={`${entry.path}-${entry.name}`}
@@ -270,8 +455,12 @@ function FolderFinderModal({ isOpen, library, item, onClose, onFolderAssigned })
             <button type="button" onClick={onClose} disabled={assigning}>
               Cancel
             </button>
-            <button type="submit" className="btn" disabled={!selection || assigning}>
-              {assigning ? 'Assigning…' : 'Use This Folder'}
+            <button
+              type="submit"
+              className="btn"
+              disabled={isSettingsMode ? !canConfirmSettings : !activeSelection || assigning}
+            >
+              {isSettingsMode ? 'Apply selection' : assigning ? 'Assigning…' : 'Use This Folder'}
             </button>
           </div>
         </form>

--- a/frontend/src/components/__tests__/FolderFinderModal.test.jsx
+++ b/frontend/src/components/__tests__/FolderFinderModal.test.jsx
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import FolderFinderModal from '../FolderFinderModal.jsx';
+
+describe('FolderFinderModal - settings mode', () => {
+  beforeEach(() => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          parent: '',
+          items: [
+            { name: 'Assets', path: 'Assets', isDir: true },
+            { name: 'Collections', path: 'Collections', isDir: true },
+          ],
+        }),
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('allows selecting an asset folder and confirms with payload', async () => {
+    const onSettingsConfirm = vi.fn();
+
+    render(
+      <FolderFinderModal
+        isOpen
+        context="settings"
+        library="Movies"
+        settingsLibraries={['Movies', 'TV Shows']}
+        defaultTarget="asset"
+        settingsIntent="asset"
+        onClose={vi.fn()}
+        onSettingsConfirm={onSettingsConfirm}
+      />
+    );
+
+    const option = await screen.findByRole('button', { name: 'Assets' });
+    fireEvent.click(option);
+
+    const confirmButton = screen.getByRole('button', { name: /Apply selection/i });
+    fireEvent.click(confirmButton);
+
+    await waitFor(() => {
+      expect(onSettingsConfirm).toHaveBeenCalledWith(
+        { assetPath: 'Assets' },
+        expect.objectContaining({ assetSelection: expect.any(Object) })
+      );
+    });
+  });
+});

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -104,6 +104,25 @@ a.btn:focus,
   cursor: pointer;
 }
 
+.btn-secondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--muted);
+  padding: 8px 10px;
+  cursor: pointer;
+}
+
+.btn-secondary:hover,
+.btn-secondary:focus {
+  color: var(--accent);
+  border-color: var(--accent);
+  outline: none;
+}
+
 .page-header-tools {
   display: flex;
   gap: 8px;
@@ -819,6 +838,8 @@ main {
 .settings-actions {
   display: flex;
   justify-content: flex-end;
+  gap: 12px;
+  flex-wrap: wrap;
 }
 
 .settings-status {
@@ -835,6 +856,169 @@ main {
 .settings-status.error {
   background: rgba(248, 113, 113, 0.1);
   color: #fca5a5;
+}
+
+.settings-status.info {
+  background: rgba(94, 161, 255, 0.12);
+  color: #93c5fd;
+}
+
+.settings-libraries-toolbar {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.settings-libraries-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.settings-libraries-toolbar button,
+.library-actions button {
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--fg);
+  border-radius: 10px;
+  padding: 6px 10px;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.settings-libraries-toolbar button:hover,
+.settings-libraries-toolbar button:focus,
+.library-actions button:hover,
+.library-actions button:focus {
+  border-color: var(--accent);
+  color: var(--accent);
+  outline: none;
+}
+
+.settings-libraries-table-wrapper {
+  overflow-x: auto;
+}
+
+.settings-libraries-status {
+  margin: 0 0 12px;
+  color: var(--muted);
+}
+
+.settings-libraries-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 640px;
+}
+
+.settings-libraries-table th,
+.settings-libraries-table td {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border);
+  text-align: left;
+  vertical-align: top;
+}
+
+.settings-libraries-table tbody tr:last-child th,
+.settings-libraries-table tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+.settings-libraries-table code {
+  font-size: 13px;
+  word-break: break-all;
+}
+
+.settings-libraries-table tr.is-dirty {
+  background: rgba(94, 161, 255, 0.08);
+}
+
+.library-select {
+  width: 48px;
+  text-align: center;
+}
+
+.library-name {
+  font-weight: 600;
+}
+
+.library-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 4px;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.library-tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.placeholder {
+  color: var(--muted);
+  font-style: italic;
+}
+
+.status-unsaved {
+  color: #fca5a5;
+  font-weight: 600;
+}
+
+.library-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+@media (min-width: 640px) {
+  .settings-libraries-toolbar {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+  }
+}
+
+@media (min-width: 768px) {
+  .library-actions {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+}
+
+.folder-targets {
+  display: inline-flex;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.folder-targets button {
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--fg);
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 13px;
+}
+
+.folder-targets button.is-active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #0b0b0f;
+}
+
+[data-theme='light'] .folder-targets button.is-active {
+  color: #ffffff;
+}
+
+.folder-targets button:hover,
+.folder-targets button:focus {
+  border-color: var(--accent);
+  color: var(--accent);
+  outline: none;
 }
 
 .asset-actions input[type='file'] {

--- a/frontend/src/pages/SettingsPage.jsx
+++ b/frontend/src/pages/SettingsPage.jsx
@@ -1,6 +1,47 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
+import FolderFinderModal from '../components/FolderFinderModal.jsx';
 import { useTheme } from '../theme/ThemeProvider.jsx';
+
+const initialModalState = {
+  open: false,
+  libraries: [],
+  primaryLibrary: '',
+  intent: 'asset',
+  defaultTarget: 'asset',
+  initialAssetPath: '',
+  initialCollectionsPath: '',
+};
+
+const normalizeText = (value) => {
+  if (value == null) return '';
+  const text = String(value).trim();
+  return text;
+};
+
+const canonicalizeMappings = (raw) => {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .map((entry) => ({
+      library: normalizeText(entry?.library ?? entry?.name),
+      assetPath: normalizeText(entry?.assetPath),
+      collectionsPath: normalizeText(entry?.collectionsPath),
+    }))
+    .filter((entry) => entry.library && entry.assetPath)
+    .sort((a, b) => a.library.localeCompare(b.library));
+};
+
+const areMappingsEqual = (left, right) => {
+  const a = canonicalizeMappings(left);
+  const b = canonicalizeMappings(right);
+  if (a.length !== b.length) return false;
+  return a.every(
+    (entry, index) =>
+      entry.library === b[index].library &&
+      entry.assetPath === b[index].assetPath &&
+      normalizeText(entry.collectionsPath) === normalizeText(b[index].collectionsPath)
+  );
+};
 
 function SettingsPage() {
   const {
@@ -9,6 +50,11 @@ function SettingsPage() {
     plexUrl,
     plexToken,
     savedSettings,
+    libraryMappings,
+    savedLibraryMappings,
+    libraries,
+    librariesLoading,
+    librariesError,
     loading,
     saving,
     error,
@@ -16,8 +62,16 @@ function SettingsPage() {
     updateSettings,
     saveSettings,
     revertSettings,
+    refreshLibraries,
+    setLibraryMapping,
+    setLibraryMappings,
   } = useTheme();
+
   const [status, setStatus] = useState(null);
+  const [selectedLibraries, setSelectedLibraries] = useState([]);
+  const [modalState, setModalState] = useState(initialModalState);
+  const selectAllRef = useRef(null);
+
   const savedPlexUrl = savedSettings?.plexUrl || '';
   const savedPlexToken = savedSettings?.plexToken || '';
 
@@ -27,16 +81,111 @@ function SettingsPage() {
     }
   }, [error]);
 
+  useEffect(() => {
+    if (librariesError) {
+      setStatus({ type: 'error', message: librariesError });
+    }
+  }, [librariesError]);
+
   const busy = loading || saving;
+  const combinedBusy = busy || librariesLoading;
+
+  const libraryRows = useMemo(() => {
+    const infoMap = new Map(
+      (Array.isArray(libraries) ? libraries : []).map((entry) => [
+        normalizeText(entry.name),
+        {
+          name: normalizeText(entry.name),
+          type: normalizeText(entry.type),
+          key: normalizeText(entry.key),
+          assetPath: normalizeText(entry.assetPath),
+          collectionsPath: normalizeText(entry.collectionsPath),
+        },
+      ])
+    );
+    const currentMap = new Map(
+      canonicalizeMappings(libraryMappings).map((entry) => [entry.library, entry])
+    );
+    const savedMap = new Map(
+      canonicalizeMappings(savedLibraryMappings).map((entry) => [entry.library, entry])
+    );
+    const names = new Set([
+      ...infoMap.keys(),
+      ...currentMap.keys(),
+      ...savedMap.keys(),
+    ]);
+
+    return Array.from(names)
+      .filter(Boolean)
+      .sort((a, b) => a.localeCompare(b))
+      .map((name) => {
+        const info = infoMap.get(name) || { name, type: '', key: '', assetPath: '', collectionsPath: '' };
+        const current = currentMap.get(name);
+        const saved = savedMap.get(name);
+        const assetPath = normalizeText(current?.assetPath ?? info.assetPath);
+        const collectionsPath = normalizeText(current?.collectionsPath ?? info.collectionsPath);
+        const savedAssetPath = normalizeText(saved?.assetPath ?? info.assetPath);
+        const savedCollectionsPath = normalizeText(saved?.collectionsPath ?? info.collectionsPath);
+        const isDirty =
+          assetPath !== savedAssetPath || normalizeText(collectionsPath) !== normalizeText(savedCollectionsPath);
+        return {
+          name,
+          type: info.type,
+          key: info.key,
+          assetPath,
+          collectionsPath,
+          savedAssetPath,
+          savedCollectionsPath,
+          isDirty,
+        };
+      });
+  }, [libraries, libraryMappings, savedLibraryMappings]);
+
+  const libraryRowMap = useMemo(() => new Map(libraryRows.map((row) => [row.name, row])), [libraryRows]);
+
+  useEffect(() => {
+    if (!selectAllRef.current) return;
+    const total = libraryRows.length;
+    const selected = selectedLibraries.length;
+    selectAllRef.current.indeterminate = selected > 0 && selected < total;
+  }, [selectedLibraries, libraryRows.length]);
+
+  useEffect(() => {
+    const available = new Set(libraryRows.map((row) => row.name));
+    setSelectedLibraries((prev) => {
+      const filtered = prev.filter((name) => available.has(name));
+      if (
+        filtered.length === prev.length &&
+        filtered.every((name, index) => name === prev[index])
+      ) {
+        return prev;
+      }
+      return filtered;
+    });
+  }, [libraryRows]);
+
+  const mappingsDirty = useMemo(
+    () => !areMappingsEqual(libraryMappings, savedLibraryMappings),
+    [libraryMappings, savedLibraryMappings]
+  );
+
   const isDirty = useMemo(() => {
     return (
-      theme !== savedTheme || plexUrl !== savedPlexUrl || plexToken !== savedPlexToken
+      theme !== savedTheme ||
+      plexUrl !== savedPlexUrl ||
+      plexToken !== savedPlexToken ||
+      mappingsDirty
     );
-  }, [theme, savedTheme, plexUrl, savedPlexUrl, plexToken, savedPlexToken]);
+  }, [theme, savedTheme, plexUrl, savedPlexUrl, plexToken, savedPlexToken, mappingsDirty]);
+
+  const selectedRows = selectedLibraries
+    .map((name) => libraryRowMap.get(name))
+    .filter(Boolean);
+  const selectionHasAsset = selectedRows.length > 0 && selectedRows.every((row) => row.assetPath);
+  const selectionHasCollections = selectedRows.some((row) => row.collectionsPath);
 
   const handleThemeChange = (event) => {
-    const next = event.target.value;
-    applyTheme(next);
+    applyTheme(event.target.value);
     setStatus(null);
   };
 
@@ -48,6 +197,199 @@ function SettingsPage() {
   const handlePlexTokenChange = (event) => {
     updateSettings({ plexToken: event.target.value });
     setStatus(null);
+  };
+
+  const handleToggleLibrary = (libraryName) => {
+    setStatus(null);
+    setSelectedLibraries((prev) =>
+      prev.includes(libraryName)
+        ? prev.filter((item) => item !== libraryName)
+        : [...prev, libraryName]
+    );
+  };
+
+  const handleToggleAll = (event) => {
+    setStatus(null);
+    if (event.target.checked) {
+      setSelectedLibraries(libraryRows.map((row) => row.name));
+    } else {
+      setSelectedLibraries([]);
+    }
+  };
+
+  const closeModal = () => {
+    setModalState(initialModalState);
+  };
+
+  const openModal = (librariesList, intent, defaultTarget) => {
+    const uniqueNames = Array.from(new Set(librariesList.map((name) => normalizeText(name)).filter(Boolean)));
+    if (!uniqueNames.length) {
+      setStatus({ type: 'error', message: 'Select at least one library first.' });
+      return;
+    }
+    const primary = uniqueNames[0];
+    const primaryRow = libraryRowMap.get(primary);
+    setStatus(null);
+    setModalState({
+      open: true,
+      libraries: uniqueNames,
+      primaryLibrary: primary,
+      intent: intent || 'asset',
+      defaultTarget: defaultTarget || (intent === 'collections' ? 'collections' : 'asset'),
+      initialAssetPath: primaryRow?.assetPath || '',
+      initialCollectionsPath: primaryRow?.collectionsPath || '',
+    });
+  };
+
+  const handleModalConfirm = (values, meta = {}) => {
+    const target = modalState.intent || 'asset';
+    const names = modalState.libraries;
+    const assetPath = normalizeText(values?.assetPath);
+    const collectionsPath =
+      values?.collectionsPath === undefined ? undefined : normalizeText(values.collectionsPath);
+
+    if (!names.length) {
+      closeModal();
+      return;
+    }
+
+    if (target !== 'collections' && !assetPath) {
+      setStatus({ type: 'error', message: 'Select an asset folder before applying changes.' });
+      return;
+    }
+    if (target !== 'asset' && collectionsPath === undefined) {
+      setStatus({ type: 'error', message: 'Select a collections folder before applying changes.' });
+      return;
+    }
+
+    if (target === 'collections') {
+      setLibraryMappings(names, { collectionsPath });
+      setStatus({
+        type: 'success',
+        message:
+          names.length > 1
+            ? `Updated collections folders for ${names.length} libraries.`
+            : `Updated collections folder for ${names[0]}.`,
+      });
+    } else {
+      const updates = collectionsPath === undefined ? { assetPath } : { assetPath, collectionsPath };
+      setLibraryMappings(names, updates);
+      const folderName = meta?.assetSelection?.name || meta?.assetSelection?.path || assetPath;
+      setStatus({
+        type: 'success',
+        message:
+          names.length > 1
+            ? `Applied ${folderName || 'selected folder'} to ${names.length} libraries.`
+            : `Updated asset folder for ${names[0]}.`,
+      });
+    }
+
+    closeModal();
+  };
+
+  const handleOpenAssetModal = (libraryName) => {
+    openModal([libraryName], 'asset', 'asset');
+  };
+
+  const handleOpenCollectionsModal = (libraryName) => {
+    const row = libraryRowMap.get(libraryName);
+    if (!row?.assetPath) {
+      setStatus({
+        type: 'error',
+        message: `${libraryName} needs an asset folder before setting a collections folder.`,
+      });
+      return;
+    }
+    openModal([libraryName], 'collections', 'collections');
+  };
+
+  const handleApplyAssetToSelection = () => {
+    if (!selectedLibraries.length) {
+      setStatus({ type: 'error', message: 'Select one or more libraries first.' });
+      return;
+    }
+    openModal(selectedLibraries, 'asset', 'asset');
+  };
+
+  const handleApplyCollectionsToSelection = () => {
+    if (!selectedLibraries.length) {
+      setStatus({ type: 'error', message: 'Select one or more libraries first.' });
+      return;
+    }
+    if (!selectionHasAsset) {
+      setStatus({
+        type: 'error',
+        message: 'All selected libraries need asset folders before setting collections folders.',
+      });
+      return;
+    }
+    openModal(selectedLibraries, 'collections', 'collections');
+  };
+
+  const handleClearCollections = (libraryName) => {
+    const row = libraryRowMap.get(libraryName);
+    if (!row?.assetPath) {
+      setStatus({
+        type: 'error',
+        message: `${libraryName} must have an asset folder before clearing collections.`,
+      });
+      return;
+    }
+    setLibraryMapping(libraryName, { collectionsPath: '' });
+    setStatus({
+      type: 'success',
+      message: `Cleared collections folder for ${libraryName}.`,
+    });
+  };
+
+  const handleClearCollectionsSelected = () => {
+    if (!selectionHasCollections) {
+      setStatus({ type: 'error', message: 'Select libraries with collections folders to clear.' });
+      return;
+    }
+    const rowsToClear = selectedRows.filter((row) => row.collectionsPath);
+    rowsToClear.forEach((row) => {
+      setLibraryMapping(row.name, { collectionsPath: '' });
+    });
+    setStatus({
+      type: 'success',
+      message: `Cleared collections folders for ${rowsToClear.length} libraries.`,
+    });
+  };
+
+  const handleClearMapping = (libraryName) => {
+    const row = libraryRowMap.get(libraryName);
+    if (!row?.assetPath) {
+      setStatus({ type: 'error', message: `${libraryName} does not have an asset folder to clear.` });
+      return;
+    }
+    setLibraryMapping(libraryName, { assetPath: '', collectionsPath: '' });
+    setStatus({ type: 'success', message: `Cleared mapping for ${libraryName}.` });
+  };
+
+  const handleClearMappingsSelected = () => {
+    const rowsToClear = selectedRows.filter((row) => row.assetPath);
+    if (!rowsToClear.length) {
+      setStatus({ type: 'error', message: 'Select libraries with asset folders to clear mappings.' });
+      return;
+    }
+    rowsToClear.forEach((row) => {
+      setLibraryMapping(row.name, { assetPath: '', collectionsPath: '' });
+    });
+    setStatus({
+      type: 'success',
+      message: `Cleared mappings for ${rowsToClear.length} libraries.`,
+    });
+  };
+
+  const handleRefreshLibraries = async () => {
+    setStatus(null);
+    try {
+      await refreshLibraries();
+      setStatus({ type: 'success', message: 'Plex libraries refreshed.' });
+    } catch (err) {
+      setStatus({ type: 'error', message: err?.message || 'Failed to refresh libraries.' });
+    }
   };
 
   const handleSubmit = async (event) => {
@@ -65,6 +407,12 @@ function SettingsPage() {
       revertSettings();
       setStatus({ type: 'error', message });
     }
+  };
+
+  const handleRevert = () => {
+    revertSettings();
+    setSelectedLibraries([]);
+    setStatus({ type: 'success', message: 'Changes reverted.' });
   };
 
   return (
@@ -139,19 +487,182 @@ function SettingsPage() {
               <button type="submit" className="btn" disabled={busy || !isDirty}>
                 Save Changes
               </button>
+              <button
+                type="button"
+                className="btn-secondary"
+                onClick={handleRevert}
+                disabled={busy || !isDirty}
+              >
+                Revert
+              </button>
             </div>
           </form>
-          {status ? (
-            <div
-              className={`settings-status ${status.type}`}
-              role={status.type === 'error' ? 'alert' : 'status'}
-              aria-live="polite"
-            >
-              {status.message}
-            </div>
-          ) : null}
         </section>
+
+        <section className="settings-card">
+          <h2>Plex Libraries</h2>
+          <p className="settings-description">
+            Map Plex libraries to asset folders. Use the controls below to assign folders, apply paths to
+            multiple libraries, and manage optional collections folders.
+          </p>
+          <div className="settings-libraries-toolbar">
+            <div className="settings-libraries-group">
+              <button
+                type="button"
+                onClick={handleApplyAssetToSelection}
+                disabled={!selectedLibraries.length || combinedBusy}
+              >
+                Set asset folder for selected
+              </button>
+              <button
+                type="button"
+                onClick={handleApplyCollectionsToSelection}
+                disabled={!selectedLibraries.length || !selectionHasAsset || combinedBusy}
+              >
+                Set collections folder for selected
+              </button>
+              <button
+                type="button"
+                onClick={handleClearCollectionsSelected}
+                disabled={!selectionHasCollections || combinedBusy}
+              >
+                Clear collections folders
+              </button>
+              <button
+                type="button"
+                onClick={handleClearMappingsSelected}
+                disabled={!selectedRows.some((row) => row.assetPath) || combinedBusy}
+              >
+                Clear mappings
+              </button>
+            </div>
+            <div className="settings-libraries-group">
+              <button type="button" onClick={handleRefreshLibraries} disabled={combinedBusy}>
+                {librariesLoading ? 'Refreshing…' : 'Refresh libraries'}
+              </button>
+            </div>
+          </div>
+          <div className="settings-libraries-table-wrapper" aria-live="polite">
+            {librariesLoading ? <p className="settings-libraries-status">Loading libraries…</p> : null}
+            {!librariesLoading && !libraryRows.length ? (
+              <p className="settings-libraries-status">No libraries are available. Configure Plex and refresh.</p>
+            ) : null}
+            {libraryRows.length ? (
+              <table className="settings-libraries-table">
+                <thead>
+                  <tr>
+                    <th scope="col" className="library-select">
+                      <input
+                        type="checkbox"
+                        ref={selectAllRef}
+                        checked={libraryRows.length > 0 && selectedLibraries.length === libraryRows.length}
+                        onChange={handleToggleAll}
+                        disabled={!libraryRows.length || combinedBusy}
+                        aria-label="Select all libraries"
+                      />
+                    </th>
+                    <th scope="col">Library</th>
+                    <th scope="col">Asset folder</th>
+                    <th scope="col">Collections folder</th>
+                    <th scope="col">Status</th>
+                    <th scope="col" className="library-actions">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {libraryRows.map((row) => {
+                    const isSelected = selectedLibraries.includes(row.name);
+                    return (
+                      <tr key={row.name} className={row.isDirty ? 'is-dirty' : undefined}>
+                        <td className="library-select">
+                          <input
+                            type="checkbox"
+                            checked={isSelected}
+                            onChange={() => handleToggleLibrary(row.name)}
+                            disabled={combinedBusy}
+                            aria-label={`Select ${row.name}`}
+                          />
+                        </td>
+                        <th scope="row">
+                          <div className="library-name">{row.name}</div>
+                          <div className="library-meta">
+                            {row.type ? <span className="library-tag">{row.type}</span> : null}
+                            {row.key ? <span className="library-tag">Key {row.key}</span> : null}
+                          </div>
+                        </th>
+                        <td>
+                          {row.assetPath ? <code>{row.assetPath}</code> : <span className="placeholder">Not set</span>}
+                        </td>
+                        <td>
+                          {row.collectionsPath ? (
+                            <code>{row.collectionsPath}</code>
+                          ) : (
+                            <span className="placeholder">Not set</span>
+                          )}
+                        </td>
+                        <td>
+                          {row.isDirty ? <span className="status-unsaved">Unsaved changes</span> : <span>Saved</span>}
+                        </td>
+                        <td className="library-actions">
+                          <button
+                            type="button"
+                            onClick={() => handleOpenAssetModal(row.name)}
+                            disabled={combinedBusy}
+                          >
+                            Set asset folder
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => handleOpenCollectionsModal(row.name)}
+                            disabled={combinedBusy || !row.assetPath}
+                          >
+                            Set collections folder
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => handleClearCollections(row.name)}
+                            disabled={combinedBusy || !row.collectionsPath}
+                          >
+                            Clear collections
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => handleClearMapping(row.name)}
+                            disabled={combinedBusy || !row.assetPath}
+                          >
+                            Clear mapping
+                          </button>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            ) : null}
+          </div>
+        </section>
+
+        {status ? (
+          <div
+            className={`settings-status ${status.type}`}
+            role={status.type === 'error' ? 'alert' : 'status'}
+            aria-live="polite"
+          >
+            {status.message}
+          </div>
+        ) : null}
       </main>
+      <FolderFinderModal
+        isOpen={modalState.open}
+        context="settings"
+        library={modalState.primaryLibrary}
+        settingsLibraries={modalState.libraries}
+        defaultTarget={modalState.defaultTarget}
+        settingsIntent={modalState.intent}
+        initialAssetPath={modalState.initialAssetPath}
+        initialCollectionsPath={modalState.initialCollectionsPath}
+        onClose={closeModal}
+        onSettingsConfirm={handleModalConfirm}
+      />
     </div>
   );
 }

--- a/frontend/src/pages/__tests__/SettingsPage.test.jsx
+++ b/frontend/src/pages/__tests__/SettingsPage.test.jsx
@@ -1,0 +1,144 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import SettingsPage from '../SettingsPage.jsx';
+import { useTheme } from '../../theme/ThemeProvider.jsx';
+
+vi.mock('../../theme/ThemeProvider.jsx', () => ({
+  useTheme: vi.fn(),
+}));
+
+describe('SettingsPage', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  beforeEach(() => {
+    global.fetch = vi.fn();
+  });
+
+  it('renders plex libraries and enables bulk actions after selection', () => {
+    const mockSave = vi.fn().mockResolvedValue({});
+    const mockRefresh = vi.fn().mockResolvedValue([]);
+    useTheme.mockReturnValue({
+      theme: 'dark',
+      savedTheme: 'dark',
+      plexUrl: 'http://plex.local',
+      plexToken: 'token',
+      savedSettings: { plexUrl: 'http://plex.local', plexToken: 'token' },
+      libraryMappings: [
+        { library: 'Movies', assetPath: '/assets/Movies', collectionsPath: '' },
+      ],
+      savedLibraryMappings: [
+        { library: 'Movies', assetPath: '/assets/Movies', collectionsPath: '' },
+      ],
+      libraries: [
+        { name: 'Movies', type: 'movie', key: '1', assetPath: '/assets/Movies', collectionsPath: '' },
+        { name: 'TV Shows', type: 'show', key: '2', assetPath: '', collectionsPath: '' },
+      ],
+      librariesLoading: false,
+      librariesError: null,
+      loading: false,
+      saving: false,
+      error: null,
+      applyTheme: vi.fn(),
+      updateSettings: vi.fn(),
+      saveSettings: mockSave,
+      revertSettings: vi.fn(),
+      refreshLibraries: mockRefresh,
+      setLibraryMapping: vi.fn(),
+      setLibraryMappings: vi.fn(),
+    });
+
+    render(
+      <MemoryRouter>
+        <SettingsPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('heading', { name: /Plex Libraries/i })).toBeInTheDocument();
+    expect(screen.getByText('Movies')).toBeInTheDocument();
+
+    const bulkButton = screen.getByRole('button', { name: /Set asset folder for selected/i });
+    expect(bulkButton).toBeDisabled();
+
+    const moviesCheckbox = screen.getByLabelText('Select Movies');
+    fireEvent.click(moviesCheckbox);
+    expect(moviesCheckbox).toBeChecked();
+    expect(bulkButton).not.toBeDisabled();
+
+    const revertButton = screen.getByRole('button', { name: /Revert/i });
+    expect(revertButton).toBeDisabled();
+  });
+
+  it('surfaces library errors in the status message', () => {
+    useTheme.mockReturnValue({
+      theme: 'dark',
+      savedTheme: 'dark',
+      plexUrl: '',
+      plexToken: '',
+      savedSettings: { plexUrl: '', plexToken: '' },
+      libraryMappings: [],
+      savedLibraryMappings: [],
+      libraries: [],
+      librariesLoading: false,
+      librariesError: 'Unable to load libraries',
+      loading: false,
+      saving: false,
+      error: null,
+      applyTheme: vi.fn(),
+      updateSettings: vi.fn(),
+      saveSettings: vi.fn(),
+      revertSettings: vi.fn(),
+      refreshLibraries: vi.fn(),
+      setLibraryMapping: vi.fn(),
+      setLibraryMappings: vi.fn(),
+    });
+
+    render(
+      <MemoryRouter>
+        <SettingsPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Unable to load libraries');
+  });
+
+  it('invokes refreshLibraries and reports success when refreshing', async () => {
+    const mockRefresh = vi.fn().mockResolvedValue([]);
+    useTheme.mockReturnValue({
+      theme: 'dark',
+      savedTheme: 'dark',
+      plexUrl: '',
+      plexToken: '',
+      savedSettings: { plexUrl: '', plexToken: '' },
+      libraryMappings: [],
+      savedLibraryMappings: [],
+      libraries: [],
+      librariesLoading: false,
+      librariesError: null,
+      loading: false,
+      saving: false,
+      error: null,
+      applyTheme: vi.fn(),
+      updateSettings: vi.fn(),
+      saveSettings: vi.fn().mockResolvedValue({}),
+      revertSettings: vi.fn(),
+      refreshLibraries: mockRefresh,
+      setLibraryMapping: vi.fn(),
+      setLibraryMappings: vi.fn(),
+    });
+
+    render(
+      <MemoryRouter>
+        <SettingsPage />
+      </MemoryRouter>
+    );
+
+    const refreshButton = screen.getByRole('button', { name: /Refresh libraries/i });
+    fireEvent.click(refreshButton);
+
+    expect(mockRefresh).toHaveBeenCalled();
+    expect(await screen.findByRole('status')).toHaveTextContent('Plex libraries refreshed.');
+  });
+});

--- a/frontend/src/setupTests.js
+++ b/frontend/src/setupTests.js
@@ -1,0 +1,7 @@
+import '@testing-library/jest-dom/vitest';
+import { afterEach } from 'vitest';
+import { cleanup } from '@testing-library/react';
+
+afterEach(() => {
+  cleanup();
+});

--- a/frontend/src/theme/ThemeProvider.jsx
+++ b/frontend/src/theme/ThemeProvider.jsx
@@ -2,14 +2,19 @@ import { createContext, useCallback, useContext, useEffect, useMemo, useRef, use
 import { responseErrorMessage, safeJson } from '../utils/api.js';
 
 const ThemeContext = createContext({
-  settings: { theme: 'dark', plexUrl: '', plexToken: '' },
-  savedSettings: { theme: 'dark', plexUrl: '', plexToken: '' },
+  settings: { theme: 'dark', plexUrl: '', plexToken: '', libraryMappings: [] },
+  savedSettings: { theme: 'dark', plexUrl: '', plexToken: '', libraryMappings: [] },
   theme: 'dark',
   savedTheme: 'dark',
   plexUrl: '',
   plexToken: '',
   savedPlexUrl: '',
   savedPlexToken: '',
+  libraryMappings: [],
+  savedLibraryMappings: [],
+  libraries: [],
+  librariesLoading: false,
+  librariesError: null,
   loading: false,
   saving: false,
   error: null,
@@ -21,9 +26,65 @@ const ThemeContext = createContext({
   saveTheme: async () => 'dark',
   refreshTheme: async () => 'dark',
   revertTheme: () => {},
+  refreshLibraries: async () => [],
+  setLibraryMapping: () => {},
+  setLibraryMappings: () => {},
 });
 
 const normalizeTheme = (value) => (value === 'light' ? 'light' : 'dark');
+
+const normalizePath = (value) => {
+  if (value == null) return '';
+  const text = String(value).trim();
+  if (!text) return '';
+  return text.replace(/\\+/g, '/');
+};
+
+const sanitizeLibraryMappings = (raw = []) => {
+  if (!raw) return [];
+  const entries = Array.isArray(raw) ? raw : [];
+  const byLibrary = new Map();
+  entries.forEach((entry) => {
+    if (!entry || typeof entry !== 'object') return;
+    const libraryValue = entry.library ?? entry.name ?? '';
+    const library = typeof libraryValue === 'string' ? libraryValue.trim() : '';
+    if (!library) return;
+    const assetPathValue = normalizePath(entry.assetPath ?? entry.path ?? entry.assetFolder);
+    if (!assetPathValue) return;
+    const collectionsPathValue = normalizePath(entry.collectionsPath ?? entry.collectionPath);
+    byLibrary.set(library, {
+      library,
+      assetPath: assetPathValue,
+      collectionsPath: collectionsPathValue,
+    });
+  });
+  return Array.from(byLibrary.values()).sort((a, b) => a.library.localeCompare(b.library));
+};
+
+const sanitizeLibrariesList = (raw) => {
+  if (!raw) return [];
+  const entries = Array.isArray(raw) ? raw : [];
+  return entries
+    .map((entry) => {
+      if (!entry || typeof entry !== 'object') return null;
+      const nameValue = entry.name ?? entry.library ?? '';
+      const name = typeof nameValue === 'string' ? nameValue.trim() : '';
+      if (!name) return null;
+      const typeValue = entry.type ?? entry.libraryType ?? null;
+      const keyValue = entry.key ?? entry.id ?? null;
+      const assetPathValue = normalizePath(entry.assetPath);
+      const collectionsPathValue = normalizePath(entry.collectionsPath);
+      return {
+        name,
+        type: typeValue ? String(typeValue) : null,
+        key: keyValue ? String(keyValue) : null,
+        assetPath: assetPathValue,
+        collectionsPath: collectionsPathValue,
+      };
+    })
+    .filter(Boolean)
+    .sort((a, b) => a.name.localeCompare(b.name));
+};
 
 const sanitizeSettings = (raw = {}) => {
   const themeValue = normalizeTheme(raw.theme);
@@ -44,16 +105,64 @@ const sanitizeSettings = (raw = {}) => {
         : plexTokenValue
         ? String(plexTokenValue)
         : '',
+    libraryMappings: sanitizeLibraryMappings(raw.libraryMappings),
   };
 };
 
 export function ThemeProvider({ children }) {
   const [settings, setSettings] = useState(() => sanitizeSettings());
   const [savedSettings, setSavedSettings] = useState(() => sanitizeSettings());
+  const [libraries, setLibraries] = useState([]);
+  const [librariesLoading, setLibrariesLoading] = useState(false);
+  const [librariesError, setLibrariesError] = useState(null);
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState(null);
   const isMountedRef = useRef(true);
+
+  const applyLibraryMappingUpdates = useCallback((libraryNames, updates) => {
+    const names = Array.isArray(libraryNames) ? libraryNames : [libraryNames];
+    if (!names.length) return;
+    const normalized = names
+      .map((name) => (typeof name === 'string' ? name.trim() : ''))
+      .filter(Boolean);
+    if (!normalized.length) return;
+    const payload = updates && typeof updates === 'object' ? updates : {};
+    setSettings((prev) => {
+      const base = sanitizeSettings(prev);
+      const nextMappings = normalized.reduce((acc, library) => {
+        const list = Array.isArray(acc) ? [...acc] : [];
+        const index = list.findIndex((entry) => entry.library === library);
+        const existing = index >= 0 ? list[index] : null;
+        const assetUpdate =
+          payload.assetPath === undefined
+            ? existing?.assetPath ?? ''
+            : normalizePath(payload.assetPath);
+        const collectionsUpdate =
+          payload.collectionsPath === undefined
+            ? existing?.collectionsPath ?? ''
+            : normalizePath(payload.collectionsPath);
+        if (!assetUpdate) {
+          if (index >= 0) {
+            list.splice(index, 1);
+          }
+          return sanitizeLibraryMappings(list);
+        }
+        const nextEntry = {
+          library,
+          assetPath: assetUpdate,
+          collectionsPath: collectionsUpdate,
+        };
+        if (index >= 0) {
+          list[index] = nextEntry;
+        } else {
+          list.push(nextEntry);
+        }
+        return sanitizeLibraryMappings(list);
+      }, base.libraryMappings);
+      return sanitizeSettings({ ...base, libraryMappings: nextMappings });
+    });
+  }, []);
 
   useEffect(() => {
     isMountedRef.current = true;
@@ -106,6 +215,36 @@ export function ThemeProvider({ children }) {
     }
   }, []);
 
+  const refreshLibraries = useCallback(async () => {
+    if (isMountedRef.current) {
+      setLibrariesLoading(true);
+      setLibrariesError(null);
+    }
+    try {
+      const response = await fetch('/api/settings/libraries');
+      const data = await safeJson(response);
+      if (!response.ok) {
+        throw new Error(responseErrorMessage(response, data));
+      }
+      const next = sanitizeLibrariesList(data);
+      if (isMountedRef.current) {
+        setLibraries(next);
+      }
+      return next;
+    } catch (err) {
+      const message = err?.message || 'Failed to load libraries';
+      if (isMountedRef.current) {
+        setLibraries([]);
+        setLibrariesError(message);
+      }
+      throw new Error(message);
+    } finally {
+      if (isMountedRef.current) {
+        setLibrariesLoading(false);
+      }
+    }
+  }, []);
+
   const saveSettings = useCallback(
     async (overrides = null) => {
       const payload = sanitizeSettings({ ...settings, ...(overrides ?? {}) });
@@ -128,6 +267,7 @@ export function ThemeProvider({ children }) {
           setSavedSettings(next);
           setSettings(next);
         }
+        await refreshLibraries().catch(() => {});
         return next;
       } catch (err) {
         const message = err?.message || 'Failed to save settings';
@@ -141,12 +281,16 @@ export function ThemeProvider({ children }) {
         }
       }
     },
-    [settings]
+    [settings, refreshLibraries]
   );
 
   useEffect(() => {
     refreshSettings().catch(() => {});
   }, [refreshSettings]);
+
+  useEffect(() => {
+    refreshLibraries().catch(() => {});
+  }, [refreshLibraries]);
 
   const revertSettings = useCallback(() => {
     if (!isMountedRef.current) return;
@@ -170,6 +314,20 @@ export function ThemeProvider({ children }) {
     revertSettings();
   }, [revertSettings]);
 
+  const setLibraryMapping = useCallback(
+    (libraryName, updates = {}) => {
+      applyLibraryMappingUpdates(libraryName, updates);
+    },
+    [applyLibraryMappingUpdates]
+  );
+
+  const setLibraryMappings = useCallback(
+    (libraryNames, updates = {}) => {
+      applyLibraryMappingUpdates(libraryNames, updates);
+    },
+    [applyLibraryMappingUpdates]
+  );
+
   const value = useMemo(
     () => ({
       settings,
@@ -180,6 +338,11 @@ export function ThemeProvider({ children }) {
       plexToken: settings.plexToken,
       savedPlexUrl: savedSettings.plexUrl,
       savedPlexToken: savedSettings.plexToken,
+      libraryMappings: settings.libraryMappings,
+      savedLibraryMappings: savedSettings.libraryMappings,
+      libraries,
+      librariesLoading,
+      librariesError,
       loading,
       saving,
       error,
@@ -191,10 +354,16 @@ export function ThemeProvider({ children }) {
       saveTheme,
       refreshTheme,
       revertTheme,
+      refreshLibraries,
+      setLibraryMapping,
+      setLibraryMappings,
     }),
     [
       settings,
       savedSettings,
+      libraries,
+      librariesLoading,
+      librariesError,
       loading,
       saving,
       error,
@@ -206,6 +375,9 @@ export function ThemeProvider({ children }) {
       saveTheme,
       refreshTheme,
       revertTheme,
+      refreshLibraries,
+      setLibraryMapping,
+      setLibraryMappings,
     ]
   );
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -81,4 +81,9 @@ export default defineConfig({
       "/fileproxy": "http://localhost:8000",
     },
   },
+  test: {
+    globals: true,
+    environment: "jsdom",
+    setupFiles: "./src/setupTests.js",
+  },
 });


### PR DESCRIPTION
## Summary
- extend the settings/theme provider to manage Plex library metadata and mapping state, including refresh helpers
- rebuild the settings page to show library mappings with bulk actions, folder selection, and status handling
- update the folder finder modal for settings workflows and add Vitest-based coverage and setup utilities

## Testing
- npm test *(fails: vitest is not installed because npm install was blocked by the registry policy)*

------
https://chatgpt.com/codex/tasks/task_e_68e1ceb9e7f88330b399f6b3bcc0b395