### PR TITLE
Enhance settings provider and UI for library mappings

### DIFF
--- a/frontend/src/components/FolderFinderModal.jsx
+++ b/frontend/src/components/FolderFinderModal.jsx
@@ -259,10 +259,9 @@ function FolderFinderModal({
   const resolvedCollectionsPath = collectionsSelection?.path || normalizedInitialCollections;
   const requireAsset = settingsIntent !== 'collections';
   const requireCollections = settingsIntent === 'collections';
-  const canConfirmSettings = (
+  const canConfirmSettings =
     (!requireAsset || Boolean(resolvedAssetPath)) &&
-    (!requireCollections || Boolean(resolvedCollectionsPath))
-  );
+    (!requireCollections || Boolean(resolvedCollectionsPath));
 
   const activeSelection = isSettingsMode
     ? target === 'collections'
@@ -286,17 +285,15 @@ function FolderFinderModal({
         return;
       }
       const payload = {};
-      if (requireAsset && resolvedAssetPath) {
+      if (requireAsset) {
         payload.assetPath = resolvedAssetPath;
-      } else if (!requireAsset && assetSelection?.path) {
+      } else if (assetSelection?.path) {
         payload.assetPath = assetSelection.path;
       }
-      if (settingsIntent !== 'asset') {
-        if (requireCollections && resolvedCollectionsPath) {
-          payload.collectionsPath = resolvedCollectionsPath;
-        } else if (!requireCollections && collectionsSelection?.path) {
-          payload.collectionsPath = collectionsSelection.path;
-        }
+      if (collectionsSelection?.path) {
+        payload.collectionsPath = collectionsSelection.path;
+      } else if (requireCollections && resolvedCollectionsPath) {
+        payload.collectionsPath = resolvedCollectionsPath;
       }
       onSettingsConfirm(payload, { assetSelection, collectionsSelection });
       return;

--- a/frontend/src/components/__tests__/FolderFinderModal.test.jsx
+++ b/frontend/src/components/__tests__/FolderFinderModal.test.jsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import FolderFinderModal from '../FolderFinderModal.jsx';
 
 describe('FolderFinderModal - settings mode', () => {
@@ -47,6 +47,46 @@ describe('FolderFinderModal - settings mode', () => {
       expect(onSettingsConfirm).toHaveBeenCalledWith(
         { assetPath: 'Assets' },
         expect.objectContaining({ assetSelection: expect.any(Object) })
+      );
+    });
+  });
+
+  it('returns both asset and collections selections when provided', async () => {
+    const onSettingsConfirm = vi.fn();
+
+    render(
+      <FolderFinderModal
+        isOpen
+        context="settings"
+        library="Movies"
+        settingsLibraries={['Movies']}
+        defaultTarget="asset"
+        settingsIntent="asset"
+        onClose={vi.fn()}
+        onSettingsConfirm={onSettingsConfirm}
+      />
+    );
+
+    const assetOption = await screen.findByRole('button', { name: 'Assets' });
+    fireEvent.click(assetOption);
+
+    const collectionsToggle = screen.getByRole('button', { name: /Collections folder/i });
+    fireEvent.click(collectionsToggle);
+
+    const results = await screen.findByRole('listbox');
+    const collectionsOption = within(results).getByRole('button', { name: 'Collections' });
+    fireEvent.click(collectionsOption);
+
+    const confirmButton = screen.getByRole('button', { name: /Apply selection/i });
+    fireEvent.click(confirmButton);
+
+    await waitFor(() => {
+      expect(onSettingsConfirm).toHaveBeenCalledWith(
+        { assetPath: 'Assets', collectionsPath: 'Collections' },
+        expect.objectContaining({
+          assetSelection: expect.any(Object),
+          collectionsSelection: expect.any(Object),
+        })
       );
     });
   });

--- a/frontend/src/pages/SettingsPage.jsx
+++ b/frontend/src/pages/SettingsPage.jsx
@@ -1,7 +1,13 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import FolderFinderModal from '../components/FolderFinderModal.jsx';
 import { useTheme } from '../theme/ThemeProvider.jsx';
+import {
+  areLibraryMappingsEqual,
+  createLibraryMappingLookup,
+  normalizeLibraryName,
+  normalizePathValue,
+} from '../utils/libraryMappings.js';
 
 const initialModalState = {
   open: false,
@@ -19,30 +25,6 @@ const normalizeText = (value) => {
   return text;
 };
 
-const canonicalizeMappings = (raw) => {
-  if (!Array.isArray(raw)) return [];
-  return raw
-    .map((entry) => ({
-      library: normalizeText(entry?.library ?? entry?.name),
-      assetPath: normalizeText(entry?.assetPath),
-      collectionsPath: normalizeText(entry?.collectionsPath),
-    }))
-    .filter((entry) => entry.library && entry.assetPath)
-    .sort((a, b) => a.library.localeCompare(b.library));
-};
-
-const areMappingsEqual = (left, right) => {
-  const a = canonicalizeMappings(left);
-  const b = canonicalizeMappings(right);
-  if (a.length !== b.length) return false;
-  return a.every(
-    (entry, index) =>
-      entry.library === b[index].library &&
-      entry.assetPath === b[index].assetPath &&
-      normalizeText(entry.collectionsPath) === normalizeText(b[index].collectionsPath)
-  );
-};
-
 function SettingsPage() {
   const {
     theme,
@@ -58,6 +40,8 @@ function SettingsPage() {
     loading,
     saving,
     error,
+    libraryMappingsDirty,
+    hasUnsavedChanges,
     applyTheme,
     updateSettings,
     saveSettings,
@@ -87,47 +71,78 @@ function SettingsPage() {
     }
   }, [librariesError]);
 
+  const showInfoStatus = useCallback(
+    (message) => {
+      setStatus((prev) => {
+        if (prev?.type === 'error') {
+          return prev;
+        }
+        return { type: 'info', message };
+      });
+    },
+    []
+  );
+
+  useEffect(() => {
+    if (loading) {
+      showInfoStatus('Loading settings…');
+    }
+  }, [loading, showInfoStatus]);
+
+  useEffect(() => {
+    if (saving) {
+      showInfoStatus('Saving settings…');
+    }
+  }, [saving, showInfoStatus]);
+
+  useEffect(() => {
+    if (librariesLoading) {
+      showInfoStatus('Loading Plex libraries…');
+    }
+  }, [librariesLoading, showInfoStatus]);
+
   const busy = loading || saving;
   const combinedBusy = busy || librariesLoading;
 
   const libraryRows = useMemo(() => {
     const infoMap = new Map(
-      (Array.isArray(libraries) ? libraries : []).map((entry) => [
-        normalizeText(entry.name),
-        {
-          name: normalizeText(entry.name),
-          type: normalizeText(entry.type),
-          key: normalizeText(entry.key),
-          assetPath: normalizeText(entry.assetPath),
-          collectionsPath: normalizeText(entry.collectionsPath),
-        },
-      ])
+      (Array.isArray(libraries) ? libraries : []).map((entry) => {
+        const name = normalizeLibraryName(entry?.name ?? entry?.library);
+        return [
+          name,
+          {
+            name: normalizeText(entry?.name ?? entry?.library ?? name),
+            type: normalizeText(entry?.type ?? entry?.libraryType),
+            key: normalizeText(entry?.key ?? entry?.id),
+            assetPath: normalizePathValue(entry?.assetPath),
+            collectionsPath: normalizePathValue(entry?.collectionsPath),
+          },
+        ];
+      })
     );
-    const currentMap = new Map(
-      canonicalizeMappings(libraryMappings).map((entry) => [entry.library, entry])
-    );
-    const savedMap = new Map(
-      canonicalizeMappings(savedLibraryMappings).map((entry) => [entry.library, entry])
-    );
-    const names = new Set([
-      ...infoMap.keys(),
-      ...currentMap.keys(),
-      ...savedMap.keys(),
-    ]);
+    const currentMap = createLibraryMappingLookup(libraryMappings);
+    const savedMap = createLibraryMappingLookup(savedLibraryMappings);
+    const names = new Set([...infoMap.keys(), ...currentMap.keys(), ...savedMap.keys()]);
 
     return Array.from(names)
       .filter(Boolean)
       .sort((a, b) => a.localeCompare(b))
       .map((name) => {
-        const info = infoMap.get(name) || { name, type: '', key: '', assetPath: '', collectionsPath: '' };
+        const info =
+          infoMap.get(name) || {
+            name,
+            type: '',
+            key: '',
+            assetPath: '',
+            collectionsPath: '',
+          };
         const current = currentMap.get(name);
         const saved = savedMap.get(name);
-        const assetPath = normalizeText(current?.assetPath ?? info.assetPath);
-        const collectionsPath = normalizeText(current?.collectionsPath ?? info.collectionsPath);
-        const savedAssetPath = normalizeText(saved?.assetPath ?? info.assetPath);
-        const savedCollectionsPath = normalizeText(saved?.collectionsPath ?? info.collectionsPath);
-        const isDirty =
-          assetPath !== savedAssetPath || normalizeText(collectionsPath) !== normalizeText(savedCollectionsPath);
+        const assetPath = normalizePathValue(current?.assetPath ?? info.assetPath);
+        const collectionsPath = normalizePathValue(current?.collectionsPath ?? info.collectionsPath);
+        const savedAssetPath = normalizePathValue(saved?.assetPath ?? info.assetPath);
+        const savedCollectionsPath = normalizePathValue(saved?.collectionsPath ?? info.collectionsPath);
+        const isDirty = assetPath !== savedAssetPath || collectionsPath !== savedCollectionsPath;
         return {
           name,
           type: info.type,
@@ -164,19 +179,30 @@ function SettingsPage() {
     });
   }, [libraryRows]);
 
-  const mappingsDirty = useMemo(
-    () => !areMappingsEqual(libraryMappings, savedLibraryMappings),
-    [libraryMappings, savedLibraryMappings]
-  );
+  const mappingsDirty = useMemo(() => {
+    if (libraryMappingsDirty != null) {
+      return Boolean(libraryMappingsDirty);
+    }
+    return !areLibraryMappingsEqual(libraryMappings, savedLibraryMappings);
+  }, [libraryMappingsDirty, libraryMappings, savedLibraryMappings]);
 
   const isDirty = useMemo(() => {
-    return (
-      theme !== savedTheme ||
-      plexUrl !== savedPlexUrl ||
-      plexToken !== savedPlexToken ||
-      mappingsDirty
-    );
-  }, [theme, savedTheme, plexUrl, savedPlexUrl, plexToken, savedPlexToken, mappingsDirty]);
+    if (typeof hasUnsavedChanges === 'boolean') {
+      return hasUnsavedChanges;
+    }
+    const settingsChanged =
+      theme !== savedTheme || plexUrl !== savedPlexUrl || plexToken !== savedPlexToken;
+    return settingsChanged || mappingsDirty;
+  }, [
+    hasUnsavedChanges,
+    theme,
+    savedTheme,
+    plexUrl,
+    savedPlexUrl,
+    plexToken,
+    savedPlexToken,
+    mappingsDirty,
+  ]);
 
   const selectedRows = selectedLibraries
     .map((name) => libraryRowMap.get(name))

--- a/frontend/src/pages/__tests__/SettingsPage.test.jsx
+++ b/frontend/src/pages/__tests__/SettingsPage.test.jsx
@@ -41,6 +41,8 @@ describe('SettingsPage', () => {
       loading: false,
       saving: false,
       error: null,
+      libraryMappingsDirty: false,
+      hasUnsavedChanges: false,
       applyTheme: vi.fn(),
       updateSettings: vi.fn(),
       saveSettings: mockSave,
@@ -86,6 +88,8 @@ describe('SettingsPage', () => {
       loading: false,
       saving: false,
       error: null,
+      libraryMappingsDirty: false,
+      hasUnsavedChanges: false,
       applyTheme: vi.fn(),
       updateSettings: vi.fn(),
       saveSettings: vi.fn(),
@@ -120,6 +124,8 @@ describe('SettingsPage', () => {
       loading: false,
       saving: false,
       error: null,
+      libraryMappingsDirty: false,
+      hasUnsavedChanges: false,
       applyTheme: vi.fn(),
       updateSettings: vi.fn(),
       saveSettings: vi.fn().mockResolvedValue({}),
@@ -140,5 +146,117 @@ describe('SettingsPage', () => {
 
     expect(mockRefresh).toHaveBeenCalled();
     expect(await screen.findByRole('status')).toHaveTextContent('Plex libraries refreshed.');
+  });
+
+  it('shows loading status when settings are loading', async () => {
+    useTheme.mockReturnValue({
+      theme: 'dark',
+      savedTheme: 'dark',
+      plexUrl: '',
+      plexToken: '',
+      savedSettings: { plexUrl: '', plexToken: '' },
+      libraryMappings: [],
+      savedLibraryMappings: [],
+      libraries: [],
+      librariesLoading: false,
+      librariesError: null,
+      loading: true,
+      saving: false,
+      error: null,
+      libraryMappingsDirty: false,
+      hasUnsavedChanges: false,
+      applyTheme: vi.fn(),
+      updateSettings: vi.fn(),
+      saveSettings: vi.fn(),
+      revertSettings: vi.fn(),
+      refreshLibraries: vi.fn(),
+      setLibraryMapping: vi.fn(),
+      setLibraryMappings: vi.fn(),
+    });
+
+    render(
+      <MemoryRouter>
+        <SettingsPage />
+      </MemoryRouter>
+    );
+
+    const status = await screen.findByRole('status');
+    expect(status).toHaveTextContent('Loading settings…');
+  });
+
+  it('shows saving status while persisting changes', async () => {
+    useTheme.mockReturnValue({
+      theme: 'dark',
+      savedTheme: 'dark',
+      plexUrl: '',
+      plexToken: '',
+      savedSettings: { plexUrl: '', plexToken: '' },
+      libraryMappings: [],
+      savedLibraryMappings: [],
+      libraries: [],
+      librariesLoading: false,
+      librariesError: null,
+      loading: false,
+      saving: true,
+      error: null,
+      libraryMappingsDirty: false,
+      hasUnsavedChanges: true,
+      applyTheme: vi.fn(),
+      updateSettings: vi.fn(),
+      saveSettings: vi.fn(),
+      revertSettings: vi.fn(),
+      refreshLibraries: vi.fn(),
+      setLibraryMapping: vi.fn(),
+      setLibraryMappings: vi.fn(),
+    });
+
+    render(
+      <MemoryRouter>
+        <SettingsPage />
+      </MemoryRouter>
+    );
+
+    const status = await screen.findByRole('status');
+    expect(status).toHaveTextContent('Saving settings…');
+  });
+
+  it('displays success status after saving changes', async () => {
+    const mockSave = vi.fn().mockResolvedValue({});
+    useTheme.mockReturnValue({
+      theme: 'light',
+      savedTheme: 'dark',
+      plexUrl: '',
+      plexToken: '',
+      savedSettings: { plexUrl: '', plexToken: '' },
+      libraryMappings: [],
+      savedLibraryMappings: [],
+      libraries: [],
+      librariesLoading: false,
+      librariesError: null,
+      loading: false,
+      saving: false,
+      error: null,
+      libraryMappingsDirty: true,
+      hasUnsavedChanges: true,
+      applyTheme: vi.fn(),
+      updateSettings: vi.fn(),
+      saveSettings: mockSave,
+      revertSettings: vi.fn(),
+      refreshLibraries: vi.fn(),
+      setLibraryMapping: vi.fn(),
+      setLibraryMappings: vi.fn(),
+    });
+
+    render(
+      <MemoryRouter>
+        <SettingsPage />
+      </MemoryRouter>
+    );
+
+    const saveButton = screen.getByRole('button', { name: /Save Changes/i });
+    fireEvent.click(saveButton);
+
+    expect(mockSave).toHaveBeenCalled();
+    expect(await screen.findByRole('status')).toHaveTextContent('Settings saved successfully.');
   });
 });

--- a/frontend/src/theme/ThemeProvider.jsx
+++ b/frontend/src/theme/ThemeProvider.jsx
@@ -1,5 +1,12 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { responseErrorMessage, safeJson } from '../utils/api.js';
+import {
+  areLibraryMappingsEqual,
+  createLibraryMappingLookup,
+  normalizeLibraryName,
+  normalizePathValue,
+  sanitizeLibraryMappings,
+} from '../utils/libraryMappings.js';
 
 const ThemeContext = createContext({
   settings: { theme: 'dark', plexUrl: '', plexToken: '', libraryMappings: [] },
@@ -18,6 +25,9 @@ const ThemeContext = createContext({
   loading: false,
   saving: false,
   error: null,
+  settingsDirty: false,
+  libraryMappingsDirty: false,
+  hasUnsavedChanges: false,
   applyTheme: () => {},
   updateSettings: () => {},
   saveSettings: async () => ({ theme: 'dark', plexUrl: '', plexToken: '' }),
@@ -29,37 +39,12 @@ const ThemeContext = createContext({
   refreshLibraries: async () => [],
   setLibraryMapping: () => {},
   setLibraryMappings: () => {},
+  getLibraryMapping: () => null,
+  revertLibraryMapping: () => {},
+  revertLibraryMappings: () => {},
 });
 
 const normalizeTheme = (value) => (value === 'light' ? 'light' : 'dark');
-
-const normalizePath = (value) => {
-  if (value == null) return '';
-  const text = String(value).trim();
-  if (!text) return '';
-  return text.replace(/\\+/g, '/');
-};
-
-const sanitizeLibraryMappings = (raw = []) => {
-  if (!raw) return [];
-  const entries = Array.isArray(raw) ? raw : [];
-  const byLibrary = new Map();
-  entries.forEach((entry) => {
-    if (!entry || typeof entry !== 'object') return;
-    const libraryValue = entry.library ?? entry.name ?? '';
-    const library = typeof libraryValue === 'string' ? libraryValue.trim() : '';
-    if (!library) return;
-    const assetPathValue = normalizePath(entry.assetPath ?? entry.path ?? entry.assetFolder);
-    if (!assetPathValue) return;
-    const collectionsPathValue = normalizePath(entry.collectionsPath ?? entry.collectionPath);
-    byLibrary.set(library, {
-      library,
-      assetPath: assetPathValue,
-      collectionsPath: collectionsPathValue,
-    });
-  });
-  return Array.from(byLibrary.values()).sort((a, b) => a.library.localeCompare(b.library));
-};
 
 const sanitizeLibrariesList = (raw) => {
   if (!raw) return [];
@@ -72,8 +57,8 @@ const sanitizeLibrariesList = (raw) => {
       if (!name) return null;
       const typeValue = entry.type ?? entry.libraryType ?? null;
       const keyValue = entry.key ?? entry.id ?? null;
-      const assetPathValue = normalizePath(entry.assetPath);
-      const collectionsPathValue = normalizePath(entry.collectionsPath);
+      const assetPathValue = normalizePathValue(entry.assetPath);
+      const collectionsPathValue = normalizePathValue(entry.collectionsPath);
       return {
         name,
         type: typeValue ? String(typeValue) : null,
@@ -124,7 +109,7 @@ export function ThemeProvider({ children }) {
     const names = Array.isArray(libraryNames) ? libraryNames : [libraryNames];
     if (!names.length) return;
     const normalized = names
-      .map((name) => (typeof name === 'string' ? name.trim() : ''))
+      .map((name) => normalizeLibraryName(name))
       .filter(Boolean);
     if (!normalized.length) return;
     const payload = updates && typeof updates === 'object' ? updates : {};
@@ -137,11 +122,11 @@ export function ThemeProvider({ children }) {
         const assetUpdate =
           payload.assetPath === undefined
             ? existing?.assetPath ?? ''
-            : normalizePath(payload.assetPath);
+            : normalizePathValue(payload.assetPath);
         const collectionsUpdate =
           payload.collectionsPath === undefined
             ? existing?.collectionsPath ?? ''
-            : normalizePath(payload.collectionsPath);
+            : normalizePathValue(payload.collectionsPath);
         if (!assetUpdate) {
           if (index >= 0) {
             list.splice(index, 1);
@@ -297,6 +282,31 @@ export function ThemeProvider({ children }) {
     setSettings(sanitizeSettings(savedSettings));
   }, [savedSettings]);
 
+  const libraryMappingLookup = useMemo(
+    () => createLibraryMappingLookup(settings.libraryMappings),
+    [settings.libraryMappings]
+  );
+
+  const savedLibraryMappingLookup = useMemo(
+    () => createLibraryMappingLookup(savedSettings.libraryMappings),
+    [savedSettings.libraryMappings]
+  );
+
+  const libraryMappingsDirty = useMemo(
+    () => !areLibraryMappingsEqual(settings.libraryMappings, savedSettings.libraryMappings),
+    [settings.libraryMappings, savedSettings.libraryMappings]
+  );
+
+  const settingsDirty = useMemo(
+    () =>
+      settings.theme !== savedSettings.theme ||
+      settings.plexUrl !== savedSettings.plexUrl ||
+      settings.plexToken !== savedSettings.plexToken,
+    [settings, savedSettings]
+  );
+
+  const hasUnsavedChanges = settingsDirty || libraryMappingsDirty;
+
   const saveTheme = useCallback(
     async (value) => {
       const result = await saveSettings({ theme: value });
@@ -328,6 +338,64 @@ export function ThemeProvider({ children }) {
     [applyLibraryMappingUpdates]
   );
 
+  const getLibraryMapping = useCallback(
+    (libraryName) => {
+      const name = normalizeLibraryName(libraryName);
+      if (!name) return null;
+      const entry = libraryMappingLookup.get(name);
+      return entry ? { ...entry } : null;
+    },
+    [libraryMappingLookup]
+  );
+
+  const revertLibraryMappings = useCallback(
+    (libraryNames) => {
+      const names = Array.isArray(libraryNames) ? libraryNames : [libraryNames];
+      const normalized = names.map((name) => normalizeLibraryName(name)).filter(Boolean);
+      if (!normalized.length) return;
+      setSettings((prev) => {
+        const base = sanitizeSettings(prev);
+        let nextMappings = sanitizeLibraryMappings(base.libraryMappings);
+        let changed = false;
+        normalized.forEach((name) => {
+          const saved = savedLibraryMappingLookup.get(name);
+          const index = nextMappings.findIndex((entry) => entry.library === name);
+          if (saved) {
+            if (index >= 0) {
+              const existing = nextMappings[index];
+              if (
+                existing.assetPath !== saved.assetPath ||
+                existing.collectionsPath !== saved.collectionsPath
+              ) {
+                nextMappings[index] = { ...saved };
+                changed = true;
+              }
+            } else {
+              nextMappings.push({ ...saved });
+              changed = true;
+            }
+          } else if (index >= 0) {
+            nextMappings.splice(index, 1);
+            changed = true;
+          }
+        });
+        if (!changed) {
+          return base;
+        }
+        return sanitizeSettings({ ...base, libraryMappings: nextMappings });
+      });
+    },
+    [savedLibraryMappingLookup]
+  );
+
+  const revertLibraryMapping = useCallback(
+    (libraryName) => {
+      if (!libraryName) return;
+      revertLibraryMappings([libraryName]);
+    },
+    [revertLibraryMappings]
+  );
+
   const value = useMemo(
     () => ({
       settings,
@@ -346,6 +414,9 @@ export function ThemeProvider({ children }) {
       loading,
       saving,
       error,
+      settingsDirty,
+      libraryMappingsDirty,
+      hasUnsavedChanges,
       applyTheme,
       updateSettings,
       saveSettings,
@@ -357,6 +428,9 @@ export function ThemeProvider({ children }) {
       refreshLibraries,
       setLibraryMapping,
       setLibraryMappings,
+      getLibraryMapping,
+      revertLibraryMapping,
+      revertLibraryMappings,
     }),
     [
       settings,
@@ -367,6 +441,9 @@ export function ThemeProvider({ children }) {
       loading,
       saving,
       error,
+      settingsDirty,
+      libraryMappingsDirty,
+      hasUnsavedChanges,
       applyTheme,
       updateSettings,
       saveSettings,
@@ -378,6 +455,9 @@ export function ThemeProvider({ children }) {
       refreshLibraries,
       setLibraryMapping,
       setLibraryMappings,
+      getLibraryMapping,
+      revertLibraryMapping,
+      revertLibraryMappings,
     ]
   );
 

--- a/frontend/src/utils/libraryMappings.js
+++ b/frontend/src/utils/libraryMappings.js
@@ -1,0 +1,62 @@
+const normalizeLibraryName = (value) => {
+  if (value == null) return '';
+  const text = String(value).trim();
+  return text;
+};
+
+const normalizePathValue = (value) => {
+  if (value == null) return '';
+  const text = String(value).trim();
+  if (!text) return '';
+  return text.replace(/\\+/g, '/');
+};
+
+const sanitizeLibraryMappings = (raw = []) => {
+  if (!raw) return [];
+  const entries = Array.isArray(raw) ? raw : [];
+  const byLibrary = new Map();
+  entries.forEach((entry) => {
+    if (!entry || typeof entry !== 'object') return;
+    const library = normalizeLibraryName(entry.library ?? entry.name);
+    if (!library) return;
+    const assetPath = normalizePathValue(entry.assetPath ?? entry.path ?? entry.assetFolder);
+    if (!assetPath) return;
+    const collectionsValue = entry.collectionsPath ?? entry.collectionPath ?? entry.collectionsFolder;
+    const collectionsPath = collectionsValue === undefined ? '' : normalizePathValue(collectionsValue);
+    byLibrary.set(library, {
+      library,
+      assetPath,
+      collectionsPath,
+    });
+  });
+  return Array.from(byLibrary.values()).sort((a, b) => a.library.localeCompare(b.library));
+};
+
+const areLibraryMappingsEqual = (left, right) => {
+  const a = sanitizeLibraryMappings(left);
+  const b = sanitizeLibraryMappings(right);
+  if (a.length !== b.length) return false;
+  return a.every(
+    (entry, index) =>
+      entry.library === b[index].library &&
+      entry.assetPath === b[index].assetPath &&
+      normalizePathValue(entry.collectionsPath) === normalizePathValue(b[index].collectionsPath)
+  );
+};
+
+const createLibraryMappingLookup = (raw = []) => {
+  const map = new Map();
+  sanitizeLibraryMappings(raw).forEach((entry) => {
+    map.set(entry.library, { ...entry });
+  });
+  return map;
+};
+
+export {
+  normalizeLibraryName,
+  normalizePathValue,
+  sanitizeLibraryMappings,
+  areLibraryMappingsEqual,
+  createLibraryMappingLookup,
+};
+


### PR DESCRIPTION
## Summary
- add shared library mapping utilities and expand ThemeProvider to expose dirty-state helpers and mapping revert APIs
- update the Settings page to use the new helpers, normalize Plex library rows, and surface loading/saving statuses
- allow FolderFinderModal to return both asset and collections selections and extend the React tests for the new flows

## Testing
- npx vitest --runInBand *(fails: 403 Forbidden fetching vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68e1d576701c8330a1b4e765d6212dd8