### PR TITLE
Use settings-driven library mappings for assets

### DIFF
--- a/app/routers/assets.py
+++ b/app/routers/assets.py
@@ -7,8 +7,8 @@ from typing import List
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
 
-from .. import config
 from ..services import folder_overrides
+from ..services import library_mappings as library_mappings_service
 from ..services.resolve import ASSETS_ROOT, resolve_existing_dir_or_422
 
 router = APIRouter()
@@ -24,14 +24,14 @@ def _library_root(library: str) -> Path:
     if not library:
         raise HTTPException(status_code=422, detail="Missing library")
     if library == "Collections":
-        base = config.COLLECTIONS_ROOT
+        base = library_mappings_service.get_collections_path()
         if not base:
             raise HTTPException(
                 status_code=404, detail="No assets mapping for library 'Collections'"
             )
         root = Path(base)
     else:
-        mapped = config.LIBRARY_MAPPINGS.get(library)
+        mapped = library_mappings_service.get_asset_path(library)
         if mapped:
             root = Path(mapped)
         else:

--- a/app/routers/collections.py
+++ b/app/routers/collections.py
@@ -4,8 +4,8 @@ from typing import Optional, List, Dict, Any, Tuple
 from ..services.plex import get_plex
 from ..services import folder_overrides
 from ..services import plex_settings
+from ..services import library_mappings as library_mappings_service
 from ..services.assets import sanitize_name
-from .. import config
 
 import os
 from pathlib import Path
@@ -15,10 +15,6 @@ router = APIRouter()
 
 # Container paths (must match your docker-compose volume mounts)
 ASSETS_ROOT = os.environ.get("KAM_ASSETS_ROOT") or os.environ.get("ASSETS_ROOT") or ""
-COLLECTIONS_ROOT = (
-    os.environ.get("COLLECTIONS_ROOT")
-    or (os.path.join(ASSETS_ROOT, "Collections") if ASSETS_ROOT else "")
-)
 
 # Try lots of common names (Kometa variants differ)
 LOCAL_FILENAMES = (
@@ -49,16 +45,24 @@ def _first_existing_poster(dir_path: Path) -> Path | None:
             return p
     return None
 
-def _local_poster_for_title(title: str) -> Tuple[Path | None, str | None, str, bool]:
+def _collections_root_for_library(library: str | None) -> Path | None:
+    path = library_mappings_service.get_collections_path(library)
+    if not path:
+        return None
+    return Path(path)
+
+
+def _local_poster_for_title(
+    title: str, base: Path | None
+) -> Tuple[Path | None, str | None, str, bool]:
     """
     Find a local poster for this collection title.
 
     Returns: (path_on_disk, public_url_or_None, folder_used, folder_exists)
     """
-    if not title or not COLLECTIONS_ROOT:
+    if not title or not base:
         return None, None, "", False
 
-    base = Path(COLLECTIONS_ROOT)
     raw_folder = title
     sani_folder = sanitize_name(title)
     found_folder = ""
@@ -71,7 +75,7 @@ def _local_poster_for_title(title: str) -> Tuple[Path | None, str | None, str, b
         found_exists = True
         p = _first_existing_poster(d1)
         if p:
-            return p, _url_for_local(d1.name, p), d1.name, True
+            return p, _url_for_local(base, d1.name, p), d1.name, True
 
     # 2) exact sanitized
     d2 = base / sani_folder
@@ -80,7 +84,7 @@ def _local_poster_for_title(title: str) -> Tuple[Path | None, str | None, str, b
         found_exists = True
         p = _first_existing_poster(d2)
         if p:
-            return p, _url_for_local(d2.name, p), d2.name, True
+            return p, _url_for_local(base, d2.name, p), d2.name, True
 
     # 3) case-insensitive match (raw)
     d3 = _case_insensitive_dir(base, raw_folder)
@@ -89,7 +93,7 @@ def _local_poster_for_title(title: str) -> Tuple[Path | None, str | None, str, b
         found_exists = True
         p = _first_existing_poster(d3)
         if p:
-            return p, _url_for_local(d3.name, p), d3.name, True
+            return p, _url_for_local(base, d3.name, p), d3.name, True
 
     # 4) case-insensitive match (sanitized)
     d4 = _case_insensitive_dir(base, sani_folder)
@@ -98,26 +102,35 @@ def _local_poster_for_title(title: str) -> Tuple[Path | None, str | None, str, b
         found_exists = True
         p = _first_existing_poster(d4)
         if p:
-            return p, _url_for_local(d4.name, p), d4.name, True
+            return p, _url_for_local(base, d4.name, p), d4.name, True
 
     if found_exists:
         return None, None, found_folder, True
 
     return None, None, "", False
 
-def _url_for_local(folder_name: str, file_path: Path) -> str:
+def _url_for_local(base: Path, folder_name: str, file_path: Path) -> str:
     """
-    Build the public URL for a local poster. Requires /assets to be mounted to ASSETS_ROOT in main.py.
+    Build the public URL for a local poster via the fileproxy.
     Adds cache-buster based on mtime so the UI flips immediately.
     """
-    url = f"/assets/Collections/{quote(folder_name)}/{file_path.name}"
+    resolved = file_path
+    try:
+        resolved_base = base.resolve()
+        resolved = file_path.resolve()
+        resolved.relative_to(resolved_base)
+    except Exception:
+        try:
+            resolved = file_path.resolve()
+        except Exception:
+            resolved = file_path
+    url = f"/fileproxy?path={quote(str(resolved))}"
     try:
         ts = int(file_path.stat().st_mtime)
     except Exception:
         ts = 0
     if ts:
-        sep = "&" if "?" in url else "?"
-        url = f"{url}{sep}t={ts}"
+        url = f"{url}&t={ts}" if "?" in url else f"{url}?t={ts}"
     return url
 
 
@@ -137,6 +150,7 @@ def collections(
     # Gather collections from all libraries
     for sec in plex.library.sections():
         try:
+            name = str(getattr(sec, "title", "") or "")
             for coll in sec.collections():
                 rk = getattr(coll, "ratingKey", None)
                 title = (getattr(coll, "title", None) or "").strip()
@@ -146,7 +160,11 @@ def collections(
                 if plex_url and plex_token:
                     poster_plex = f"{plex_url}/library/metadata/{rk}/thumb?X-Plex-Token={plex_token}"
 
-                override_folder = folder_overrides.get_override("Collections", str(rk)) if rk else None
+                library_name = name
+                collections_base = _collections_root_for_library(library_name)
+                override_folder = (
+                    folder_overrides.get_override(library_name, str(rk)) if rk else None
+                )
 
                 poster_local = None
                 folder_used = sanitize_name(title) if title else ""
@@ -157,17 +175,27 @@ def collections(
                     folder_used = override_folder
                     asset_ready = True
                     folder_exists = True
-                    if COLLECTIONS_ROOT:
-                        override_path = Path(COLLECTIONS_ROOT) / override_folder
-                        poster_path = _first_existing_poster(override_path) if override_path.is_dir() else None
+                    if collections_base:
+                        override_path = collections_base / override_folder
+                        poster_path = (
+                            _first_existing_poster(override_path)
+                            if override_path.is_dir()
+                            else None
+                        )
                         if poster_path:
-                            poster_local = _url_for_local(override_folder, poster_path)
+                            poster_local = _url_for_local(collections_base, override_folder, poster_path)
                 else:
-                    _poster_path, poster_local, folder_used, folder_exists = _local_poster_for_title(title)
+                    (
+                        _poster_path,
+                        poster_local,
+                        folder_used,
+                        folder_exists,
+                    ) = _local_poster_for_title(title, collections_base)
                     asset_ready = folder_exists
 
                 item = {
                     "ratingKey": rk,
+                    "library": library_name,
                     "title": title,
                     "year": None,
                     "folderName": folder_used or (sanitize_name(title) if title else ""),
@@ -183,7 +211,7 @@ def collections(
                 # Remove this once you're happy:
                 if poster_local is None:
                     item["_debug"] = {
-                        "collections_root": COLLECTIONS_ROOT,
+                        "collections_root": str(collections_base) if collections_base else None,
                         "tried_titles": [title, sanitize_name(title)],
                         "folder_used": folder_used,
                         "asset_ready": folder_exists,

--- a/app/routers/fileproxy.py
+++ b/app/routers/fileproxy.py
@@ -2,16 +2,22 @@
 import os, mimetypes
 from fastapi import APIRouter, HTTPException, Query
 from fastapi.responses import FileResponse
-from .. import config
+from ..services import library_mappings as library_mappings_service
 
 router = APIRouter()
 
 def _allowed_roots():
     roots = set()
-    roots.update(getattr(config, "LIBRARY_MAPPINGS", {}).values())
-    coll = getattr(config, "COLLECTIONS_ROOT", None)
-    if coll:
-        roots.add(coll)
+    for entry in library_mappings_service.load_library_mappings():
+        asset = entry.get("assetPath")
+        if asset:
+            roots.add(asset)
+        coll = entry.get("collectionsPath")
+        if coll:
+            roots.add(coll)
+    fallback_coll = library_mappings_service.get_collections_path()
+    if fallback_coll:
+        roots.add(fallback_coll)
     return [os.path.realpath(p) for p in roots if p]
 
 def _is_allowed(path: str) -> bool:

--- a/app/routers/libraries.py
+++ b/app/routers/libraries.py
@@ -11,58 +11,28 @@ from __future__ import annotations
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
 from typing import Dict, List, Optional
-import os
+
+from ..services import library_mappings as library_mappings_service
 
 router = APIRouter()
 
 # --- Load mappings -----------------------------------------------------------
 
-def _parse_env_mappings(raw: str) -> Dict[str, str]:
-    """
-    Parse "Name:/path,Other Name:/other/path" into {"Name": "/path", ...}
-    Ignores empty items; trims whitespace; last duplicate wins.
-    """
-    mapping: Dict[str, str] = {}
-    for part in (raw or "").split(","):
-        part = part.strip()
-        if not part:
-            continue
-        if ":" not in part:
-            # Skip malformed entry gracefully
-            continue
-        name, path = part.split(":", 1)
-        name = name.strip()
-        path = path.strip()
-        if name and path:
-            mapping[name] = path
-    return mapping
+def _asset_library_map() -> Dict[str, str]:
+    """Return libraries that have an active asset mapping."""
+    mappings = library_mappings_service.load_library_mappings()
+    result: Dict[str, str] = {}
+    for entry in mappings:
+        name = str(entry.get("library") or "").strip()
+        asset_path = library_mappings_service.normalize_path(entry.get("assetPath"))
+        if name and asset_path:
+            result[name] = asset_path
+    return result
 
 
-def _load_mappings() -> Dict[str, str]:
-    """
-    Prefer importing from app.config if available (e.g., LIBRARY_MAPPINGS),
-    otherwise parse LIBRARIES from the environment directly.
-    """
-    # Try to use central config if present
-    try:
-        # Expected in your codebase: app/config.py defines LIBRARY_MAPPINGS: Dict[str, str]
-        from ..config import LIBRARY_MAPPINGS  # type: ignore
-        if isinstance(LIBRARY_MAPPINGS, dict) and LIBRARY_MAPPINGS:
-            # Normalize keys/values
-            return {str(k).strip(): str(v).strip() for k, v in LIBRARY_MAPPINGS.items() if str(k).strip() and str(v).strip()}
-    except Exception:
-        pass
-
-    # Fallback: parse from ENV
-    env_raw = os.environ.get("LIBRARIES", "")
-    return _parse_env_mappings(env_raw)
-
-
-LIBRARY_MAPPINGS: Dict[str, str] = _load_mappings()
-
-
-def _ensure_any_mapped() -> None:
-    if not LIBRARY_MAPPINGS:
+def _ensure_any_mapped() -> Dict[str, str]:
+    mapping = _asset_library_map()
+    if not mapping:
         raise HTTPException(
             status_code=500,
             detail=(
@@ -70,6 +40,7 @@ def _ensure_any_mapped() -> None:
                 "in your environment (or ensure config.LIBRARY_MAPPINGS is populated)."
             ),
         )
+    return mapping
 
 
 # --- Endpoints ---------------------------------------------------------------
@@ -80,8 +51,14 @@ def get_libraries() -> List[str]:
     Return only the names of libraries that are explicitly mapped.
     This prevents showing unsupported sections like Music, etc.
     """
-    _ensure_any_mapped()
-    return sorted(LIBRARY_MAPPINGS.keys())
+    mapping = _ensure_any_mapped()
+    names = sorted(mapping.keys())
+    # Surface "Collections" when any per-library collections path exists.
+    collections_root = library_mappings_service.get_collections_path()
+    if collections_root and "Collections" not in names:
+        names.append("Collections")
+        names.sort()
+    return names
 
 
 @router.get("/api/libraries/map", response_model=Dict[str, str])
@@ -89,9 +66,8 @@ def get_library_map() -> Dict[str, str]:
     """
     Return the full name -> path map (useful for uploads).
     """
-    _ensure_any_mapped()
-    # Return a stable ordering for deterministic diffs/tests (optional)
-    return {name: LIBRARY_MAPPINGS[name] for name in sorted(LIBRARY_MAPPINGS.keys())}
+    mapping = _ensure_any_mapped()
+    return {name: mapping[name] for name in sorted(mapping.keys())}
 
 
 @router.get("/api/library-path")
@@ -99,8 +75,8 @@ def get_library_path(name: str = Query(..., description="Mapped library name")) 
     """
     Resolve a single library name to its mapped path.
     """
-    _ensure_any_mapped()
-    path = LIBRARY_MAPPINGS.get(name)
+    mapping = _ensure_any_mapped()
+    path = mapping.get(name)
     if not path:
         raise HTTPException(status_code=404, detail=f"Library '{name}' is not mapped.")
     return {"name": name, "path": path}
@@ -120,7 +96,6 @@ def list_available_libraries() -> List[LibrarySectionInfo]:
     from ..services import (
         library_mappings as library_mappings_service,
         plex_settings,
-        settings as settings_service,
     )
     from ..services.plex import get_plex
 
@@ -133,7 +108,7 @@ def list_available_libraries() -> List[LibrarySectionInfo]:
     except Exception as exc:  # pragma: no cover - defensive
         raise HTTPException(status_code=500, detail=f"Unable to list Plex libraries: {exc}")
 
-    stored = settings_service.load_settings().get("libraryMappings", [])
+    stored = library_mappings_service.load_library_mappings()
     mappings = library_mappings_service.sanitize_library_mappings(stored)
     mapping_lookup = {item["library"]: item for item in mappings}
 

--- a/app/routers/movie.py
+++ b/app/routers/movie.py
@@ -4,10 +4,10 @@ from typing import Optional, Tuple
 
 from ..services import folder_overrides
 from ..services import plex_settings
+from ..services import library_mappings as library_mappings_service
 from ..services.plex import get_plex
 from ..services.assets import folder_name_for
 from ..services.resolve import resolve_existing_dir_or_422
-from .. import config
 
 router = APIRouter()
 
@@ -74,7 +74,7 @@ def movie(library: str = Query(...), ratingKey: int = Query(...)):
         folder = resolved_folder
 
     # Map to asset root for this library
-    base = config.LIBRARY_MAPPINGS.get(library)
+    base = library_mappings_service.get_asset_path(library)
     poster_exists = False
     background_exists = False
     poster_url_local = None

--- a/app/services/library_mappings.py
+++ b/app/services/library_mappings.py
@@ -13,6 +13,11 @@ __all__ = [
     "set_cached_mappings",
     "get_cached_mappings",
     "clear_cache",
+    "load_library_mappings",
+    "get_library_map",
+    "get_library_entry",
+    "get_asset_path",
+    "get_collections_path",
 ]
 
 _CACHE: Optional[List[Dict[str, Any]]] = None
@@ -109,3 +114,89 @@ def get_cached_mappings() -> Optional[List[Dict[str, Any]]]:
 def clear_cache() -> None:
     """Clear the cached mappings."""
     set_cached_mappings(None)
+
+
+def _load_from_settings() -> List[Dict[str, Any]]:
+    """Return sanitized mappings from persisted settings with env fallback."""
+    try:
+        from . import settings as settings_service  # Local import to avoid cycle
+
+        payload = settings_service.load_settings()
+        raw = payload.get("libraryMappings") if isinstance(payload, dict) else None
+    except Exception:
+        raw = None
+
+    mappings = sanitize_library_mappings(raw)
+    if mappings:
+        return mappings
+    return seed_from_env()
+
+
+def load_library_mappings() -> List[Dict[str, Any]]:
+    """Return sanitized library mappings from settings (cached)."""
+    cached = get_cached_mappings()
+    if cached is not None:
+        return cached
+
+    mappings = _load_from_settings()
+    set_cached_mappings(mappings)
+    return copy.deepcopy(mappings)
+
+
+def get_library_map() -> Dict[str, Dict[str, Any]]:
+    """Return a library -> mapping lookup."""
+    mappings = load_library_mappings()
+    lookup: Dict[str, Dict[str, Any]] = {}
+    for item in mappings:
+        library = str(item.get("library") or "")
+        if not library:
+            continue
+        lookup[library] = dict(item)
+    return lookup
+
+
+def get_library_entry(library: str) -> Optional[Dict[str, Any]]:
+    """Return the mapping entry for *library* (if any)."""
+    if not library:
+        return None
+    mapping = get_library_map().get(str(library))
+    return dict(mapping) if mapping else None
+
+
+def get_asset_path(library: str) -> Optional[str]:
+    """Return the configured asset path for *library* (if any)."""
+    entry = get_library_entry(library)
+    if not entry:
+        return None
+    path = normalize_path(entry.get("assetPath"))
+    return path or None
+
+
+def _default_collections_root() -> Optional[str]:
+    return normalize_path(os.environ.get("COLLECTIONS_ROOT"))
+
+
+def get_collections_path(library: Optional[str] = None) -> Optional[str]:
+    """Return the collections path for *library* or the global default."""
+    if library:
+        entry = get_library_entry(library)
+        if entry:
+            path = normalize_path(entry.get("collectionsPath"))
+            if path:
+                return path
+
+    explicit = get_library_entry("Collections")
+    if explicit:
+        explicit_coll = normalize_path(explicit.get("collectionsPath") or explicit.get("assetPath"))
+        if explicit_coll:
+            return explicit_coll
+
+    fallback = _default_collections_root()
+    if fallback:
+        return fallback
+
+    for entry in load_library_mappings():
+        candidate = normalize_path(entry.get("collectionsPath"))
+        if candidate:
+            return candidate
+    return None

--- a/app/services/resolve.py
+++ b/app/services/resolve.py
@@ -3,9 +3,9 @@ import os
 import re
 import unicodedata
 from difflib import SequenceMatcher
-from typing import Optional
+from typing import Iterable, Optional
 
-from app import config
+from . import library_mappings as library_mappings_service
 
 ASSETS_ROOT = os.environ.get("KAM_ASSETS_ROOT", "/assets")
 
@@ -93,6 +93,35 @@ def _best_match(candidates, want: str) -> Optional[str]:
         return best_candidate
     return None
 
+def _candidate_bases(library: str) -> Iterable[str]:
+    """Yield possible asset roots for *library* in priority order."""
+    if not library:
+        return []
+
+    candidates: list[str] = []
+    if library == "Collections":
+        coll_base = library_mappings_service.get_collections_path()
+        if coll_base:
+            candidates.append(coll_base)
+    else:
+        asset_base = library_mappings_service.get_asset_path(library)
+        if asset_base:
+            candidates.append(asset_base)
+
+        coll_base = library_mappings_service.get_collections_path(library)
+        if coll_base and coll_base not in candidates:
+            candidates.append(coll_base)
+
+    if ASSETS_ROOT:
+        fallback = os.path.join(ASSETS_ROOT, library)
+        if fallback not in candidates:
+            candidates.append(fallback)
+        if ASSETS_ROOT not in candidates:
+            candidates.append(ASSETS_ROOT)
+
+    return candidates
+
+
 def resolve_existing_dir_or_422(library: str, folder_name: str) -> str:
     """
     Resolve the asset directory for (library, folder_name) to an EXISTING folder.
@@ -105,15 +134,24 @@ def resolve_existing_dir_or_422(library: str, folder_name: str) -> str:
     if not library:
         raise FileNotFoundError("Missing library")
 
-    mapped_base: Optional[str]
-    if library == "Collections":
-        mapped_base = config.COLLECTIONS_ROOT
-    else:
-        mapped_base = config.LIBRARY_MAPPINGS.get(library)
+    bases = list(dict.fromkeys(_candidate_bases(library)))
+    for base in bases:
+        if not os.path.isdir(base):
+            continue
+        try:
+            resolved = _resolve_within_base(base, library, folder_name)
+        except FileNotFoundError:
+            continue
+        if resolved:
+            return resolved
 
-    base = os.fspath(mapped_base) if mapped_base else os.path.join(ASSETS_ROOT, library)
+    last_base = bases[0] if bases else os.path.join(ASSETS_ROOT, library)
+    raise FileNotFoundError(f"Assets library not found: {last_base}")
+
+
+def _resolve_within_base(base: str, library: str, folder_name: str) -> Optional[str]:
     if not os.path.isdir(base):
-        raise FileNotFoundError(f"Assets library not found: {base}")
+        return None
 
     raw = (folder_name or "").strip()
     if not raw:
@@ -134,4 +172,6 @@ def resolve_existing_dir_or_422(library: str, folder_name: str) -> str:
         return os.path.join(base, match)
 
     # Not found => caller should 422 (do not create)
-    raise FileNotFoundError(f"No existing asset folder matches '{folder_name}' in '{library}'")
+    raise FileNotFoundError(
+        f"No existing asset folder matches '{folder_name}' in '{library}'"
+    )

--- a/tests/test_collections_route.py
+++ b/tests/test_collections_route.py
@@ -18,7 +18,8 @@ class _DummyCollection:
 
 
 class _DummySection:
-    def __init__(self, collections):
+    def __init__(self, title, collections):
+        self.title = title
         self._collections = collections
 
     def collections(self):
@@ -42,29 +43,33 @@ class _DummyPlex:
 def collections_env(tmp_path, monkeypatch):
     assets_root = tmp_path / "assets"
     collections_root = assets_root / "Collections"
+    movies_root = assets_root / "Movies"
+    movies_root.mkdir(parents=True)
     ready_folder = collections_root / "my cool collection"
     ready_folder.mkdir(parents=True)
     override_folder = collections_root / "override folder"
     override_folder.mkdir()
 
-    from app import config
-
-    settings_module = importlib.import_module("app.services.settings")
-    monkeypatch.setattr(
-        settings_module,
-        "load_settings",
-        lambda: {
+    settings_module = importlib.reload(importlib.import_module("app.services.settings"))
+    settings_module.set_settings_path(str(tmp_path / "settings.json"))
+    settings_module.save_settings(
+        {
             "theme": "dark",
             "plexUrl": "http://plex.test",
             "plexToken": "token",
-        },
+            "libraryMappings": [
+                {
+                    "library": "Movies",
+                    "assetPath": str(movies_root),
+                    "collectionsPath": str(collections_root),
+                }
+            ],
+        }
     )
     plex_settings = importlib.reload(importlib.import_module("app.services.plex_settings"))
     plex_settings.clear_cache()
 
     monkeypatch.setenv("KAM_ASSETS_ROOT", str(assets_root))
-    monkeypatch.setenv("COLLECTIONS_ROOT", str(collections_root))
-    monkeypatch.setattr(config, "COLLECTIONS_ROOT", str(collections_root))
     overrides_path = tmp_path / "overrides.json"
     monkeypatch.setenv("KAM_FOLDER_OVERRIDES_PATH", str(overrides_path))
 
@@ -76,13 +81,13 @@ def collections_env(tmp_path, monkeypatch):
 
     collections_router = importlib.reload(importlib.import_module("app.routers.collections"))
 
-    collections_router.ASSETS_ROOT = str(assets_root)
-    collections_router.COLLECTIONS_ROOT = str(collections_root)
-
-    sections = [_DummySection([
-        _DummyCollection("My Cool Collection", 1),
-        _DummyCollection("Missing Assets", 2),
-    ])]
+    sections = [_DummySection(
+        "Movies",
+        [
+            _DummyCollection("My Cool Collection", 1),
+            _DummyCollection("Missing Assets", 2),
+        ],
+    )]
 
     monkeypatch.setattr(collections_router, "get_plex", lambda: _DummyPlex(sections))
 
@@ -107,10 +112,12 @@ def test_collections_route_marks_asset_readiness(collections_env):
     # Folder detected despite casing difference and missing poster
     assert ready["folderName"] == "my cool collection"
     assert ready["assetReady"] is True
+    assert ready["library"] == "Movies"
 
     missing = items["Missing Assets"]
     assert missing["assetReady"] is False
     assert missing["folderName"] == "Missing Assets"
+    assert missing["library"] == "Movies"
     assert missing["posterUrlPlex"].startswith("http://plex.test")
 
 
@@ -128,7 +135,7 @@ def test_collections_route_uses_overrides(collections_env):
     folder = collections_env.override_folder
     (folder / "poster.jpg").write_bytes(b"poster")
 
-    collections_env.folder_overrides.set_override("Collections", "2", folder.name)
+    collections_env.folder_overrides.set_override("Movies", "2", folder.name)
 
     data = collections_env.call()
     items = {it["title"]: it for it in data["items"]}
@@ -137,7 +144,7 @@ def test_collections_route_uses_overrides(collections_env):
     assert overridden["folderName"] == folder.name
     assert overridden["assetReady"] is True
     assert overridden["posterUrlLocal"] is not None
-    assert folder.name.replace(" ", "%20") in overridden["posterUrlLocal"]
+    assert overridden["posterUrlLocal"].startswith("/fileproxy?")
 
 
 def test_collections_route_reports_not_ready_count_and_filters(collections_env):

--- a/tests/test_folder_overrides.py
+++ b/tests/test_folder_overrides.py
@@ -29,10 +29,19 @@ def overrides_env(tmp_path, monkeypatch):
     monkeypatch.setenv("KAM_ASSETS_ROOT", str(assets_root))
     monkeypatch.setenv("KAM_FOLDER_OVERRIDES_PATH", str(overrides_path))
 
-    from app import config
-
-    monkeypatch.setattr(config, "LIBRARY_MAPPINGS", {"Movies": str(movies_dir)})
-    monkeypatch.setattr(config, "COLLECTIONS_ROOT", str(collections_dir))
+    settings_module = importlib.reload(importlib.import_module("app.services.settings"))
+    settings_module.set_settings_path(str(tmp_path / "settings.json"))
+    settings_module.save_settings(
+        {
+            "libraryMappings": [
+                {
+                    "library": "Movies",
+                    "assetPath": str(movies_dir),
+                    "collectionsPath": str(collections_dir),
+                }
+            ]
+        }
+    )
 
     resolve_module = importlib.reload(importlib.import_module("app.services.resolve"))
     resolve_module.ASSETS_ROOT = str(assets_root)

--- a/tests/test_items_route.py
+++ b/tests/test_items_route.py
@@ -1,4 +1,5 @@
 import importlib
+import importlib
 from types import SimpleNamespace
 
 import pytest
@@ -18,23 +19,24 @@ def items_env(tmp_path, monkeypatch):
     monkeypatch.setenv("KAM_ASSETS_ROOT", str(assets_root))
     monkeypatch.setenv("KAM_FOLDER_OVERRIDES_PATH", str(overrides_path))
 
-    settings_module = importlib.import_module("app.services.settings")
-    monkeypatch.setattr(
-        settings_module,
-        "load_settings",
-        lambda: {
+    settings_module = importlib.reload(importlib.import_module("app.services.settings"))
+    settings_module.set_settings_path(str(tmp_path / "settings.json"))
+    settings_module.save_settings(
+        {
             "theme": "dark",
             "plexUrl": "http://plex.test",
             "plexToken": "token",
-        },
+            "libraryMappings": [
+                {
+                    "library": library,
+                    "assetPath": str(library_path),
+                    "collectionsPath": None,
+                }
+            ],
+        }
     )
     plex_settings = importlib.reload(importlib.import_module("app.services.plex_settings"))
     plex_settings.clear_cache()
-
-    from app import config
-
-    monkeypatch.setattr(config, "LIBRARY_MAPPINGS", {library: str(library_path)})
-    monkeypatch.setattr(config, "COLLECTIONS_ROOT", "")
 
     resolve_module = importlib.reload(importlib.import_module("app.services.resolve"))
     resolve_module.ASSETS_ROOT = str(assets_root)

--- a/tests/test_libraries_settings_endpoints.py
+++ b/tests/test_libraries_settings_endpoints.py
@@ -189,20 +189,32 @@ def test_settings_libraries_endpoint_handles_empty_mappings(monkeypatch):
 def test_asset_folders_unmapped_library(tmp_path, monkeypatch):
     assets_root = tmp_path / "assets"
     assets_root.mkdir()
-    (assets_root / "Movies").mkdir()
+    movies_dir = assets_root / "Movies"
+    movies_dir.mkdir()
     loose = assets_root / "LooseAssets"
     loose.mkdir()
     (loose / "Clips").mkdir()
+    collections_dir = assets_root / "Collections"
+    collections_dir.mkdir()
 
     monkeypatch.setenv("KAM_ASSETS_ROOT", str(assets_root))
 
     resolve_module = importlib.reload(importlib.import_module("app.services.resolve"))
     resolve_module.ASSETS_ROOT = str(assets_root)
 
-    from app import config
-
-    monkeypatch.setattr(config, "LIBRARY_MAPPINGS", {"Movies": str(assets_root / "Movies")})
-    monkeypatch.setattr(config, "COLLECTIONS_ROOT", str(assets_root / "Collections"))
+    settings_module = importlib.reload(importlib.import_module("app.services.settings"))
+    settings_module.set_settings_path(str(tmp_path / "settings.json"))
+    settings_module.save_settings(
+        {
+            "libraryMappings": [
+                {
+                    "library": "Movies",
+                    "assetPath": str(movies_dir),
+                    "collectionsPath": str(collections_dir),
+                }
+            ]
+        }
+    )
 
     assets_router = importlib.reload(importlib.import_module("app.routers.assets"))
 

--- a/tests/test_movie_route.py
+++ b/tests/test_movie_route.py
@@ -53,19 +53,21 @@ def movie_env(tmp_path, monkeypatch):
     # Another unrelated folder to ensure false positives are avoided
     (library_path / "Completely Different (2020)").mkdir()
 
-    from app import config
-
-    monkeypatch.setattr(config, "LIBRARY_MAPPINGS", {library: str(library_path)})
-
-    settings_module = importlib.import_module("app.services.settings")
-    monkeypatch.setattr(
-        settings_module,
-        "load_settings",
-        lambda: {
+    settings_module = importlib.reload(importlib.import_module("app.services.settings"))
+    settings_module.set_settings_path(str(tmp_path / "settings.json"))
+    settings_module.save_settings(
+        {
             "theme": "dark",
             "plexUrl": "http://plex.test",
             "plexToken": "token",
-        },
+            "libraryMappings": [
+                {
+                    "library": library,
+                    "assetPath": str(library_path),
+                    "collectionsPath": None,
+                }
+            ],
+        }
     )
     plex_settings = importlib.reload(importlib.import_module("app.services.plex_settings"))
     plex_settings.clear_cache()

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -29,12 +29,16 @@ def test_resolve_prefers_config_mapping(tmp_path, monkeypatch):
 
     monkeypatch.setenv("KAM_ASSETS_ROOT", str(assets_root))
 
-    config_module = importlib.import_module("app.config")
-    monkeypatch.setattr(
-        config_module,
-        "LIBRARY_MAPPINGS",
-        {library: str(mapped_library_path)},
-        raising=False,
+    settings_module = importlib.reload(importlib.import_module("app.services.settings"))
+    settings_module.set_settings_path(str(tmp_path / "settings.json"))
+    settings_module.save_library_mappings(
+        [
+            {
+                "library": library,
+                "assetPath": str(mapped_library_path),
+                "collectionsPath": None,
+            }
+        ]
     )
 
     resolve_module = _reload_with_assets_root(str(assets_root))
@@ -55,6 +59,10 @@ def test_resolve_accepts_high_similarity_variant(tmp_path, monkeypatch):
 
     monkeypatch.setenv("KAM_ASSETS_ROOT", str(assets_root))
 
+    settings_module = importlib.reload(importlib.import_module("app.services.settings"))
+    settings_module.set_settings_path(str(tmp_path / "settings.json"))
+    settings_module.save_library_mappings([])
+
     resolve_module = _reload_with_assets_root(str(assets_root))
 
     resolved = resolve_module.resolve_existing_dir_or_422(library, target)
@@ -73,6 +81,10 @@ def test_resolve_matches_stopword_and_year_variants(tmp_path, monkeypatch):
 
     monkeypatch.setenv("KAM_ASSETS_ROOT", str(assets_root))
 
+    settings_module = importlib.reload(importlib.import_module("app.services.settings"))
+    settings_module.set_settings_path(str(tmp_path / "settings.json"))
+    settings_module.save_library_mappings([])
+
     resolve_module = _reload_with_assets_root(str(assets_root))
 
     resolved = resolve_module.resolve_existing_dir_or_422(library, target)
@@ -90,6 +102,10 @@ def test_resolve_rejects_low_similarity_titles(tmp_path, monkeypatch):
     (library_path / existing).mkdir()
 
     monkeypatch.setenv("KAM_ASSETS_ROOT", str(assets_root))
+
+    settings_module = importlib.reload(importlib.import_module("app.services.settings"))
+    settings_module.set_settings_path(str(tmp_path / "settings.json"))
+    settings_module.save_library_mappings([])
 
     resolve_module = _reload_with_assets_root(str(assets_root))
 

--- a/tests/test_tv_route.py
+++ b/tests/test_tv_route.py
@@ -1,4 +1,5 @@
 import importlib
+import importlib
 from types import SimpleNamespace
 
 import pytest
@@ -33,23 +34,24 @@ def tv_env(tmp_path, monkeypatch):
     monkeypatch.setenv("KAM_ASSETS_ROOT", str(assets_root))
     monkeypatch.setenv("KAM_FOLDER_OVERRIDES_PATH", str(overrides_path))
 
-    settings_module = importlib.import_module("app.services.settings")
-    monkeypatch.setattr(
-        settings_module,
-        "load_settings",
-        lambda: {
+    settings_module = importlib.reload(importlib.import_module("app.services.settings"))
+    settings_module.set_settings_path(str(tmp_path / "settings.json"))
+    settings_module.save_settings(
+        {
             "theme": "dark",
             "plexUrl": "http://plex.test",
             "plexToken": "token",
-        },
+            "libraryMappings": [
+                {
+                    "library": library,
+                    "assetPath": str(library_path),
+                    "collectionsPath": None,
+                }
+            ],
+        }
     )
     plex_settings = importlib.reload(importlib.import_module("app.services.plex_settings"))
     plex_settings.clear_cache()
-
-    from app import config
-
-    monkeypatch.setattr(config, "LIBRARY_MAPPINGS", {library: str(library_path)})
-    monkeypatch.setattr(config, "COLLECTIONS_ROOT", "")
 
     resolve_module = importlib.reload(importlib.import_module("app.services.resolve"))
     resolve_module.ASSETS_ROOT = str(assets_root)


### PR DESCRIPTION
## Summary
- add utilities to load asset and collections paths from persisted library mapping settings with environment fallbacks
- update asset resolution, routers, and collections handling to rely on the settings-backed mappings and per-library collection roots
- adjust tests to seed mapping settings instead of mutating config globals and cover the new behaviour

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e1d57773bc8330a400dc8410bf02b4