### PR TITLE
Ensure settings info banners clear after loading

### DIFF
--- a/frontend/src/pages/SettingsPage.jsx
+++ b/frontend/src/pages/SettingsPage.jsx
@@ -55,6 +55,11 @@ function SettingsPage() {
   const [selectedLibraries, setSelectedLibraries] = useState([]);
   const [modalState, setModalState] = useState(initialModalState);
   const selectAllRef = useRef(null);
+  const previousLoadingFlagsRef = useRef({
+    loading,
+    saving,
+    librariesLoading,
+  });
 
   const savedPlexUrl = savedSettings?.plexUrl || '';
   const savedPlexToken = savedSettings?.plexToken || '';
@@ -100,6 +105,32 @@ function SettingsPage() {
       showInfoStatus('Loading Plex libraries…');
     }
   }, [librariesLoading, showInfoStatus]);
+
+  useEffect(() => {
+    const previous = previousLoadingFlagsRef.current;
+    const infoMessages = [
+      ['loading', loading, 'Loading settings…'],
+      ['saving', saving, 'Saving settings…'],
+      ['librariesLoading', librariesLoading, 'Loading Plex libraries…'],
+    ];
+
+    const shouldClearInfo =
+      status?.type === 'info' &&
+      infoMessages.some(([key, isActive, message]) => {
+        const wasActive = previous[key];
+        return wasActive && !isActive && status?.message === message;
+      });
+
+    if (shouldClearInfo) {
+      setStatus(null);
+    }
+
+    previousLoadingFlagsRef.current = {
+      loading,
+      saving,
+      librariesLoading,
+    };
+  }, [loading, saving, librariesLoading, status]);
 
   const busy = loading || saving;
   const combinedBusy = busy || librariesLoading;

--- a/frontend/src/pages/__tests__/SettingsPage.test.jsx
+++ b/frontend/src/pages/__tests__/SettingsPage.test.jsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import SettingsPage from '../SettingsPage.jsx';
 import { useTheme } from '../../theme/ThemeProvider.jsx';
@@ -218,6 +218,55 @@ describe('SettingsPage', () => {
 
     const status = await screen.findByRole('status');
     expect(status).toHaveTextContent('Saving settings…');
+  });
+
+  it('clears transient info statuses after loading completes', async () => {
+    const state = {
+      theme: 'dark',
+      savedTheme: 'dark',
+      plexUrl: '',
+      plexToken: '',
+      savedSettings: { plexUrl: '', plexToken: '' },
+      libraryMappings: [],
+      savedLibraryMappings: [],
+      libraries: [],
+      librariesLoading: true,
+      librariesError: null,
+      loading: false,
+      saving: false,
+      error: null,
+      libraryMappingsDirty: false,
+      hasUnsavedChanges: false,
+      applyTheme: vi.fn(),
+      updateSettings: vi.fn(),
+      saveSettings: vi.fn(),
+      revertSettings: vi.fn(),
+      refreshLibraries: vi.fn(),
+      setLibraryMapping: vi.fn(),
+      setLibraryMappings: vi.fn(),
+    };
+
+    useTheme.mockImplementation(() => state);
+
+    const { rerender } = render(
+      <MemoryRouter>
+        <SettingsPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('status')).toHaveTextContent('Loading Plex libraries…');
+
+    state.librariesLoading = false;
+
+    rerender(
+      <MemoryRouter>
+        <SettingsPage />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByRole('status')).toBeNull();
+    });
   });
 
   it('displays success status after saving changes', async () => {


### PR DESCRIPTION
## Summary
- clear transient info banners when the loading, saving, or library-loading flags settle
- add a regression test that verifies the Plex libraries loading banner disappears

## Testing
- npm test -- --run *(fails: unable to install dependencies in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1de0d71d48330b93a593b4fd86d73