### PR TITLE
Enable assets root browsing for settings mode

### DIFF
--- a/app/routers/assets.py
+++ b/app/routers/assets.py
@@ -20,7 +20,7 @@ class AssignFolderPayload(BaseModel):
     folderName: str
 
 
-def _library_root(library: str) -> Path:
+def _library_root(library: str, *, settings_mode: bool = False) -> Path:
     if not library:
         raise HTTPException(status_code=422, detail="Missing library")
     if library == "Collections":
@@ -32,22 +32,31 @@ def _library_root(library: str) -> Path:
         root = Path(base)
     else:
         mapped = library_mappings_service.get_asset_path(library)
-        if mapped:
+        if mapped and not settings_mode:
             root = Path(mapped)
         else:
             if not ASSETS_ROOT:
-                raise HTTPException(
-                    status_code=404,
-                    detail=f"No assets mapping for library '{library}'",
-                )
-            assets_root = Path(ASSETS_ROOT)
-            if not assets_root.is_dir():
-                raise HTTPException(
-                    status_code=404,
-                    detail=f"Assets library not found: {assets_root}",
-                )
-            candidate = assets_root / library
-            root = candidate if candidate.is_dir() else assets_root
+                if mapped:
+                    root = Path(mapped)
+                else:
+                    raise HTTPException(
+                        status_code=404,
+                        detail=f"No assets mapping for library '{library}'",
+                    )
+            else:
+                assets_root = Path(ASSETS_ROOT)
+                if not assets_root.is_dir():
+                    raise HTTPException(
+                        status_code=404,
+                        detail=f"Assets library not found: {assets_root}",
+                    )
+                if settings_mode:
+                    root = assets_root
+                elif mapped:
+                    root = Path(mapped)
+                else:
+                    candidate = assets_root / library
+                    root = candidate if candidate.is_dir() else assets_root
 
     try:
         resolved_root = root.resolve()
@@ -76,17 +85,21 @@ def list_asset_folders(
     library: str = Query(...),
     parent: str | None = Query(None),
     search: str | None = Query(None),
+    settings: bool = Query(False),
 ):
     parent_value = parent if isinstance(parent, str) else None
     search_value = search if isinstance(search, str) else None
 
-    root = _library_root(library)
+    root = _library_root(library, settings_mode=settings)
     current = root
     if parent_value:
         rel = Path(parent_value)
-        if rel.is_absolute():
-            raise HTTPException(status_code=400, detail="Invalid parent path")
-        current = _ensure_within_root(root, (root / rel).resolve())
+        if settings and rel.is_absolute():
+            current = _ensure_within_root(root, rel.resolve())
+        else:
+            if rel.is_absolute():
+                raise HTTPException(status_code=400, detail="Invalid parent path")
+            current = _ensure_within_root(root, (root / rel).resolve())
         if not current.exists() or not current.is_dir():
             raise HTTPException(status_code=404, detail="Parent directory not found")
 

--- a/frontend/src/components/FolderFinderModal.jsx
+++ b/frontend/src/components/FolderFinderModal.jsx
@@ -167,6 +167,7 @@ function FolderFinderModal({
       params.set('library', effectiveLibrary);
       if (path) params.set('parent', path);
       if (query) params.set('search', query);
+      if (isSettingsMode) params.set('settings', 'true');
 
       try {
         const response = await fetch(`/api/asset-folders?${params.toString()}`);
@@ -196,8 +197,25 @@ function FolderFinderModal({
 
   useEffect(() => {
     if (!isOpen) return;
-    loadFolders({ path: '', query: '' });
-  }, [isOpen, loadFolders]);
+    let initialPath = '';
+    if (isSettingsMode) {
+      if (target === 'collections') {
+        initialPath = normalizeText(collectionsSelection?.path || normalizedInitialCollections);
+      } else {
+        initialPath = normalizeText(assetSelection?.path || normalizedInitialAsset);
+      }
+    }
+    loadFolders({ path: initialPath, query: '', preserveSelection: true });
+  }, [
+    isOpen,
+    isSettingsMode,
+    target,
+    normalizedInitialAsset,
+    normalizedInitialCollections,
+    assetSelection,
+    collectionsSelection,
+    loadFolders,
+  ]);
 
   useEffect(() => {
     if (!isOpen) return undefined;

--- a/frontend/src/components/__tests__/FolderFinderModal.test.jsx
+++ b/frontend/src/components/__tests__/FolderFinderModal.test.jsx
@@ -90,4 +90,84 @@ describe('FolderFinderModal - settings mode', () => {
       );
     });
   });
+
+  it('navigates between mapping and assets root in settings mode', async () => {
+    const makeResponse = (payload) =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(payload),
+      });
+
+    const payloads = {
+      '': { parent: '', items: [
+        { name: 'Movies', path: 'Movies', isDir: true },
+        { name: 'LooseAssets', path: 'LooseAssets', isDir: true },
+      ] },
+      '/assets/Movies/Featured': {
+        parent: 'Movies/Featured',
+        items: [
+          { name: 'Posters', path: 'Movies/Featured/Posters', isDir: true },
+        ],
+      },
+      'Movies/Featured': {
+        parent: 'Movies/Featured',
+        items: [
+          { name: 'Posters', path: 'Movies/Featured/Posters', isDir: true },
+        ],
+      },
+      Movies: {
+        parent: 'Movies',
+        items: [
+          { name: 'Featured', path: 'Movies/Featured', isDir: true },
+        ],
+      },
+    };
+
+    global.fetch = vi.fn((url) => {
+      const parsed = new URL(url, 'http://localhost');
+      expect(parsed.searchParams.get('settings')).toBe('true');
+      const key = parsed.searchParams.get('parent') || '';
+      const payload = payloads[key];
+      if (!payload) {
+        throw new Error(`Unexpected parent ${key}`);
+      }
+      return makeResponse(payload);
+    });
+
+    render(
+      <FolderFinderModal
+        isOpen
+        context="settings"
+        library="Movies"
+        settingsLibraries={['Movies']}
+        defaultTarget="asset"
+        settingsIntent="asset"
+        onClose={vi.fn()}
+        onSettingsConfirm={vi.fn()}
+        initialAssetPath="/assets/Movies/Featured"
+      />
+    );
+
+    await screen.findByRole('button', { name: 'Posters' });
+
+    const breadcrumbNav = screen.getByLabelText('Folder breadcrumbs');
+    const moviesCrumb = within(breadcrumbNav).getByRole('button', { name: 'Movies' });
+    fireEvent.click(moviesCrumb);
+
+    await screen.findByRole('button', { name: 'Featured' });
+
+    const featuredFolder = screen.getByRole('button', { name: 'Featured' });
+    fireEvent.click(featuredFolder);
+
+    await screen.findByRole('button', { name: 'Posters' });
+
+    const rootCrumb = within(screen.getByLabelText('Folder breadcrumbs')).getByRole('button', {
+      name: 'Root',
+    });
+    fireEvent.click(rootCrumb);
+
+    await screen.findByRole('button', { name: 'LooseAssets' });
+
+    expect(global.fetch).toHaveBeenCalled();
+  });
 });

--- a/tests/test_libraries_settings_endpoints.py
+++ b/tests/test_libraries_settings_endpoints.py
@@ -259,3 +259,102 @@ def test_asset_folders_unmapped_library(tmp_path, monkeypatch):
         "/api/asset-folders", params={"library": "Documentaries", "parent": "../"}
     )
     assert invalid.status_code == 400
+
+
+def test_asset_folders_settings_mode_allows_assets_root(tmp_path, monkeypatch):
+    assets_root = tmp_path / "assets"
+    movies_dir = assets_root / "Movies"
+    featured_dir = movies_dir / "Featured"
+    posters_dir = featured_dir / "Posters"
+    loose_dir = assets_root / "LooseAssets"
+
+    posters_dir.mkdir(parents=True)
+    loose_dir.mkdir(parents=True)
+
+    monkeypatch.setenv("KAM_ASSETS_ROOT", str(assets_root))
+
+    resolve_module = importlib.reload(importlib.import_module("app.services.resolve"))
+    resolve_module.ASSETS_ROOT = str(assets_root)
+
+    settings_module = importlib.reload(importlib.import_module("app.services.settings"))
+    settings_module.set_settings_path(str(tmp_path / "settings.json"))
+    settings_module.save_settings(
+        {
+            "libraryMappings": [
+                {
+                    "library": "Movies",
+                    "assetPath": str(featured_dir),
+                    "collectionsPath": None,
+                }
+            ]
+        }
+    )
+
+    library_mappings_module = importlib.reload(
+        importlib.import_module("app.services.library_mappings")
+    )
+    library_mappings_module.clear_cache()
+
+    assets_router = importlib.reload(importlib.import_module("app.routers.assets"))
+
+    app = FastAPI()
+    app.include_router(assets_router.router)
+
+    client = TestClient(app)
+
+    # Runtime (non-settings) access remains scoped to the configured mapping
+    restricted = client.get("/api/asset-folders", params={"library": "Movies"})
+    assert restricted.status_code == 200
+    restricted_data = restricted.json()
+    restricted_names = {item["name"] for item in restricted_data["items"]}
+    assert restricted_names == {"Posters"}
+
+    # Settings browsing exposes the assets root even when a mapping exists
+    settings_root = client.get(
+        "/api/asset-folders",
+        params={"library": "Movies", "settings": "true"},
+    )
+    assert settings_root.status_code == 200
+    root_payload = settings_root.json()
+    root_names = {item["name"] for item in root_payload["items"]}
+    assert {"Movies", "LooseAssets"}.issubset(root_names)
+
+    # Absolute parent paths resolve relative to the assets root in settings mode
+    absolute = client.get(
+        "/api/asset-folders",
+        params={
+            "library": "Movies",
+            "settings": "true",
+            "parent": str(featured_dir),
+        },
+    )
+    assert absolute.status_code == 200
+    absolute_payload = absolute.json()
+    assert absolute_payload["parent"] == "Movies/Featured"
+    absolute_names = {item["name"] for item in absolute_payload["items"]}
+    assert "Posters" in absolute_names
+
+    # Relative navigation within settings mode continues to work
+    relative = client.get(
+        "/api/asset-folders",
+        params={
+            "library": "Movies",
+            "settings": "true",
+            "parent": "Movies",
+        },
+    )
+    assert relative.status_code == 200
+    relative_payload = relative.json()
+    assert relative_payload["parent"] == "Movies"
+    relative_names = {item["name"] for item in relative_payload["items"]}
+    assert "Featured" in relative_names
+
+    outside = client.get(
+        "/api/asset-folders",
+        params={
+            "library": "Movies",
+            "settings": "true",
+            "parent": str(tmp_path),
+        },
+    )
+    assert outside.status_code == 400


### PR DESCRIPTION
## Summary
- update the asset folder router to honor a settings flag, using the assets root for browsing even when a mapping exists and supporting absolute parent paths in that mode
- pass the new flag from the settings folder picker while seeding navigation from the current mapping so users can move between the mapping and assets root
- extend backend and frontend tests to cover settings-mode navigation behaviours

## Testing
- pytest tests/test_libraries_settings_endpoints.py *(skipped: requires optional httpx dependency)*
- npm --prefix frontend test -- --runInBand *(fails: vitest binary unavailable; npm install blocked by registry restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68e1de2be39c833088d0ede48a87b4ad