### PR TITLE
Filter music libraries from settings endpoint

### DIFF
--- a/app/routers/libraries.py
+++ b/app/routers/libraries.py
@@ -16,6 +16,18 @@ from ..services import library_mappings as library_mappings_service
 
 router = APIRouter()
 
+# Section types that should be ignored when listing available libraries. Plex
+# exposes music libraries with types like "artist"/"audio" which KAM cannot
+# currently map.
+IGNORED_SECTION_TYPES = {"artist", "audio"}
+
+
+def _is_supported_section(section_type: Optional[str]) -> bool:
+    if not section_type:
+        return True
+    return section_type.lower() not in IGNORED_SECTION_TYPES
+
+
 # --- Load mappings -----------------------------------------------------------
 
 def _asset_library_map() -> Dict[str, str]:
@@ -117,9 +129,14 @@ def list_available_libraries() -> List[LibrarySectionInfo]:
         name = str(getattr(section, "title", "") or "")
         key_value = getattr(section, "key", None)
         key_str = str(key_value) if key_value not in (None, "") else None
+        section_type = getattr(section, "type", None) or None
+
+        if not _is_supported_section(section_type):
+            continue
+
         entry = {
             "name": name,
-            "type": getattr(section, "type", None) or None,
+            "type": section_type,
             "key": key_str,
             "assetPath": None,
             "collectionsPath": None,

--- a/tests/test_libraries_settings_endpoints.py
+++ b/tests/test_libraries_settings_endpoints.py
@@ -76,6 +76,7 @@ def test_settings_libraries_endpoint_lists_sections(monkeypatch):
             _DummySection("TV Shows", "show", "2"),
             _DummySection("Documentaries", "show", "3"),
             _DummySection("Movies", "movie", "1"),
+            _DummySection("Music", "artist", "4"),
         ],
     )
 
@@ -104,6 +105,37 @@ def test_settings_libraries_endpoint_lists_sections(monkeypatch):
             "assetPath": None,
             "collectionsPath": None,
         },
+    ]
+
+
+def test_settings_libraries_endpoint_omits_music_sections(monkeypatch):
+    client = _create_libraries_client(
+        monkeypatch,
+        {
+            "theme": "dark",
+            "plexUrl": "http://plex.example:32400",
+            "plexToken": "token",
+            "libraryMappings": [],
+        },
+        sections=[
+            _DummySection("Music", "artist", "4"),
+            _DummySection("Concerts", "audio", "5"),
+            _DummySection("Movies", "movie", "1"),
+        ],
+    )
+
+    resp = client.get("/api/settings/libraries")
+    assert resp.status_code == 200
+    data = resp.json()
+
+    assert data == [
+        {
+            "name": "Movies",
+            "type": "movie",
+            "key": "1",
+            "assetPath": None,
+            "collectionsPath": None,
+        }
     ]
 
 


### PR DESCRIPTION
## Summary
- add a helper to skip unsupported music section types when listing Plex libraries
- ensure settings endpoint tests include and ignore dummy music sections

## Testing
- pytest tests/test_libraries_settings_endpoints.py

------
https://chatgpt.com/codex/tasks/task_e_68e1e175d398833081700031e07726cf