### PR TITLE
Streamline settings clearing controls

### DIFF
--- a/frontend/src/components/FolderFinderModal.jsx
+++ b/frontend/src/components/FolderFinderModal.jsx
@@ -57,6 +57,8 @@ function FolderFinderModal({
   initialAssetPath = '',
   initialCollectionsPath = '',
   onSettingsConfirm,
+  settingsCanClearAsset = false,
+  settingsCanClearCollections = false,
 }) {
   const isSettingsMode = context === 'settings';
   const normalizedInitialAsset = normalizeText(initialAssetPath);
@@ -280,6 +282,11 @@ function FolderFinderModal({
   const canConfirmSettings =
     (!requireAsset || Boolean(resolvedAssetPath)) &&
     (!requireCollections || Boolean(resolvedCollectionsPath));
+  const canClearCurrent = isSettingsMode
+    ? target === 'collections'
+      ? settingsCanClearCollections
+      : settingsCanClearAsset
+    : false;
 
   const activeSelection = isSettingsMode
     ? target === 'collections'
@@ -352,6 +359,19 @@ function FolderFinderModal({
     } finally {
       setAssigning(false);
     }
+  };
+
+  const handleClear = () => {
+    if (!isSettingsMode || !onSettingsConfirm) {
+      return;
+    }
+    setError('');
+    const clearTarget = target === 'collections' ? 'collections' : 'asset';
+    const payload =
+      clearTarget === 'collections'
+        ? { collectionsPath: '' }
+        : { assetPath: '', collectionsPath: '' };
+    onSettingsConfirm(payload, { clearTarget });
   };
 
   if (!isOpen) {
@@ -467,6 +487,11 @@ function FolderFinderModal({
             </p>
           </div>
           <div className="actions">
+            {isSettingsMode ? (
+              <button type="button" onClick={handleClear} disabled={!canClearCurrent || assigning}>
+                {target === 'collections' ? 'Clear collections folder' : 'Clear asset folder'}
+              </button>
+            ) : null}
             <button type="button" onClick={onClose} disabled={assigning}>
               Cancel
             </button>

--- a/frontend/src/pages/SettingsPage.jsx
+++ b/frontend/src/pages/SettingsPage.jsx
@@ -17,6 +17,8 @@ const initialModalState = {
   defaultTarget: 'asset',
   initialAssetPath: '',
   initialCollectionsPath: '',
+  canClearAsset: false,
+  canClearCollections: false,
 };
 
 const normalizeText = (value) => {
@@ -47,7 +49,6 @@ function SettingsPage() {
     saveSettings,
     revertSettings,
     refreshLibraries,
-    setLibraryMapping,
     setLibraryMappings,
   } = useTheme();
 
@@ -239,7 +240,6 @@ function SettingsPage() {
     .map((name) => libraryRowMap.get(name))
     .filter(Boolean);
   const selectionHasAsset = selectedRows.length > 0 && selectedRows.every((row) => row.assetPath);
-  const selectionHasCollections = selectedRows.some((row) => row.collectionsPath);
 
   const handleThemeChange = (event) => {
     applyTheme(event.target.value);
@@ -286,6 +286,9 @@ function SettingsPage() {
     }
     const primary = uniqueNames[0];
     const primaryRow = libraryRowMap.get(primary);
+    const modalRows = uniqueNames.map((name) => libraryRowMap.get(name)).filter(Boolean);
+    const canClearAsset = modalRows.some((row) => row.assetPath);
+    const canClearCollections = modalRows.some((row) => row.collectionsPath);
     setStatus(null);
     setModalState({
       open: true,
@@ -295,20 +298,63 @@ function SettingsPage() {
       defaultTarget: defaultTarget || (intent === 'collections' ? 'collections' : 'asset'),
       initialAssetPath: primaryRow?.assetPath || '',
       initialCollectionsPath: primaryRow?.collectionsPath || '',
+      canClearAsset,
+      canClearCollections,
     });
   };
 
   const handleModalConfirm = (values, meta = {}) => {
     const target = modalState.intent || 'asset';
     const names = modalState.libraries;
-    const assetPath = normalizeText(values?.assetPath);
-    const collectionsPath =
-      values?.collectionsPath === undefined ? undefined : normalizeText(values.collectionsPath);
 
     if (!names.length) {
       closeModal();
       return;
     }
+
+    if (meta?.clearTarget === 'asset') {
+      const rowsToClear = names
+        .map((name) => libraryRowMap.get(name))
+        .filter((row) => row?.assetPath);
+      if (!rowsToClear.length) {
+        setStatus({ type: 'error', message: 'Select libraries with asset folders to clear mappings.' });
+        return;
+      }
+      setLibraryMappings(names, { assetPath: '', collectionsPath: '' });
+      setStatus({
+        type: 'success',
+        message:
+          rowsToClear.length > 1
+            ? `Cleared mappings for ${rowsToClear.length} libraries.`
+            : `Cleared mapping for ${rowsToClear[0].name}.`,
+      });
+      closeModal();
+      return;
+    }
+
+    if (meta?.clearTarget === 'collections') {
+      const rowsToClear = names
+        .map((name) => libraryRowMap.get(name))
+        .filter((row) => row?.collectionsPath);
+      if (!rowsToClear.length) {
+        setStatus({ type: 'error', message: 'Select libraries with collections folders to clear.' });
+        return;
+      }
+      setLibraryMappings(names, { collectionsPath: '' });
+      setStatus({
+        type: 'success',
+        message:
+          rowsToClear.length > 1
+            ? `Cleared collections folders for ${rowsToClear.length} libraries.`
+            : `Cleared collections folder for ${rowsToClear[0].name}.`,
+      });
+      closeModal();
+      return;
+    }
+
+    const assetPath = normalizeText(values?.assetPath);
+    const collectionsPath =
+      values?.collectionsPath === undefined ? undefined : normalizeText(values.collectionsPath);
 
     if (target !== 'collections' && !assetPath) {
       setStatus({ type: 'error', message: 'Select an asset folder before applying changes.' });
@@ -381,62 +427,6 @@ function SettingsPage() {
       return;
     }
     openModal(selectedLibraries, 'collections', 'collections');
-  };
-
-  const handleClearCollections = (libraryName) => {
-    const row = libraryRowMap.get(libraryName);
-    if (!row?.assetPath) {
-      setStatus({
-        type: 'error',
-        message: `${libraryName} must have an asset folder before clearing collections.`,
-      });
-      return;
-    }
-    setLibraryMapping(libraryName, { collectionsPath: '' });
-    setStatus({
-      type: 'success',
-      message: `Cleared collections folder for ${libraryName}.`,
-    });
-  };
-
-  const handleClearCollectionsSelected = () => {
-    if (!selectionHasCollections) {
-      setStatus({ type: 'error', message: 'Select libraries with collections folders to clear.' });
-      return;
-    }
-    const rowsToClear = selectedRows.filter((row) => row.collectionsPath);
-    rowsToClear.forEach((row) => {
-      setLibraryMapping(row.name, { collectionsPath: '' });
-    });
-    setStatus({
-      type: 'success',
-      message: `Cleared collections folders for ${rowsToClear.length} libraries.`,
-    });
-  };
-
-  const handleClearMapping = (libraryName) => {
-    const row = libraryRowMap.get(libraryName);
-    if (!row?.assetPath) {
-      setStatus({ type: 'error', message: `${libraryName} does not have an asset folder to clear.` });
-      return;
-    }
-    setLibraryMapping(libraryName, { assetPath: '', collectionsPath: '' });
-    setStatus({ type: 'success', message: `Cleared mapping for ${libraryName}.` });
-  };
-
-  const handleClearMappingsSelected = () => {
-    const rowsToClear = selectedRows.filter((row) => row.assetPath);
-    if (!rowsToClear.length) {
-      setStatus({ type: 'error', message: 'Select libraries with asset folders to clear mappings.' });
-      return;
-    }
-    rowsToClear.forEach((row) => {
-      setLibraryMapping(row.name, { assetPath: '', collectionsPath: '' });
-    });
-    setStatus({
-      type: 'success',
-      message: `Cleared mappings for ${rowsToClear.length} libraries.`,
-    });
   };
 
   const handleRefreshLibraries = async () => {
@@ -578,20 +568,6 @@ function SettingsPage() {
               >
                 Set collections folder for selected
               </button>
-              <button
-                type="button"
-                onClick={handleClearCollectionsSelected}
-                disabled={!selectionHasCollections || combinedBusy}
-              >
-                Clear collections folders
-              </button>
-              <button
-                type="button"
-                onClick={handleClearMappingsSelected}
-                disabled={!selectedRows.some((row) => row.assetPath) || combinedBusy}
-              >
-                Clear mappings
-              </button>
             </div>
             <div className="settings-libraries-group">
               <button type="button" onClick={handleRefreshLibraries} disabled={combinedBusy}>
@@ -674,20 +650,6 @@ function SettingsPage() {
                           >
                             Set collections folder
                           </button>
-                          <button
-                            type="button"
-                            onClick={() => handleClearCollections(row.name)}
-                            disabled={combinedBusy || !row.collectionsPath}
-                          >
-                            Clear collections
-                          </button>
-                          <button
-                            type="button"
-                            onClick={() => handleClearMapping(row.name)}
-                            disabled={combinedBusy || !row.assetPath}
-                          >
-                            Clear mapping
-                          </button>
                         </td>
                       </tr>
                     );
@@ -717,6 +679,8 @@ function SettingsPage() {
         settingsIntent={modalState.intent}
         initialAssetPath={modalState.initialAssetPath}
         initialCollectionsPath={modalState.initialCollectionsPath}
+        settingsCanClearAsset={modalState.canClearAsset}
+        settingsCanClearCollections={modalState.canClearCollections}
         onClose={closeModal}
         onSettingsConfirm={handleModalConfirm}
       />

--- a/frontend/src/pages/__tests__/SettingsPage.test.jsx
+++ b/frontend/src/pages/__tests__/SettingsPage.test.jsx
@@ -48,7 +48,6 @@ describe('SettingsPage', () => {
       saveSettings: mockSave,
       revertSettings: vi.fn(),
       refreshLibraries: mockRefresh,
-      setLibraryMapping: vi.fn(),
       setLibraryMappings: vi.fn(),
     });
 
@@ -95,7 +94,6 @@ describe('SettingsPage', () => {
       saveSettings: vi.fn(),
       revertSettings: vi.fn(),
       refreshLibraries: vi.fn(),
-      setLibraryMapping: vi.fn(),
       setLibraryMappings: vi.fn(),
     });
 
@@ -131,7 +129,6 @@ describe('SettingsPage', () => {
       saveSettings: vi.fn().mockResolvedValue({}),
       revertSettings: vi.fn(),
       refreshLibraries: mockRefresh,
-      setLibraryMapping: vi.fn(),
       setLibraryMappings: vi.fn(),
     });
 
@@ -170,7 +167,6 @@ describe('SettingsPage', () => {
       saveSettings: vi.fn(),
       revertSettings: vi.fn(),
       refreshLibraries: vi.fn(),
-      setLibraryMapping: vi.fn(),
       setLibraryMappings: vi.fn(),
     });
 
@@ -206,7 +202,6 @@ describe('SettingsPage', () => {
       saveSettings: vi.fn(),
       revertSettings: vi.fn(),
       refreshLibraries: vi.fn(),
-      setLibraryMapping: vi.fn(),
       setLibraryMappings: vi.fn(),
     });
 
@@ -218,6 +213,76 @@ describe('SettingsPage', () => {
 
     const status = await screen.findByRole('status');
     expect(status).toHaveTextContent('Saving settings…');
+  });
+
+  it('allows clearing asset folders through the modal', async () => {
+    const mockSetLibraryMappings = vi.fn();
+    const mockRefresh = vi.fn().mockResolvedValue([]);
+    global.fetch.mockImplementation(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ folders: [] }),
+      })
+    );
+
+    useTheme.mockReturnValue({
+      theme: 'dark',
+      savedTheme: 'dark',
+      plexUrl: 'http://plex.local',
+      plexToken: 'token',
+      savedSettings: { plexUrl: 'http://plex.local', plexToken: 'token' },
+      libraryMappings: [
+        { library: 'Movies', assetPath: '/assets/Movies', collectionsPath: '/collections/Movies' },
+      ],
+      savedLibraryMappings: [
+        { library: 'Movies', assetPath: '/assets/Movies', collectionsPath: '/collections/Movies' },
+      ],
+      libraries: [
+        {
+          name: 'Movies',
+          type: 'movie',
+          key: '1',
+          assetPath: '/assets/Movies',
+          collectionsPath: '/collections/Movies',
+        },
+      ],
+      librariesLoading: false,
+      librariesError: null,
+      loading: false,
+      saving: false,
+      error: null,
+      libraryMappingsDirty: false,
+      hasUnsavedChanges: false,
+      applyTheme: vi.fn(),
+      updateSettings: vi.fn(),
+      saveSettings: vi.fn(),
+      revertSettings: vi.fn(),
+      refreshLibraries: mockRefresh,
+      setLibraryMappings: mockSetLibraryMappings,
+    });
+
+    render(
+      <MemoryRouter>
+        <SettingsPage />
+      </MemoryRouter>
+    );
+
+    const openModalButton = screen.getAllByRole('button', { name: 'Set asset folder' })[0];
+    fireEvent.click(openModalButton);
+
+    const clearButton = await screen.findByRole('button', { name: 'Clear asset folder' });
+    expect(clearButton).not.toBeDisabled();
+
+    fireEvent.click(clearButton);
+
+    await waitFor(() => {
+      expect(mockSetLibraryMappings).toHaveBeenCalledWith(['Movies'], {
+        assetPath: '',
+        collectionsPath: '',
+      });
+    });
+
+    expect(await screen.findByRole('status')).toHaveTextContent('Cleared mapping for Movies.');
   });
 
   it('clears transient info statuses after loading completes', async () => {
@@ -242,7 +307,6 @@ describe('SettingsPage', () => {
       saveSettings: vi.fn(),
       revertSettings: vi.fn(),
       refreshLibraries: vi.fn(),
-      setLibraryMapping: vi.fn(),
       setLibraryMappings: vi.fn(),
     };
 
@@ -292,7 +356,6 @@ describe('SettingsPage', () => {
       saveSettings: mockSave,
       revertSettings: vi.fn(),
       refreshLibraries: vi.fn(),
-      setLibraryMapping: vi.fn(),
       setLibraryMappings: vi.fn(),
     });
 


### PR DESCRIPTION
## Summary
- remove the clear mapping and collections buttons from the settings toolbar and per-row actions
- add a clear folder control inside the settings FolderFinderModal that updates selected libraries
- refresh settings page tests to reflect the streamlined layout and cover clearing via the modal

## Testing
- npm test -- --runInBand *(fails: vitest binary not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1e1e635f0833084b698752d90c422