### PR TITLE
Allow selecting current folder in settings modal

### DIFF
--- a/frontend/src/components/FolderFinderModal.jsx
+++ b/frontend/src/components/FolderFinderModal.jsx
@@ -131,7 +131,9 @@ function FolderFinderModal({
       const text = normalizeText(collectionsSelection?.path ?? normalizedInitialCollections);
       setCurrentFolder(text || '');
     } else {
-      const text = normalizeText(assetSelection?.path ?? normalizedInitialAsset);
+      const fallbackCurrent = normalizeText(currentPath);
+      const selectedOrInitial = assetSelection?.path ?? normalizedInitialAsset;
+      const text = normalizeText(selectedOrInitial || fallbackCurrent);
       setCurrentFolder(text || '');
     }
   }, [
@@ -142,6 +144,7 @@ function FolderFinderModal({
     collectionsSelection,
     normalizedInitialAsset,
     normalizedInitialCollections,
+    currentPath,
   ]);
 
   const loadFolders = useCallback(
@@ -230,7 +233,12 @@ function FolderFinderModal({
 
   useEffect(() => {
     if (!isOpen) return;
-    loadFolders({ path: currentPath, query: searchTerm, preserveSelection: false });
+    const isSearchActive = Boolean(searchTerm);
+    loadFolders({
+      path: currentPath,
+      query: searchTerm,
+      preserveSelection: !isSearchActive,
+    });
   }, [searchTerm, isOpen, currentPath, loadFolders]);
 
   const breadcrumbs = useMemo(
@@ -275,7 +283,10 @@ function FolderFinderModal({
     setSearchTerm('');
   };
 
-  const resolvedAssetPath = assetSelection?.path || normalizedInitialAsset;
+  const resolvedAssetPath =
+    assetSelection?.path ||
+    normalizedInitialAsset ||
+    (isSettingsMode ? normalizeText(currentPath) : '');
   const resolvedCollectionsPath = collectionsSelection?.path || normalizedInitialCollections;
   const requireAsset = settingsIntent !== 'collections';
   const requireCollections = settingsIntent === 'collections';

--- a/frontend/src/components/__tests__/FolderFinderModal.test.jsx
+++ b/frontend/src/components/__tests__/FolderFinderModal.test.jsx
@@ -51,6 +51,71 @@ describe('FolderFinderModal - settings mode', () => {
     });
   });
 
+  it('allows confirming using the currently open folder when nothing is selected', async () => {
+    const onSettingsConfirm = vi.fn();
+
+    const payloads = {
+      '': {
+        parent: '',
+        items: [{ name: 'Kids TV', path: 'Kids TV', isDir: true }],
+      },
+      'Kids TV': {
+        parent: 'Kids TV',
+        items: [],
+      },
+    };
+
+    global.fetch = vi.fn((url) => {
+      const parsed = new URL(url, 'http://localhost');
+      const parent = parsed.searchParams.get('parent') || '';
+      const payload = payloads[parent];
+      if (!payload) {
+        throw new Error(`Unexpected parent ${parent}`);
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(payload),
+      });
+    });
+
+    render(
+      <FolderFinderModal
+        isOpen
+        context="settings"
+        library="Kids"
+        settingsLibraries={['Kids']}
+        defaultTarget="asset"
+        settingsIntent="asset"
+        onClose={vi.fn()}
+        onSettingsConfirm={onSettingsConfirm}
+      />
+    );
+
+    const openButton = await screen.findByRole('button', { name: 'Open' });
+    fireEvent.click(openButton);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('parent=Kids%20TV')
+      );
+    });
+
+    const confirmButton = await screen.findByRole('button', { name: /Apply selection/i });
+
+    await waitFor(() => {
+      expect(confirmButton).not.toBeDisabled();
+    });
+
+    fireEvent.click(confirmButton);
+
+    await waitFor(() => {
+      expect(onSettingsConfirm).toHaveBeenCalledWith(
+        { assetPath: 'Kids TV' },
+        expect.objectContaining({ assetSelection: null, collectionsSelection: null })
+      );
+    });
+  });
+
   it('returns both asset and collections selections when provided', async () => {
     const onSettingsConfirm = vi.fn();
 


### PR DESCRIPTION
## Summary
- keep the current folder in view when navigating the settings folder picker so the modal reflects the active path
- let the settings confirmation fall back to the folder that is currently open so libraries without mappings can be assigned
- preserve selections while browsing unless a search is active and add a regression test that covers confirming from the open folder

## Testing
- npm test -- --runInBand *(fails: vitest not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e1c96b6bac8330a0538a4a20b20307