### PR TITLE
Add Kometa config picker modal and scanning support

### DIFF
--- a/app/routers/settings.py
+++ b/app/routers/settings.py
@@ -1,7 +1,7 @@
 """Settings API endpoints."""
 from __future__ import annotations
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 from typing import List, Literal
 from urllib.parse import urlparse
@@ -131,3 +131,39 @@ def update_library_mappings(payload: LibraryMappingsUpdatePayload) -> List[Libra
     )
     mappings = stored.get("libraryMappings", [])
     return [LibraryMappingPayload(**item) for item in mappings]
+
+
+class KometaConfigEntry(BaseModel):
+    name: str
+    path: str
+    isDir: bool
+    isFile: bool
+
+
+class KometaConfigBrowseResponse(BaseModel):
+    root: str
+    parent: str
+    items: List[KometaConfigEntry]
+    selection: str | None = None
+
+
+@router.get(
+    "/api/settings/kometa-config/browse",
+    response_model=KometaConfigBrowseResponse,
+)
+def browse_kometa_config(
+    parent: str | None = Query(None),
+    search: str | None = Query(None),
+    current: str | None = Query(None),
+) -> KometaConfigBrowseResponse:
+    try:
+        data = kometa_config_service.browse_config_locations(
+            parent=parent, search=search, current=current
+        )
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    except PermissionError as exc:
+        raise HTTPException(status_code=403, detail=str(exc))
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return KometaConfigBrowseResponse(**data)

--- a/app/services/kometa_config.py
+++ b/app/services/kometa_config.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 import os
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set, TypedDict
+from typing import Any, Dict, Iterable, List, Optional, Set, TypedDict
 
 import yaml
 
@@ -15,6 +15,8 @@ __all__ = [
     "normalize_config_path",
     "extract_library_info",
     "load_library_summaries",
+    "candidate_config_roots",
+    "browse_config_locations",
 ]
 
 logger = logging.getLogger(__name__)
@@ -154,4 +156,268 @@ def load_library_summaries(path: str | os.PathLike[str] | None) -> Dict[str, Kom
             results[name.strip()] = {}
 
     return results
+
+
+def _nearest_existing_dir(path: Path) -> Optional[Path]:
+    """Return the closest existing directory for *path* (including parents)."""
+
+    try:
+        candidate = path.resolve(strict=False)
+    except Exception:  # pragma: no cover - defensive
+        candidate = path
+
+    visited: Set[Path] = set()
+    current = candidate
+    while True:
+        if current in visited:
+            break
+        visited.add(current)
+        if current.exists():
+            if current.is_dir():
+                try:
+                    return current.resolve()
+                except Exception:  # pragma: no cover - best-effort resolution
+                    return current
+            if current.is_file():
+                current = current.parent
+                continue
+        parent = current.parent
+        if parent == current:
+            break
+        current = parent
+
+    if current.exists() and current.is_dir():
+        try:
+            return current.resolve()
+        except Exception:  # pragma: no cover - best-effort resolution
+            return current
+    return None
+
+
+def _dedupe_paths(paths: Iterable[Path]) -> List[Path]:
+    seen: Set[str] = set()
+    result: List[Path] = []
+    for path in paths:
+        try:
+            resolved = path.resolve()
+        except Exception:  # pragma: no cover - defensive
+            resolved = path
+        key = resolved.as_posix()
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(resolved)
+    return result
+
+
+def candidate_config_roots(
+    current: str | os.PathLike[str] | None = None,
+) -> List[Path]:
+    """Return possible base directories to browse for Kometa configs."""
+
+    raw_candidates: List[str] = []
+    if current:
+        normalized_current = normalize_config_path(current)
+        if normalized_current:
+            raw_candidates.append(normalized_current)
+
+    try:
+        from . import settings as settings_service  # Local import to avoid circular
+
+        stored_path = settings_service.load_settings().get("kometaConfigPath")
+        if stored_path:
+            normalized_stored = normalize_config_path(stored_path)
+            if normalized_stored:
+                raw_candidates.append(normalized_stored)
+    except Exception:  # pragma: no cover - defensive
+        logger.debug("Unable to load stored Kometa config path", exc_info=True)
+
+    env_path = os.environ.get("KOMETA_CONFIG_PATH")
+    if env_path:
+        normalized_env = normalize_config_path(env_path)
+        if normalized_env:
+            raw_candidates.append(normalized_env)
+
+    # Provide sensible defaults inside containers where Kometa configs are often mounted.
+    raw_candidates.extend(["/config", "/configs", "/etc", "/data"])
+
+    directories: List[Path] = []
+    for raw in raw_candidates:
+        try:
+            candidate = Path(raw)
+        except TypeError:  # pragma: no cover - defensive
+            continue
+        existing = _nearest_existing_dir(candidate)
+        if existing:
+            directories.append(existing)
+
+    if not directories:
+        fallback = _nearest_existing_dir(Path.cwd())
+        if fallback:
+            directories.append(fallback)
+
+    return _dedupe_paths(directories)
+
+
+def _ensure_within_root(root: Path, target: Path) -> Path:
+    root_resolved = root.resolve()
+    target_resolved = target.resolve()
+    try:
+        target_resolved.relative_to(root_resolved)
+    except ValueError:
+        raise ValueError("Invalid path outside Kometa config root")
+    return target_resolved
+
+
+def browse_config_locations(
+    *,
+    parent: str | None = None,
+    search: str | None = None,
+    current: str | os.PathLike[str] | None = None,
+) -> Dict[str, Any]:
+    """Return directory contents suitable for browsing Kometa config files."""
+
+    normalized_current = normalize_config_path(current)
+    roots = candidate_config_roots(normalized_current)
+    if not roots:
+        raise FileNotFoundError("No Kometa config directories are available")
+
+    root = roots[0]
+    root_resolved = root.resolve()
+
+    parent_value = normalize_path(parent) if parent else ""
+    if parent_value in (".", ""):
+        parent_value = ""
+
+    if parent_value:
+        parent_path = Path(parent_value)
+        if any(part == ".." for part in parent_path.parts):
+            raise ValueError("Invalid parent path")
+        candidate_dir = (root_resolved / parent_path).resolve()
+        candidate_dir = _ensure_within_root(root_resolved, candidate_dir)
+        if not candidate_dir.exists() or not candidate_dir.is_dir():
+            raise FileNotFoundError("Directory not found")
+        current_dir = candidate_dir
+    else:
+        current_dir = root_resolved
+
+    selection_rel = ""
+
+    if not parent_value and normalized_current:
+        current_path = Path(normalized_current)
+        try:
+            current_resolved = current_path.resolve(strict=False)
+        except Exception:  # pragma: no cover - defensive
+            current_resolved = current_path
+        try:
+            rel_to_root = current_resolved.relative_to(root_resolved)
+        except ValueError:
+            rel_to_root = None
+
+        if rel_to_root is not None:
+            candidate_dir = current_resolved
+            if candidate_dir.exists() and candidate_dir.is_dir():
+                current_dir = candidate_dir
+                parent_value = rel_to_root.as_posix()
+                if parent_value == ".":
+                    parent_value = ""
+            else:
+                selection_rel = rel_to_root.as_posix()
+                if selection_rel == ".":
+                    selection_rel = ""
+                candidate_parent = current_resolved.parent
+                while True:
+                    try:
+                        rel_parent = candidate_parent.relative_to(root_resolved)
+                    except ValueError:
+                        break
+                    if candidate_parent.exists() and candidate_parent.is_dir():
+                        current_dir = candidate_parent
+                        parent_value = rel_parent.as_posix()
+                        if parent_value == ".":
+                            parent_value = ""
+                        break
+                    if candidate_parent == root_resolved:
+                        current_dir = root_resolved
+                        parent_value = ""
+                        break
+                    candidate_parent = candidate_parent.parent
+
+    try:
+        current_dir = _ensure_within_root(root_resolved, current_dir)
+    except ValueError as exc:
+        raise ValueError(str(exc))
+
+    if not current_dir.exists() or not current_dir.is_dir():
+        raise FileNotFoundError("Directory not found")
+
+    term = (search or "").strip().lower()
+    items: List[Dict[str, Any]] = []
+
+    try:
+        if term:
+            matches: List[Path] = []
+            for child in current_dir.rglob("*"):
+                try:
+                    name_lower = child.name.lower()
+                    is_valid = child.is_dir() or child.is_file()
+                except PermissionError:
+                    continue
+                if term not in name_lower or not is_valid:
+                    continue
+                try:
+                    resolved_child = child.resolve()
+                    resolved_child.relative_to(root_resolved)
+                except (OSError, ValueError):
+                    continue
+                matches.append(resolved_child)
+            matches.sort(
+                key=lambda p: (not p.is_dir(), str(p.relative_to(root_resolved)).lower())
+            )
+            for child in matches:
+                rel_path = child.relative_to(root_resolved)
+                rel_text = rel_path.as_posix()
+                if rel_text == ".":
+                    rel_text = ""
+                items.append(
+                    {
+                        "name": child.name,
+                        "path": rel_text,
+                        "isDir": child.is_dir(),
+                        "isFile": child.is_file(),
+                    }
+                )
+        else:
+            entries = sorted(
+                current_dir.iterdir(), key=lambda p: (not p.is_dir(), p.name.lower())
+            )
+            for child in entries:
+                try:
+                    resolved_child = child.resolve()
+                    resolved_child.relative_to(root_resolved)
+                except (OSError, ValueError):
+                    continue
+                rel_path = resolved_child.relative_to(root_resolved)
+                rel_text = rel_path.as_posix()
+                if rel_text == ".":
+                    rel_text = ""
+                items.append(
+                    {
+                        "name": child.name,
+                        "path": rel_text,
+                        "isDir": resolved_child.is_dir(),
+                        "isFile": resolved_child.is_file(),
+                    }
+                )
+    except PermissionError:
+        raise PermissionError("Permission denied")
+
+    parent_value = parent_value or ""
+
+    return {
+        "root": root_resolved.as_posix(),
+        "parent": parent_value,
+        "items": items,
+        "selection": selection_rel or None,
+    }
 

--- a/frontend/src/components/ConfigFinderModal.jsx
+++ b/frontend/src/components/ConfigFinderModal.jsx
@@ -1,0 +1,342 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+const normalizeText = (value) => {
+  if (value == null) return '';
+  return String(value).trim();
+};
+
+const joinRootWithRelative = (root, relative) => {
+  const base = normalizeText(root);
+  const rel = normalizeText(relative);
+  if (!rel) {
+    return base;
+  }
+  if (rel.startsWith('/')) {
+    return rel;
+  }
+  if (!base || base === '/') {
+    return `/${rel}`.replace(/\/+/g, '/');
+  }
+  const cleanedBase = base.endsWith('/') ? base.slice(0, -1) : base;
+  return `${cleanedBase}/${rel}`.replace(/\/+/g, '/');
+};
+
+const makeBreadcrumbs = (rootPath, parentPath, isSearching, term) => {
+  const crumbs = [];
+  const rootLabel = normalizeText(rootPath) || 'Root';
+  crumbs.push({ label: rootLabel, path: '' });
+  const relative = normalizeText(parentPath);
+  if (relative) {
+    const parts = relative.split('/').filter(Boolean);
+    let acc = '';
+    parts.forEach((part) => {
+      acc = acc ? `${acc}/${part}` : part;
+      crumbs.push({ label: part, path: acc });
+    });
+  }
+  if (isSearching && term) {
+    crumbs.push({ label: `Search: ${term}`, path: null, isSearch: true });
+  }
+  return crumbs;
+};
+
+function ConfigFinderModal({
+  isOpen,
+  initialPath = '',
+  onClose,
+  onConfirm,
+  onClear,
+}) {
+  const [rootPath, setRootPath] = useState('');
+  const [parentPath, setParentPath] = useState('');
+  const [items, setItems] = useState([]);
+  const [selectedPath, setSelectedPath] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [searchInput, setSearchInput] = useState('');
+  const [searchTerm, setSearchTerm] = useState('');
+  const [isSearching, setIsSearching] = useState(false);
+
+  const initialPathRef = useRef('');
+  const selectedPathRef = useRef('');
+  const selectedAbsoluteRef = useRef('');
+  const debounceRef = useRef();
+
+  const resetState = useCallback(() => {
+    setItems([]);
+    setSelectedPath('');
+    setError('');
+    setSearchInput('');
+    setSearchTerm('');
+    setIsSearching(false);
+    selectedPathRef.current = '';
+    selectedAbsoluteRef.current = '';
+  }, []);
+
+  const loadEntries = useCallback(
+    async ({ parent = '', search = '', initial = false } = {}) => {
+      if (!isOpen) {
+        return;
+      }
+      setLoading(true);
+      setError('');
+      setIsSearching(Boolean(search));
+      const params = new URLSearchParams();
+      if (parent) params.set('parent', parent);
+      if (search) params.set('search', search);
+
+      const effectiveCurrent = initial
+        ? normalizeText(initialPathRef.current)
+        : normalizeText(selectedAbsoluteRef.current || initialPathRef.current);
+      if (effectiveCurrent) {
+        params.set('current', effectiveCurrent);
+      }
+
+      const query = params.toString();
+      const url = query
+        ? `/api/settings/kometa-config/browse?${query}`
+        : '/api/settings/kometa-config/browse';
+
+      try {
+        const response = await fetch(url);
+        const data = await response.json();
+        if (!response.ok) {
+          const message = data?.detail || data?.error || `${response.status} ${response.statusText}`;
+          throw new Error(message);
+        }
+        const normalizedRoot = normalizeText(data?.root);
+        const normalizedParent = normalizeText(data?.parent);
+        const normalizedSelection = normalizeText(data?.selection);
+        const normalizedItems = Array.isArray(data?.items)
+          ? data.items
+              .map((entry) => ({
+                name: normalizeText(entry?.name),
+                path: normalizeText(entry?.path),
+                isDir: Boolean(entry?.isDir),
+                isFile: Boolean(entry?.isFile),
+              }))
+              .filter((entry) => entry.name)
+          : [];
+
+        setRootPath(normalizedRoot);
+        setParentPath(normalizedParent);
+        setItems(normalizedItems);
+
+        let nextSelection = normalizedSelection || selectedPathRef.current;
+        if (nextSelection && !normalizedItems.some((entry) => entry.path === nextSelection)) {
+          // Preserve selection even if it's outside the current listing (e.g., different folder).
+          nextSelection = normalizedSelection || selectedPathRef.current;
+        }
+        nextSelection = normalizeText(nextSelection);
+        setSelectedPath(nextSelection);
+        selectedPathRef.current = nextSelection;
+        const absolute = nextSelection ? joinRootWithRelative(normalizedRoot, nextSelection) : '';
+        selectedAbsoluteRef.current = absolute;
+      } catch (err) {
+        setItems([]);
+        setError(err?.message || 'Failed to load Kometa config files.');
+      } finally {
+        setLoading(false);
+      }
+    },
+    [isOpen]
+  );
+
+  useEffect(() => {
+    if (!isOpen) {
+      resetState();
+      return;
+    }
+    initialPathRef.current = normalizeText(initialPath);
+    selectedAbsoluteRef.current = normalizeText(initialPath);
+    selectedPathRef.current = '';
+    setError('');
+    setSearchInput('');
+    setSearchTerm('');
+    setIsSearching(false);
+    loadEntries({ parent: '', search: '', initial: true });
+  }, [initialPath, isOpen, loadEntries, resetState]);
+
+  useEffect(() => {
+    if (!isOpen) return undefined;
+    clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      setSearchTerm(searchInput.trim());
+    }, 250);
+    return () => clearTimeout(debounceRef.current);
+  }, [searchInput, isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    loadEntries({ parent: parentPath, search: searchTerm });
+  }, [searchTerm, parentPath, isOpen, loadEntries]);
+
+  const breadcrumbs = useMemo(
+    () => makeBreadcrumbs(rootPath, parentPath, isSearching, searchTerm),
+    [rootPath, parentPath, isSearching, searchTerm]
+  );
+
+  const handleBreadcrumbClick = (crumb) => {
+    if (crumb.isSearch) return;
+    setSearchInput('');
+    setSearchTerm('');
+    loadEntries({ parent: crumb.path || '', search: '' });
+  };
+
+  const handleSelectEntry = (entry) => {
+    if (!entry) return;
+    setError('');
+    if (entry.isDir) {
+      setSelectedPath('');
+      selectedPathRef.current = '';
+      selectedAbsoluteRef.current = '';
+      setSearchInput('');
+      setSearchTerm('');
+      loadEntries({ parent: entry.path || '', search: '' });
+      return;
+    }
+    if (!entry.isFile) return;
+    setSelectedPath(entry.path);
+    selectedPathRef.current = entry.path;
+    selectedAbsoluteRef.current = joinRootWithRelative(rootPath, entry.path);
+  };
+
+  const handleClearSelection = () => {
+    setSelectedPath('');
+    selectedPathRef.current = '';
+    selectedAbsoluteRef.current = '';
+    setError('');
+    onClear?.();
+  };
+
+  const handleConfirm = (event) => {
+    event.preventDefault();
+    if (!selectedPathRef.current) {
+      setError('Select a config file before confirming.');
+      return;
+    }
+    const absolute = joinRootWithRelative(rootPath, selectedPathRef.current);
+    if (!absolute) {
+      setError('Unable to resolve the selected config file.');
+      return;
+    }
+    onConfirm?.(absolute);
+  };
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="dialog-backdrop">
+      <div
+        className="dialog-panel folder-dlg"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="configFinderHeading"
+      >
+        <form onSubmit={handleConfirm}>
+          <div className="dialog-body">
+            <h2 id="configFinderHeading">Select Kometa Config File</h2>
+            <nav aria-label="Config breadcrumbs">
+              <ol className="breadcrumbs">
+                {breadcrumbs.map((crumb, index) => (
+                  <li key={`${crumb.label}-${index}`}>
+                    {crumb.isSearch ? (
+                      <span className="tag">{crumb.label}</span>
+                    ) : (
+                      <button
+                        type="button"
+                        onClick={() => handleBreadcrumbClick(crumb)}
+                        disabled={index === breadcrumbs.length - 1 && !isSearching}
+                        aria-current={index === breadcrumbs.length - 1 && !isSearching ? 'location' : undefined}
+                      >
+                        {crumb.label}
+                      </button>
+                    )}
+                    {index < breadcrumbs.length - 1 && !crumb.isSearch ? <span aria-hidden="true">/</span> : null}
+                  </li>
+                ))}
+              </ol>
+            </nav>
+            <div className="folder-search">
+              <label htmlFor="configFinderSearch">Search config files</label>
+              <input
+                id="configFinderSearch"
+                type="search"
+                placeholder="Search by name"
+                value={searchInput}
+                onChange={(event) => setSearchInput(event.target.value)}
+                autoComplete="off"
+              />
+            </div>
+            <ul className="folder-results" role="listbox">
+              {loading && <li className="folder-empty">Loading entries…</li>}
+              {!loading && !items.length && (
+                <li className="folder-empty">
+                  {isSearching && searchTerm
+                    ? 'No entries matched your search.'
+                    : 'No files or folders available in this location.'}
+                </li>
+              )}
+              {!loading &&
+                items.map((entry) => {
+                  const isSelected = !entry.isDir && entry.path === selectedPath;
+                  return (
+                    <li
+                      key={`${entry.path}-${entry.name}`}
+                      className={`folder-row${isSelected ? ' is-selected' : ''}`}
+                      role="option"
+                      aria-selected={isSelected}
+                    >
+                      <button
+                        type="button"
+                        className="folder-option"
+                        onClick={() => handleSelectEntry(entry)}
+                      >
+                        {entry.name}
+                      </button>
+                      {entry.isDir ? (
+                        <button
+                          type="button"
+                          className="folder-open"
+                          onClick={() => handleSelectEntry(entry)}
+                        >
+                          {isSearching ? 'Go' : 'Open'}
+                        </button>
+                      ) : (
+                        <span className="tag">File</span>
+                      )}
+                    </li>
+                  );
+                })}
+            </ul>
+            <p className="folder-alert" role="alert">
+              {error}
+            </p>
+            {selectedPath ? (
+              <p className="folder-selection" aria-live="polite">
+                Selected: <code>{joinRootWithRelative(rootPath, selectedPath)}</code>
+              </p>
+            ) : null}
+          </div>
+          <div className="actions">
+            {onClear ? (
+              <button type="button" onClick={handleClearSelection} disabled={!selectedPath}>
+                Clear config path
+              </button>
+            ) : null}
+            <button type="button" onClick={onClose}>
+              Cancel
+            </button>
+            <button type="submit" className="btn" disabled={!selectedPath}>
+              Use this file
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export default ConfigFinderModal;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -809,6 +809,23 @@ main {
   width: 100%;
 }
 
+.settings-config-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.settings-config-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.settings-config-scan {
+  align-self: flex-start;
+  margin-top: 4px;
+}
+
 .settings-radio {
   display: inline-flex;
   align-items: center;

--- a/frontend/src/pages/SettingsPage.jsx
+++ b/frontend/src/pages/SettingsPage.jsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
+import ConfigFinderModal from '../components/ConfigFinderModal.jsx';
 import FolderFinderModal from '../components/FolderFinderModal.jsx';
 import { useTheme } from '../theme/ThemeProvider.jsx';
 import {
@@ -57,6 +58,8 @@ function SettingsPage() {
   const [status, setStatus] = useState(null);
   const [selectedLibraries, setSelectedLibraries] = useState([]);
   const [modalState, setModalState] = useState(initialModalState);
+  const [configModalOpen, setConfigModalOpen] = useState(false);
+  const [configScanInProgress, setConfigScanInProgress] = useState(false);
   const selectAllRef = useRef(null);
   const previousLoadingFlagsRef = useRef({
     loading,
@@ -67,6 +70,7 @@ function SettingsPage() {
   const savedPlexUrl = savedSettings?.plexUrl || '';
   const savedPlexToken = savedSettings?.plexToken || '';
   const savedKometaPath = savedKometaConfigPath || savedSettings?.kometaConfigPath || '';
+  const configModalInitialPath = kometaConfigPath || savedKometaPath;
 
   useEffect(() => {
     if (error) {
@@ -285,9 +289,29 @@ function SettingsPage() {
     setStatus(null);
   };
 
-  const handleKometaConfigPathChange = (event) => {
-    updateSettings({ kometaConfigPath: event.target.value });
+  const handleOpenKometaConfigModal = () => {
     setStatus(null);
+    setConfigModalOpen(true);
+  };
+
+  const handleCloseKometaConfigModal = () => {
+    setConfigModalOpen(false);
+  };
+
+  const handleKometaConfigSelected = (nextPath) => {
+    updateSettings({ kometaConfigPath: nextPath });
+    setConfigModalOpen(false);
+    setStatus({ type: 'success', message: 'Kometa config path updated.' });
+  };
+
+  const handleClearKometaConfig = () => {
+    updateSettings({ kometaConfigPath: '' });
+    setStatus({ type: 'success', message: 'Kometa config path cleared.' });
+  };
+
+  const handleModalClearKometaConfig = () => {
+    handleClearKometaConfig();
+    setConfigModalOpen(false);
   };
 
   const handleToggleLibrary = (libraryName) => {
@@ -463,6 +487,19 @@ function SettingsPage() {
     openModal(selectedLibraries, 'collections', 'collections');
   };
 
+  const handleScanKometaConfig = async () => {
+    setStatus(null);
+    setConfigScanInProgress(true);
+    try {
+      await refreshLibraries();
+      setStatus({ type: 'success', message: 'Kometa config scanned.' });
+    } catch (err) {
+      setStatus({ type: 'error', message: err?.message || 'Failed to scan Kometa config.' });
+    } finally {
+      setConfigScanInProgress(false);
+    }
+  };
+
   const handleRefreshLibraries = async () => {
     setStatus(null);
     try {
@@ -596,18 +633,34 @@ function SettingsPage() {
                 Provide the path to your Kometa configuration file so KAM can scan it for asset
                 folders.
               </p>
-              <label className="settings-input">
+              <div className="settings-input">
                 <span>Kometa config path</span>
-                <input
-                  type="text"
-                  name="kometaConfigPath"
-                  value={kometaConfigPath}
-                  onChange={handleKometaConfigPathChange}
-                  placeholder="/config/config.yml"
-                  autoComplete="off"
-                  disabled={busy}
-                />
-              </label>
+                <div className="settings-config-picker">
+                  {kometaConfigPath ? (
+                    <code>{kometaConfigPath}</code>
+                  ) : (
+                    <span className="placeholder">Not set</span>
+                  )}
+                  <div className="settings-config-buttons">
+                    <button type="button" onClick={handleOpenKometaConfigModal} disabled={busy}>
+                      {kometaConfigPath ? 'Change file' : 'Choose file'}
+                    </button>
+                    {kometaConfigPath ? (
+                      <button type="button" onClick={handleClearKometaConfig} disabled={busy}>
+                        Clear
+                      </button>
+                    ) : null}
+                  </div>
+                </div>
+              </div>
+              <button
+                type="button"
+                className="settings-config-scan"
+                onClick={handleScanKometaConfig}
+                disabled={combinedBusy}
+              >
+                {configScanInProgress ? 'Scanning…' : 'Scan Kometa config'}
+              </button>
             </div>
           </form>
         </section>
@@ -765,6 +818,13 @@ function SettingsPage() {
           </button>
         </div>
       </main>
+      <ConfigFinderModal
+        isOpen={configModalOpen}
+        initialPath={configModalInitialPath}
+        onClose={handleCloseKometaConfigModal}
+        onConfirm={handleKometaConfigSelected}
+        onClear={kometaConfigPath ? handleModalClearKometaConfig : undefined}
+      />
       <FolderFinderModal
         isOpen={modalState.open}
         context="settings"

--- a/frontend/src/pages/__tests__/SettingsPage.test.jsx
+++ b/frontend/src/pages/__tests__/SettingsPage.test.jsx
@@ -154,6 +154,47 @@ describe('SettingsPage', () => {
     expect(await screen.findByRole('status')).toHaveTextContent('Plex libraries refreshed.');
   });
 
+  it('invokes refreshLibraries when scanning the Kometa config', async () => {
+    const mockRefresh = vi.fn().mockResolvedValue([]);
+    useTheme.mockReturnValue({
+      theme: 'dark',
+      savedTheme: 'dark',
+      plexUrl: '',
+      plexToken: '',
+      kometaConfigPath: '/config/config.yml',
+      savedKometaConfigPath: '/config/config.yml',
+      savedSettings: { plexUrl: '', plexToken: '', kometaConfigPath: '/config/config.yml' },
+      libraryMappings: [],
+      savedLibraryMappings: [],
+      libraries: [],
+      librariesLoading: false,
+      librariesError: null,
+      loading: false,
+      saving: false,
+      error: null,
+      libraryMappingsDirty: false,
+      hasUnsavedChanges: false,
+      applyTheme: vi.fn(),
+      updateSettings: vi.fn(),
+      saveSettings: vi.fn(),
+      revertSettings: vi.fn(),
+      refreshLibraries: mockRefresh,
+      setLibraryMappings: vi.fn(),
+    });
+
+    render(
+      <MemoryRouter>
+        <SettingsPage />
+      </MemoryRouter>
+    );
+
+    const scanButton = screen.getByRole('button', { name: /Scan Kometa config/i });
+    fireEvent.click(scanButton);
+
+    expect(mockRefresh).toHaveBeenCalled();
+    expect(await screen.findByRole('status')).toHaveTextContent('Kometa config scanned.');
+  });
+
   it('shows loading status when settings are loading', async () => {
     useTheme.mockReturnValue({
       theme: 'dark',

--- a/tests/test_libraries_settings_endpoints.py
+++ b/tests/test_libraries_settings_endpoints.py
@@ -1,5 +1,6 @@
 import importlib
 from dataclasses import dataclass
+from pathlib import Path
 from typing import List
 
 import pytest
@@ -423,3 +424,103 @@ def test_asset_folders_settings_mode_allows_assets_root(tmp_path, monkeypatch):
         },
     )
     assert outside.status_code == 400
+
+
+def _create_settings_client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    settings_module = importlib.reload(importlib.import_module("app.services.settings"))
+    kometa_module = importlib.reload(importlib.import_module("app.services.kometa_config"))
+    router_module = importlib.reload(importlib.import_module("app.routers.settings"))
+
+    app = FastAPI()
+    app.include_router(router_module.router)
+    client = TestClient(app)
+
+    # Ensure patched modules remain referenced for the duration of the test
+    monkeypatch.setattr("app.routers.settings.settings_service", settings_module)
+    monkeypatch.setattr("app.routers.settings.kometa_config_service", kometa_module)
+    return client
+
+
+def test_browse_kometa_config_lists_files(tmp_path, monkeypatch):
+    config_root = tmp_path / "config"
+    config_root.mkdir()
+    primary_config = config_root / "config.yml"
+    primary_config.write_text("libraries: {}", encoding="utf-8")
+    extra_file = config_root / "extra.yaml"
+    extra_file.write_text("", encoding="utf-8")
+
+    monkeypatch.setenv("KOMETA_CONFIG_PATH", str(primary_config))
+
+    settings_module = importlib.reload(importlib.import_module("app.services.settings"))
+    settings_module.set_settings_path(str(tmp_path / "settings.json"))
+    settings_module.save_settings({"kometaConfigPath": str(primary_config)})
+
+    client = _create_settings_client(monkeypatch)
+
+    resp = client.get("/api/settings/kometa-config/browse")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["root"] == config_root.resolve().as_posix()
+    assert data["parent"] == ""
+
+    names = {item["name"]: item for item in data["items"]}
+    assert "config.yml" in names
+    assert names["config.yml"]["isFile"] is True
+    assert names["config.yml"]["path"] == "config.yml"
+    assert names["extra.yaml"]["isFile"] is True
+
+
+def test_browse_kometa_config_supports_navigation_and_search(tmp_path, monkeypatch):
+    config_root = tmp_path / "config"
+    config_root.mkdir()
+    primary_config = config_root / "config.yml"
+    primary_config.write_text("libraries: {}", encoding="utf-8")
+    nested_dir = config_root / "profiles"
+    nested_dir.mkdir()
+    nested_file = nested_dir / "alt.yml"
+    nested_file.write_text("", encoding="utf-8")
+
+    monkeypatch.setenv("KOMETA_CONFIG_PATH", str(primary_config))
+
+    settings_module = importlib.reload(importlib.import_module("app.services.settings"))
+    settings_module.set_settings_path(str(tmp_path / "settings.json"))
+    settings_module.save_settings({"kometaConfigPath": str(primary_config)})
+
+    client = _create_settings_client(monkeypatch)
+
+    # Navigate into a subdirectory
+    nested = client.get(
+        "/api/settings/kometa-config/browse",
+        params={"parent": "profiles"},
+    )
+    assert nested.status_code == 200
+    nested_payload = nested.json()
+    assert nested_payload["parent"] == "profiles"
+    nested_names = {item["name"] for item in nested_payload["items"]}
+    assert "alt.yml" in nested_names
+
+    # Search within the current directory
+    search = client.get(
+        "/api/settings/kometa-config/browse",
+        params={"search": "alt"},
+    )
+    assert search.status_code == 200
+    search_payload = search.json()
+    search_names = {item["name"] for item in search_payload["items"]}
+    assert "alt.yml" in search_names
+
+    # Ensure the current path highlights the configured file
+    current = client.get(
+        "/api/settings/kometa-config/browse",
+        params={"current": str(nested_file)},
+    )
+    assert current.status_code == 200
+    current_payload = current.json()
+    assert current_payload["selection"] == "profiles/alt.yml"
+    assert current_payload["parent"] == "profiles"
+
+    invalid = client.get(
+        "/api/settings/kometa-config/browse",
+        params={"parent": "../"},
+    )
+    assert invalid.status_code == 400


### PR DESCRIPTION
## Summary
- add an API endpoint that exposes Kometa config directories for browsing
- implement a ConfigFinderModal UI that lets settings users pick the Kometa config file and trigger manual scans
- extend automated tests and styles to cover the new browsing and scan workflow

## Testing
- pytest
- npm test -- --runInBand *(fails: vitest binary unavailable without npm install)*

------
https://chatgpt.com/codex/tasks/task_e_68e2f97b14e88330980bab11374a1bd9