### PR TITLE
Improve Kometa config path normalization

### DIFF
--- a/app/services/kometa_config.py
+++ b/app/services/kometa_config.py
@@ -49,10 +49,41 @@ def normalize_config_path(value: Any, base_dir: Optional[Path] = None) -> str:
             base = Path(base_dir)
         except TypeError:  # pragma: no cover - defensive
             base = None
+
         if base and not os.path.isabs(normalized):
-            candidate = normalize_path(str(base.joinpath(normalized)))
-            if candidate and os.path.exists(candidate):
-                return candidate
+            candidates: List[str] = []
+
+            def _add_candidate(root: Path, fragment: str) -> None:
+                try:
+                    combined = root.joinpath(fragment)
+                except Exception:  # pragma: no cover - defensive
+                    return
+                try:
+                    combined = combined.resolve(strict=False)
+                except Exception:  # pragma: no cover - defensive
+                    pass
+                candidate = normalize_path(str(combined))
+                if candidate and candidate not in candidates:
+                    candidates.append(candidate)
+
+            name = base.name
+            if name and normalized.startswith(f"{name}/"):
+                trimmed = normalized[len(name) + 1 :]
+                if trimmed:
+                    _add_candidate(base, trimmed)
+
+            _add_candidate(base, normalized)
+
+            parent = base.parent
+            if parent != base:
+                _add_candidate(parent, normalized)
+
+            for candidate in candidates:
+                if os.path.exists(candidate):
+                    return candidate
+
+            if candidates:
+                return candidates[0]
 
     return normalized
 

--- a/tests/test_kometa_config.py
+++ b/tests/test_kometa_config.py
@@ -40,11 +40,11 @@ libraries:
 
     movies = summaries["Movies"]
     assert movies["assetPath"] == str(assets_dir)
-    assert movies["collectionsPaths"] == [
+    assert set(movies["collectionsPaths"]) == {
         str(defaults_dir),
-        "config/assets/Collections",
-        "config/assets/Holidays",
-    ]
+        str(config_dir / "assets" / "Collections"),
+        str(config_dir / "assets" / "Holidays"),
+    }
 
     assert summaries["Documentaries"] == {}
 


### PR DESCRIPTION
## Summary
- enhance Kometa config path normalization to derive useful absolute asset directory suggestions relative to the config root
- update Kometa config tests to expect absolute collection asset suggestions derived from asset_directory entries

## Testing
- PYTHONPATH=. pytest tests/test_kometa_config.py

------
https://chatgpt.com/codex/tasks/task_e_68e2ffeed2588330a1bffb924b6c9400