### PR TITLE
Add Kometa collection override support in settings

### DIFF
--- a/app/routers/libraries.py
+++ b/app/routers/libraries.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel, Field
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from ..services import (
     kometa_config as kometa_config_service,
@@ -98,6 +98,12 @@ def get_library_path(name: str = Query(..., description="Mapped library name")) 
     return {"name": name, "path": path}
 
 
+class CollectionOverrideInfo(BaseModel):
+    name: str
+    collectionsPath: Optional[str] = None
+    suggestionPaths: List[str] = Field(default_factory=list)
+
+
 class LibrarySectionInfo(BaseModel):
     name: str
     type: Optional[str] = None
@@ -105,6 +111,7 @@ class LibrarySectionInfo(BaseModel):
     assetPath: Optional[str] = None
     collectionsPath: Optional[str] = None
     collectionAssetPaths: List[str] = Field(default_factory=list)
+    collectionOverrides: List[CollectionOverrideInfo] = Field(default_factory=list)
 
 
 @router.get("/api/settings/libraries", response_model=List[LibrarySectionInfo])
@@ -176,6 +183,80 @@ def list_available_libraries() -> List[LibrarySectionInfo]:
             if not entry["collectionsPath"] and deduped:
                 entry["collectionsPath"] = deduped[0]
 
+        overrides: Dict[str, Dict[str, Any]] = {}
+        stored_sections = mapping.get("collectionSections") if mapping else []
+        if isinstance(stored_sections, list):
+            for section in stored_sections:
+                if not isinstance(section, dict):
+                    continue
+                raw_name = section.get("name")
+                if not raw_name:
+                    continue
+                name_key = str(raw_name).strip()
+                if not name_key:
+                    continue
+                key_norm = name_key.casefold()
+                current = overrides.setdefault(
+                    key_norm,
+                    {
+                        "name": name_key,
+                        "collectionsPath": None,
+                        "suggestionPaths": [],
+                    },
+                )
+                path = library_mappings_service.normalize_path(
+                    section.get("collectionsPath")
+                )
+                if path:
+                    current["collectionsPath"] = path
+                if not current.get("name"):
+                    current["name"] = name_key
+
+        if config_info:
+            for override in config_info.get("collectionOverrides", []) or []:
+                if not isinstance(override, dict):
+                    continue
+                raw_name = override.get("name")
+                if not raw_name:
+                    continue
+                display = str(raw_name).strip()
+                if not display:
+                    continue
+                key_norm = display.casefold()
+                current = overrides.setdefault(
+                    key_norm,
+                    {
+                        "name": display,
+                        "collectionsPath": None,
+                        "suggestionPaths": [],
+                    },
+                )
+                if not current.get("name"):
+                    current["name"] = display
+                suggestion = library_mappings_service.normalize_path(
+                    override.get("assetPath")
+                )
+                if suggestion and suggestion not in current["suggestionPaths"]:
+                    current["suggestionPaths"].append(suggestion)
+
+        if overrides:
+            entry["collectionOverrides"] = [
+                CollectionOverrideInfo(
+                    name=value.get("name") or key,
+                    collectionsPath=value.get("collectionsPath"),
+                    suggestionPaths=sorted(
+                        [
+                            path
+                            for path in value.get("suggestionPaths", [])
+                            if path
+                        ]
+                    ),
+                )
+                for key, value in sorted(
+                    overrides.items(), key=lambda item: item[0]
+                )
+            ]
+
         results.append(LibrarySectionInfo(**entry))
 
     seen_names = {item.name for item in results}
@@ -191,6 +272,28 @@ def list_available_libraries() -> List[LibrarySectionInfo]:
             "collectionsPath": suggestions[0] if suggestions else None,
             "collectionAssetPaths": suggestions,
         }
+        overrides: List[CollectionOverrideInfo] = []
+        for override in info.get("collectionOverrides", []) or []:
+            if not isinstance(override, dict):
+                continue
+            raw_name = override.get("name")
+            if not raw_name:
+                continue
+            display = str(raw_name).strip()
+            if not display:
+                continue
+            suggestion = library_mappings_service.normalize_path(
+                override.get("assetPath")
+            )
+            overrides.append(
+                CollectionOverrideInfo(
+                    name=display,
+                    collectionsPath=None,
+                    suggestionPaths=[path for path in [suggestion] if path],
+                )
+            )
+        if overrides:
+            entry["collectionOverrides"] = overrides
         results.append(LibrarySectionInfo(**entry))
 
     results.sort(key=lambda item: (item.name.lower(), item.key or ""))

--- a/app/routers/settings.py
+++ b/app/routers/settings.py
@@ -15,12 +15,38 @@ from ..services import (
 router = APIRouter()
 
 
+class CollectionSectionPayload(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    name: str
+    collectionsPath: str
+
+    @field_validator("name", mode="before")
+    @classmethod
+    def _validate_name(cls, value: str | None) -> str:
+        if value in (None, ""):
+            raise ValueError("Collection name is required")
+        text = str(value).strip()
+        if not text:
+            raise ValueError("Collection name is required")
+        return text
+
+    @field_validator("collectionsPath", mode="before")
+    @classmethod
+    def _validate_path(cls, value: str | None) -> str:
+        normalized = library_mappings_service.normalize_path(value)
+        if not normalized:
+            raise ValueError("Collections path is required")
+        return normalized
+
+
 class LibraryMappingPayload(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
     library: str
     assetPath: str
     collectionsPath: str | None = None
+    collectionSections: List[CollectionSectionPayload] = Field(default_factory=list)
 
     @field_validator("library", mode="before")
     @classmethod
@@ -45,6 +71,16 @@ class LibraryMappingPayload(BaseModel):
     def _validate_collections_path(cls, value: str | None) -> str | None:
         normalized = library_mappings_service.normalize_path(value)
         return normalized or None
+
+    @field_validator("collectionSections", mode="after")
+    @classmethod
+    def _sanitize_sections(
+        cls, value: List[CollectionSectionPayload]
+    ) -> List[CollectionSectionPayload]:
+        normalized = library_mappings_service.normalize_collection_sections(
+            [item.model_dump() for item in value]
+        )
+        return [CollectionSectionPayload(**item) for item in normalized]
 
 
 class SettingsPayload(BaseModel):

--- a/app/services/kometa_config.py
+++ b/app/services/kometa_config.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 import os
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Set, TypedDict
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, TypedDict
 
 import yaml
 
@@ -12,6 +12,7 @@ from .library_mappings import normalize_path
 
 __all__ = [
     "KometaLibraryInfo",
+    "KometaCollectionOverride",
     "normalize_config_path",
     "extract_library_info",
     "load_library_summaries",
@@ -22,11 +23,19 @@ __all__ = [
 logger = logging.getLogger(__name__)
 
 
+class KometaCollectionOverride(TypedDict, total=False):
+    """Named collection override discovered in the Kometa config."""
+
+    name: str
+    assetPath: str
+
+
 class KometaLibraryInfo(TypedDict, total=False):
     """Summary of asset configuration for a single Kometa library."""
 
     assetPath: Optional[str]
     collectionsPaths: List[str]
+    collectionOverrides: List[KometaCollectionOverride]
 
 
 def normalize_config_path(value: Any, base_dir: Optional[Path] = None) -> str:
@@ -83,6 +92,8 @@ def normalize_config_path(value: Any, base_dir: Optional[Path] = None) -> str:
                     return candidate
 
             if candidates:
+                if isinstance(base, Path) and not base.is_absolute():
+                    return normalized
                 return candidates[0]
 
     return normalized
@@ -107,6 +118,78 @@ def _collect_asset_directories(value: Any, base_dir: Optional[Path]) -> Set[str]
 
     _walk(value)
     return collected
+
+
+def _normalize_override_name(value: Any) -> str:
+    if value in (None, ""):
+        return ""
+    text = str(value).strip()
+    if not text:
+        return ""
+
+    cleaned = text.replace("_", " ").replace("-", " ").strip()
+    if cleaned and cleaned.lower() == cleaned:
+        cleaned = " ".join(part for part in cleaned.split())
+        cleaned = cleaned.title()
+    return cleaned or text
+
+
+def _extract_override_entry(
+    entry: Any, base_dir: Optional[Path], fallback_name: Optional[str] = None
+) -> Optional[Tuple[str, str]]:
+    if not isinstance(entry, dict):
+        return None
+
+    path = normalize_config_path(
+        entry.get("asset_directory") or entry.get("asset_path"), base_dir
+    )
+    if not path:
+        return None
+
+    name_value = (
+        entry.get("name")
+        or entry.get("default")
+        or entry.get("collection")
+        or entry.get("template")
+        or fallback_name
+    )
+    name = _normalize_override_name(name_value)
+    if not name:
+        return None
+
+    return name, path
+
+
+def _collect_overrides_from_collection_files(
+    value: Any, base_dir: Optional[Path]
+) -> Dict[str, str]:
+    overrides: Dict[str, str] = {}
+    if isinstance(value, list):
+        for entry in value:
+            result = _extract_override_entry(entry, base_dir)
+            if result:
+                name, path = result
+                overrides.setdefault(name, path)
+    elif isinstance(value, dict):
+        for key, entry in value.items():
+            result = _extract_override_entry(entry, base_dir, str(key))
+            if result:
+                name, path = result
+                overrides.setdefault(name, path)
+    return overrides
+
+
+def _collect_overrides_from_mapping(
+    value: Any, base_dir: Optional[Path]
+) -> Dict[str, str]:
+    overrides: Dict[str, str] = {}
+    if isinstance(value, dict):
+        for key, entry in value.items():
+            result = _extract_override_entry(entry, base_dir, str(key))
+            if result:
+                name, path = result
+                overrides.setdefault(name, path)
+    return overrides
 
 
 def extract_library_info(library_config: Any, base_dir: Optional[Path]) -> KometaLibraryInfo:
@@ -137,6 +220,29 @@ def extract_library_info(library_config: Any, base_dir: Optional[Path]) -> Komet
 
     if collections_paths:
         info["collectionsPaths"] = sorted(collections_paths)
+
+    overrides: Dict[str, str] = {}
+    overrides.update(
+        _collect_overrides_from_collection_files(
+            library_config.get("collection_files"), base_dir
+        )
+    )
+    overrides.update(
+        _collect_overrides_from_mapping(
+            library_config.get("collections"), base_dir
+        )
+    )
+    overrides.update(
+        _collect_overrides_from_mapping(
+            library_config.get("dynamic_collections"), base_dir
+        )
+    )
+
+    if overrides:
+        info["collectionOverrides"] = [
+            {"name": name, "assetPath": path}
+            for name, path in sorted(overrides.items(), key=lambda item: item[0].lower())
+        ]
 
     return info
 

--- a/app/services/library_mappings.py
+++ b/app/services/library_mappings.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, Iterable, List, Optional
 
 __all__ = [
     "normalize_path",
+    "normalize_collection_sections",
     "sanitize_library_mappings",
     "seed_from_env",
     "set_cached_mappings",
@@ -37,6 +38,47 @@ def normalize_path(value: Any) -> str:
     return normalized.replace("\\", "/")
 
 
+def normalize_collection_sections(value: Any) -> List[Dict[str, str]]:
+    """Normalize collection override mappings into a sorted list."""
+
+    if not value:
+        return []
+
+    items: List[Dict[str, Any]] = []
+    if isinstance(value, dict):
+        for key, entry in value.items():
+            if isinstance(entry, dict):
+                candidate = dict(entry)
+            else:
+                candidate = {"collectionsPath": entry}
+            candidate.setdefault("name", key)
+            items.append(candidate)
+    elif isinstance(value, list):
+        items = [dict(entry) for entry in value if isinstance(entry, dict)]
+    else:
+        return []
+
+    ordered: Dict[str, Dict[str, str]] = {}
+    for item in items:
+        raw_name = item.get("name") or item.get("section") or item.get("default") or item.get("key")
+        if raw_name in (None, ""):
+            continue
+        name = str(raw_name).strip()
+        if not name:
+            continue
+        path = normalize_path(
+            item.get("collectionsPath")
+            or item.get("path")
+            or item.get("assetPath")
+            or item.get("asset_directory")
+        )
+        if not path:
+            continue
+        ordered[name] = {"name": name, "collectionsPath": path}
+
+    return [ordered[key] for key in sorted(ordered.keys(), key=lambda s: s.lower())]
+
+
 def sanitize_library_mappings(raw: Any) -> List[Dict[str, Any]]:
     """Normalize arbitrary input into a deterministic list of mappings."""
     if not raw:
@@ -63,6 +105,9 @@ def sanitize_library_mappings(raw: Any) -> List[Dict[str, Any]]:
         library = library.strip()
         asset_path = normalize_path(item.get("assetPath"))
         collections_path = normalize_path(item.get("collectionsPath"))
+        sections = normalize_collection_sections(
+            item.get("collectionSections") or item.get("collectionOverrides")
+        )
 
         if not library or not asset_path:
             continue
@@ -72,6 +117,8 @@ def sanitize_library_mappings(raw: Any) -> List[Dict[str, Any]]:
             "assetPath": asset_path,
             "collectionsPath": collections_path or None,
         }
+        if sections:
+            ordered[library]["collectionSections"] = sections
 
     return [copy.deepcopy(value) for value in ordered.values()]
 

--- a/frontend/src/components/FolderFinderModal.jsx
+++ b/frontend/src/components/FolderFinderModal.jsx
@@ -52,6 +52,7 @@ function FolderFinderModal({
   onFolderAssigned,
   context = 'library',
   settingsLibraries = [],
+  settingsContextNote = '',
   defaultTarget = 'asset',
   settingsIntent = 'asset',
   initialAssetPath = '',
@@ -248,12 +249,16 @@ function FolderFinderModal({
 
   const contextLabel = useMemo(() => {
     if (isSettingsMode) {
-      return `Libraries: ${formatLibraryList(settingsLibraries)}`;
+      const base = `Libraries: ${formatLibraryList(settingsLibraries)}`;
+      if (settingsContextNote) {
+        return `${base} • ${settingsContextNote}`;
+      }
+      return base;
     }
     const title = item?.title || item?.name || '(Untitled)';
     if (!effectiveLibrary) return title;
     return `Library: ${effectiveLibrary} • Item: ${title}`;
-  }, [isSettingsMode, settingsLibraries, item, effectiveLibrary]);
+  }, [isSettingsMode, settingsLibraries, settingsContextNote, item, effectiveLibrary]);
 
   const displayCurrentFolder = currentFolder ? currentFolder : '';
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -971,6 +971,21 @@ main {
   background: rgba(94, 161, 255, 0.08);
 }
 
+.settings-libraries-table tr.library-override-row th,
+.settings-libraries-table tr.library-override-row td {
+  padding-top: 8px;
+  padding-bottom: 8px;
+}
+
+.settings-libraries-table tr.library-override-row th {
+  padding-left: 40px;
+  font-weight: 500;
+}
+
+.settings-libraries-table .library-name.override-name {
+  font-weight: 600;
+}
+
 .library-select {
   width: 48px;
   text-align: center;

--- a/frontend/src/pages/SettingsPage.jsx
+++ b/frontend/src/pages/SettingsPage.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import ConfigFinderModal from '../components/ConfigFinderModal.jsx';
 import FolderFinderModal from '../components/FolderFinderModal.jsx';
@@ -8,6 +8,7 @@ import {
   createLibraryMappingLookup,
   normalizeLibraryName,
   normalizePathValue,
+  normalizeSectionName,
 } from '../utils/libraryMappings.js';
 
 const initialModalState = {
@@ -20,6 +21,10 @@ const initialModalState = {
   initialCollectionsPath: '',
   canClearAsset: false,
   canClearCollections: false,
+  overrideName: '',
+  overrideKey: '',
+  overrideDisplayName: '',
+  collectionSuggestions: [],
 };
 
 const normalizeText = (value) => {
@@ -53,6 +58,7 @@ function SettingsPage() {
     revertSettings,
     refreshLibraries,
     setLibraryMappings,
+    getLibraryMapping,
   } = useTheme();
 
   const [status, setStatus] = useState(null);
@@ -200,7 +206,92 @@ function SettingsPage() {
         const collectionSuggestionExtras = collectionSuggestions.filter(
           (value) => value !== collectionsPath
         );
-        const isDirty = assetPath !== savedAssetPath || collectionsPath !== savedCollectionsPath;
+        const infoOverrides = Array.isArray(info.collectionOverrides)
+          ? info.collectionOverrides
+          : [];
+        const currentOverrides = Array.isArray(current?.collectionSections)
+          ? current.collectionSections
+          : [];
+        const savedOverrides = Array.isArray(saved?.collectionSections)
+          ? saved.collectionSections
+          : [];
+        const overrideMap = new Map();
+
+        infoOverrides.forEach((override) => {
+          const normalizedName = normalizeSectionName(override?.name);
+          if (!normalizedName) return;
+          const suggestions = Array.isArray(override?.suggestionPaths)
+            ? override.suggestionPaths.map((value) => normalizePathValue(value)).filter(Boolean)
+            : [];
+          overrideMap.set(normalizedName, {
+            key: normalizedName,
+            name: override.name || normalizedName,
+            collectionsPath: '',
+            savedCollectionsPath: '',
+            suggestions: Array.from(new Set(suggestions)),
+          });
+        });
+
+        currentOverrides.forEach((override) => {
+          const normalizedName = normalizeSectionName(override?.name);
+          if (!normalizedName) return;
+          const path = normalizePathValue(override?.collectionsPath);
+          const existing = overrideMap.get(normalizedName) || {
+            key: normalizedName,
+            name: override?.name || normalizedName,
+            collectionsPath: '',
+            savedCollectionsPath: '',
+            suggestions: [],
+          };
+          if (!existing.name) {
+            existing.name = override?.name || normalizedName;
+          }
+          existing.collectionsPath = path;
+          overrideMap.set(normalizedName, existing);
+        });
+
+        savedOverrides.forEach((override) => {
+          const normalizedName = normalizeSectionName(override?.name);
+          if (!normalizedName) return;
+          const path = normalizePathValue(override?.collectionsPath);
+          const existing = overrideMap.get(normalizedName) || {
+            key: normalizedName,
+            name: override?.name || normalizedName,
+            collectionsPath: '',
+            savedCollectionsPath: '',
+            suggestions: [],
+          };
+          if (!existing.name) {
+            existing.name = override?.name || normalizedName;
+          }
+          existing.savedCollectionsPath = path;
+          overrideMap.set(normalizedName, existing);
+        });
+
+        const collectionOverrides = Array.from(overrideMap.values())
+          .map((override) => {
+            const currentPath = normalizePathValue(override.collectionsPath);
+            const savedPath = normalizePathValue(override.savedCollectionsPath);
+            const suggestions = Array.from(
+              new Set([currentPath, ...(override.suggestions || [])].filter(Boolean))
+            );
+            const suggestionExtras = suggestions.filter((value) => value !== currentPath);
+            return {
+              key: override.key,
+              name: override.name,
+              collectionsPath: currentPath,
+              savedCollectionsPath: savedPath,
+              collectionSuggestions: suggestions,
+              collectionSuggestionExtras: suggestionExtras,
+              isDirty: currentPath !== savedPath,
+            };
+          })
+          .sort((a, b) => a.name.localeCompare(b.name));
+
+        const isDirty =
+          assetPath !== savedAssetPath ||
+          collectionsPath !== savedCollectionsPath ||
+          collectionOverrides.some((override) => override.isDirty);
         return {
           name,
           type: info.type,
@@ -212,6 +303,7 @@ function SettingsPage() {
           isDirty,
           collectionSuggestions,
           collectionSuggestionExtras,
+          collectionOverrides,
         };
       });
   }, [libraries, libraryMappings, savedLibraryMappings]);
@@ -354,7 +446,7 @@ function SettingsPage() {
     setModalState(initialModalState);
   };
 
-  const openModal = (librariesList, intent, defaultTarget) => {
+  const openModal = (librariesList, intent, defaultTarget, options = {}) => {
     const uniqueNames = Array.from(new Set(librariesList.map((name) => normalizeText(name)).filter(Boolean)));
     if (!uniqueNames.length) {
       setStatus({ type: 'error', message: 'Select at least one library first.' });
@@ -364,7 +456,10 @@ function SettingsPage() {
     const primaryRow = libraryRowMap.get(primary);
     const modalRows = uniqueNames.map((name) => libraryRowMap.get(name)).filter(Boolean);
     const canClearAsset = modalRows.some((row) => row.assetPath);
-    const canClearCollections = modalRows.some((row) => row.collectionsPath);
+    const canClearCollections =
+      options.canClearCollections !== undefined
+        ? Boolean(options.canClearCollections)
+        : modalRows.some((row) => row.collectionsPath);
     setStatus(null);
     setModalState({
       open: true,
@@ -373,9 +468,18 @@ function SettingsPage() {
       intent: intent || 'asset',
       defaultTarget: defaultTarget || (intent === 'collections' ? 'collections' : 'asset'),
       initialAssetPath: primaryRow?.assetPath || '',
-      initialCollectionsPath: primaryRow?.collectionsPath || '',
+      initialCollectionsPath:
+        options.initialCollectionsPath !== undefined
+          ? options.initialCollectionsPath
+          : primaryRow?.collectionsPath || '',
       canClearAsset,
       canClearCollections,
+      overrideName: options.overrideName || '',
+      overrideKey: options.overrideKey || '',
+      overrideDisplayName: options.overrideDisplayName || '',
+      collectionSuggestions: Array.isArray(options.collectionSuggestions)
+        ? options.collectionSuggestions.filter(Boolean)
+        : primaryRow?.collectionSuggestions || [],
     });
   };
 
@@ -384,6 +488,52 @@ function SettingsPage() {
     const names = modalState.libraries;
 
     if (!names.length) {
+      closeModal();
+      return;
+    }
+
+    if (modalState.overrideKey) {
+      const libraryName = modalState.primaryLibrary;
+      if (!libraryName) {
+        closeModal();
+        return;
+      }
+      const mapping = getLibraryMapping(libraryName);
+      const existingSections = Array.isArray(mapping?.collectionSections)
+        ? mapping.collectionSections
+        : [];
+      const filteredSections = existingSections.filter(
+        (section) => normalizeSectionName(section?.name) !== modalState.overrideKey
+      );
+
+      if (meta?.clearTarget === 'collections') {
+        setLibraryMappings([libraryName], { collectionSections: filteredSections });
+        const displayName = modalState.overrideDisplayName || modalState.overrideName || modalState.overrideKey;
+        setStatus({
+          type: 'success',
+          message: `Cleared collections folder for ${displayName} in ${libraryName}.`,
+        });
+        closeModal();
+        return;
+      }
+
+      let nextPath = values?.collectionsPath;
+      if (nextPath === undefined) {
+        nextPath = modalState.initialCollectionsPath;
+      }
+      nextPath = normalizePathValue(nextPath);
+      if (!nextPath) {
+        setStatus({ type: 'error', message: 'Select a collections folder before applying changes.' });
+        return;
+      }
+
+      const displayName = modalState.overrideDisplayName || modalState.overrideName || modalState.overrideKey;
+      const nextSections = [...filteredSections, { name: displayName, collectionsPath: nextPath }];
+      setLibraryMappings([libraryName], { collectionSections: nextSections });
+      setStatus({
+        type: 'success',
+        message: `Updated collections folder for ${displayName} in ${libraryName}.`,
+      });
       closeModal();
       return;
     }
@@ -479,7 +629,36 @@ function SettingsPage() {
       });
       return;
     }
-    openModal([libraryName], 'collections', 'collections');
+    openModal([libraryName], 'collections', 'collections', {
+      collectionSuggestions: row.collectionSuggestions,
+    });
+  };
+
+  const handleOpenCollectionOverrideModal = (libraryName, overrideKey) => {
+    const row = libraryRowMap.get(libraryName);
+    if (!row?.assetPath) {
+      setStatus({
+        type: 'error',
+        message: `${libraryName} needs an asset folder before setting collections overrides.`,
+      });
+      return;
+    }
+    const override = row.collectionOverrides?.find((item) => item.key === overrideKey);
+    if (!override) return;
+
+    const suggestions = override.collectionSuggestions?.length
+      ? override.collectionSuggestions
+      : row.collectionSuggestions || [];
+    const initialPath = override.collectionsPath || suggestions[0] || row.collectionsPath || '';
+
+    openModal([libraryName], 'collections', 'collections', {
+      overrideName: override.name,
+      overrideDisplayName: override.name,
+      overrideKey,
+      initialCollectionsPath: initialPath,
+      canClearCollections: Boolean(override.collectionsPath),
+      collectionSuggestions: suggestions,
+    });
   };
 
   const handleApplyAssetToSelection = () => {
@@ -742,64 +921,117 @@ function SettingsPage() {
                   {libraryRows.map((row) => {
                     const isSelected = selectedLibraries.includes(row.name);
                     return (
-                      <tr key={row.name} className={row.isDirty ? 'is-dirty' : undefined}>
-                        <td className="library-select">
-                          <input
-                            type="checkbox"
-                            checked={isSelected}
-                            onChange={() => handleToggleLibrary(row.name)}
-                            disabled={combinedBusy}
-                            aria-label={`Select ${row.name}`}
-                          />
-                        </td>
-                        <th scope="row">
-                          <div className="library-name">{row.name}</div>
-                          <div className="library-meta">
-                            {row.type ? <span className="library-tag">{row.type}</span> : null}
-                            {row.key ? <span className="library-tag">Key {row.key}</span> : null}
-                          </div>
-                        </th>
-                        <td>
-                          {row.assetPath ? <code>{row.assetPath}</code> : <span className="placeholder">Not set</span>}
-                        </td>
-                        <td>
-                          {row.collectionsPath ? (
-                            <code>{row.collectionsPath}</code>
-                          ) : (
-                            <span className="placeholder">Not set</span>
-                          )}
-                          {row.collectionSuggestionExtras?.length ? (
-                            <div className="collection-suggestions">
-                              Suggested:{' '}
-                              {row.collectionSuggestionExtras.map((value, index) => (
-                                <span key={value}>
-                                  {index > 0 ? ', ' : ''}
-                                  <code>{value}</code>
-                                </span>
-                              ))}
+                      <Fragment key={row.name}>
+                        <tr className={row.isDirty ? 'is-dirty' : undefined}>
+                          <td className="library-select">
+                            <input
+                              type="checkbox"
+                              checked={isSelected}
+                              onChange={() => handleToggleLibrary(row.name)}
+                              disabled={combinedBusy}
+                              aria-label={`Select ${row.name}`}
+                            />
+                          </td>
+                          <th scope="row">
+                            <div className="library-name">{row.name}</div>
+                            <div className="library-meta">
+                              {row.type ? <span className="library-tag">{row.type}</span> : null}
+                              {row.key ? <span className="library-tag">Key {row.key}</span> : null}
                             </div>
-                          ) : null}
-                        </td>
-                        <td>
-                          {row.isDirty ? <span className="status-unsaved">Unsaved changes</span> : <span>Saved</span>}
-                        </td>
-                        <td className="library-actions">
-                          <button
-                            type="button"
-                            onClick={() => handleOpenAssetModal(row.name)}
-                            disabled={combinedBusy}
+                          </th>
+                          <td>
+                            {row.assetPath ? <code>{row.assetPath}</code> : <span className="placeholder">Not set</span>}
+                          </td>
+                          <td>
+                            {row.collectionsPath ? (
+                              <code>{row.collectionsPath}</code>
+                            ) : (
+                              <span className="placeholder">Not set</span>
+                            )}
+                            {row.collectionSuggestionExtras?.length ? (
+                              <div className="collection-suggestions">
+                                Suggested:{' '}
+                                {row.collectionSuggestionExtras.map((value, index) => (
+                                  <span key={value}>
+                                    {index > 0 ? ', ' : ''}
+                                    <code>{value}</code>
+                                  </span>
+                                ))}
+                              </div>
+                            ) : null}
+                          </td>
+                          <td>
+                            {row.isDirty ? <span className="status-unsaved">Unsaved changes</span> : <span>Saved</span>}
+                          </td>
+                          <td className="library-actions">
+                            <button
+                              type="button"
+                              onClick={() => handleOpenAssetModal(row.name)}
+                              disabled={combinedBusy}
+                            >
+                              Set asset folder
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => handleOpenCollectionsModal(row.name)}
+                              disabled={combinedBusy || !row.assetPath}
+                            >
+                              Set collections folder
+                            </button>
+                          </td>
+                        </tr>
+                        {row.collectionOverrides?.map((override) => (
+                          <tr
+                            key={`${row.name}::${override.key}`}
+                            className={`library-override-row${override.isDirty ? ' is-dirty' : ''}`}
                           >
-                            Set asset folder
-                          </button>
-                          <button
-                            type="button"
-                            onClick={() => handleOpenCollectionsModal(row.name)}
-                            disabled={combinedBusy || !row.assetPath}
-                          >
-                            Set collections folder
-                          </button>
-                        </td>
-                      </tr>
+                            <td className="library-select" aria-hidden="true" />
+                            <th scope="row">
+                              <div className="library-name override-name">{override.name}</div>
+                              <div className="library-meta">
+                                <span className="library-tag">Collections override</span>
+                              </div>
+                            </th>
+                            <td>
+                              <span className="placeholder">Uses library asset folder</span>
+                            </td>
+                            <td>
+                              {override.collectionsPath ? (
+                                <code>{override.collectionsPath}</code>
+                              ) : (
+                                <span className="placeholder">Not set</span>
+                              )}
+                              {override.collectionSuggestionExtras?.length ? (
+                                <div className="collection-suggestions">
+                                  Suggested:{' '}
+                                  {override.collectionSuggestionExtras.map((value, index) => (
+                                    <span key={value}>
+                                      {index > 0 ? ', ' : ''}
+                                      <code>{value}</code>
+                                    </span>
+                                  ))}
+                                </div>
+                              ) : null}
+                            </td>
+                            <td>
+                              {override.isDirty ? (
+                                <span className="status-unsaved">Unsaved changes</span>
+                              ) : (
+                                <span>Saved</span>
+                              )}
+                            </td>
+                            <td className="library-actions">
+                              <button
+                                type="button"
+                                onClick={() => handleOpenCollectionOverrideModal(row.name, override.key)}
+                                disabled={combinedBusy || !row.assetPath}
+                              >
+                                Set collections folder
+                              </button>
+                            </td>
+                          </tr>
+                        ))}
+                      </Fragment>
                     );
                   })}
                 </tbody>
@@ -848,6 +1080,11 @@ function SettingsPage() {
         context="settings"
         library={modalState.primaryLibrary}
         settingsLibraries={modalState.libraries}
+        settingsContextNote={
+          modalState.overrideDisplayName
+            ? `Override: ${modalState.overrideDisplayName}`
+            : ''
+        }
         defaultTarget={modalState.defaultTarget}
         settingsIntent={modalState.intent}
         initialAssetPath={modalState.initialAssetPath}

--- a/frontend/src/theme/ThemeProvider.jsx
+++ b/frontend/src/theme/ThemeProvider.jsx
@@ -5,6 +5,7 @@ import {
   createLibraryMappingLookup,
   normalizeLibraryName,
   normalizePathValue,
+  sanitizeCollectionSections,
   sanitizeLibraryMappings,
 } from '../utils/libraryMappings.js';
 
@@ -76,6 +77,27 @@ const sanitizeLibrariesList = (raw) => {
       const collectionAssetPathsValue = Array.isArray(entry.collectionAssetPaths)
         ? entry.collectionAssetPaths.map((value) => normalizePathValue(value)).filter(Boolean)
         : [];
+      const rawOverrides = Array.isArray(entry.collectionOverrides)
+        ? entry.collectionOverrides
+        : [];
+      const collectionOverridesValue = rawOverrides
+        .map((override) => {
+          if (!override || typeof override !== 'object') return null;
+          const nameValue = override.name ?? override.section ?? override.default;
+          const name = typeof nameValue === 'string' ? nameValue.trim() : '';
+          if (!name) return null;
+          const collectionsOverridePath = normalizePathValue(override.collectionsPath);
+          const suggestions = Array.isArray(override.suggestionPaths)
+            ? override.suggestionPaths.map((value) => normalizePathValue(value)).filter(Boolean)
+            : [];
+          return {
+            name,
+            collectionsPath: collectionsOverridePath,
+            suggestionPaths: Array.from(new Set(suggestions)),
+          };
+        })
+        .filter(Boolean)
+        .sort((a, b) => a.name.localeCompare(b.name));
       return {
         name,
         type: typeValue ? String(typeValue) : null,
@@ -83,6 +105,7 @@ const sanitizeLibrariesList = (raw) => {
         assetPath: assetPathValue,
         collectionsPath: collectionsPathValue,
         collectionAssetPaths: collectionAssetPathsValue,
+        collectionOverrides: collectionOverridesValue,
       };
     })
     .filter(Boolean)
@@ -147,6 +170,10 @@ export function ThemeProvider({ children }) {
           payload.collectionsPath === undefined
             ? existing?.collectionsPath ?? ''
             : normalizePathValue(payload.collectionsPath);
+        const sectionsUpdate =
+          payload.collectionSections === undefined
+            ? existing?.collectionSections ?? []
+            : sanitizeCollectionSections(payload.collectionSections);
         if (!assetUpdate) {
           if (index >= 0) {
             list.splice(index, 1);
@@ -158,6 +185,9 @@ export function ThemeProvider({ children }) {
           assetPath: assetUpdate,
           collectionsPath: collectionsUpdate,
         };
+        if (sectionsUpdate.length) {
+          nextEntry.collectionSections = sectionsUpdate;
+        }
         if (index >= 0) {
           list[index] = nextEntry;
         } else {

--- a/frontend/src/utils/libraryMappings.js
+++ b/frontend/src/utils/libraryMappings.js
@@ -11,6 +11,43 @@ const normalizePathValue = (value) => {
   return text.replace(/\\+/g, '/');
 };
 
+const normalizeSectionName = (value) => {
+  if (value == null) return '';
+  const text = String(value).trim();
+  return text;
+};
+
+const sanitizeCollectionSections = (raw = []) => {
+  if (!raw) return [];
+  let entries = [];
+  if (Array.isArray(raw)) {
+    entries = raw.filter((entry) => entry && typeof entry === 'object');
+  } else if (raw && typeof raw === 'object') {
+    entries = Object.entries(raw).map(([name, value]) =>
+      value && typeof value === 'object'
+        ? { name, ...value }
+        : { name, collectionsPath: value }
+    );
+  } else {
+    return [];
+  }
+
+  const byName = new Map();
+  entries.forEach((entry) => {
+    const name = normalizeSectionName(
+      entry.name ?? entry.section ?? entry.default ?? entry.key
+    );
+    if (!name) return;
+    const path = normalizePathValue(
+      entry.collectionsPath ?? entry.path ?? entry.assetPath ?? entry.asset_directory
+    );
+    if (!path) return;
+    byName.set(name, { name, collectionsPath: path });
+  });
+
+  return Array.from(byName.values()).sort((a, b) => a.name.localeCompare(b.name));
+};
+
 const sanitizeLibraryMappings = (raw = []) => {
   if (!raw) return [];
   const entries = Array.isArray(raw) ? raw : [];
@@ -23,10 +60,14 @@ const sanitizeLibraryMappings = (raw = []) => {
     if (!assetPath) return;
     const collectionsValue = entry.collectionsPath ?? entry.collectionPath ?? entry.collectionsFolder;
     const collectionsPath = collectionsValue === undefined ? '' : normalizePathValue(collectionsValue);
+    const collectionSections = sanitizeCollectionSections(
+      entry.collectionSections ?? entry.collectionOverrides
+    );
     byLibrary.set(library, {
       library,
       assetPath,
       collectionsPath,
+      collectionSections,
     });
   });
   return Array.from(byLibrary.values()).sort((a, b) => a.library.localeCompare(b.library));
@@ -40,7 +81,18 @@ const areLibraryMappingsEqual = (left, right) => {
     (entry, index) =>
       entry.library === b[index].library &&
       entry.assetPath === b[index].assetPath &&
-      normalizePathValue(entry.collectionsPath) === normalizePathValue(b[index].collectionsPath)
+      normalizePathValue(entry.collectionsPath) ===
+        normalizePathValue(b[index].collectionsPath) &&
+      sanitizeCollectionSections(entry.collectionSections).every((section, sectionIndex) => {
+        const other = sanitizeCollectionSections(b[index].collectionSections)[sectionIndex];
+        if (!other) return false;
+        return (
+          normalizeSectionName(section.name) === normalizeSectionName(other.name) &&
+          normalizePathValue(section.collectionsPath) === normalizePathValue(other.collectionsPath)
+        );
+      }) &&
+      sanitizeCollectionSections(entry.collectionSections).length ===
+        sanitizeCollectionSections(b[index].collectionSections).length
   );
 };
 
@@ -55,6 +107,8 @@ const createLibraryMappingLookup = (raw = []) => {
 export {
   normalizeLibraryName,
   normalizePathValue,
+  normalizeSectionName,
+  sanitizeCollectionSections,
   sanitizeLibraryMappings,
   areLibraryMappingsEqual,
   createLibraryMappingLookup,

--- a/tests/test_kometa_config.py
+++ b/tests/test_kometa_config.py
@@ -71,6 +71,13 @@ libraries:
         str(config_dir / "assets" / "Holidays"),
     }
 
+    assert movies["collectionOverrides"] == [
+        {
+            "name": "Franchise",
+            "assetPath": str(config_dir / "assets" / "Collections"),
+        }
+    ]
+
     assert summaries["Documentaries"] == {}
 
 

--- a/tests/test_settings_route.py
+++ b/tests/test_settings_route.py
@@ -73,11 +73,13 @@ def test_get_settings_returns_defaults(settings_modules):
                 "library": "Movies",
                 "assetPath": "/assets/Movies",
                 "collectionsPath": "/assets/Collections",
+                "collectionSections": [],
             },
             {
                 "library": "TV Shows",
                 "assetPath": "/assets/TV Shows",
                 "collectionsPath": "/assets/Collections",
+                "collectionSections": [],
             },
         ],
     }
@@ -115,11 +117,13 @@ def test_put_settings_updates_file(settings_modules):
                 "library": "Movies",
                 "assetPath": "/assets/New Movies",
                 "collectionsPath": None,
+                "collectionSections": [],
             },
             {
                 "library": "TV Shows",
                 "assetPath": "/assets/TV Shows",
                 "collectionsPath": "/assets/Collections/Shows",
+                "collectionSections": [],
             },
         ],
     }


### PR DESCRIPTION
## Summary
- collect collection-level asset overrides from Kometa configs and surface them via the settings libraries API
- persist optional per-library collection sections in settings payloads and expose them in library responses
- update the settings UI to display collection overrides, open targeted folder modals, and style nested rows while adjusting supporting utilities and tests

## Testing
- pytest
- npm test -- --runTestsByPath src/pages/__tests__/SettingsPage.test.jsx *(fails: vitest binary unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e30a8086088330ad1e4fccf674425a