### PR TITLE
Allow folder finder navigation beyond mapped assets

### DIFF
--- a/app/routers/assets.py
+++ b/app/routers/assets.py
@@ -20,7 +20,12 @@ class AssignFolderPayload(BaseModel):
     folderName: str
 
 
-def _library_root(library: str, *, settings_mode: bool = False) -> Path:
+def _library_root(
+    library: str,
+    *,
+    settings_mode: bool = False,
+    allow_beyond_mapping: bool = False,
+) -> tuple[Path, str | None]:
     if not library:
         raise HTTPException(status_code=422, detail="Missing library")
     if library == "Collections":
@@ -30,33 +35,77 @@ def _library_root(library: str, *, settings_mode: bool = False) -> Path:
                 status_code=404, detail="No assets mapping for library 'Collections'"
             )
         root = Path(base)
+        default_relative = None
     else:
         mapped = library_mappings_service.get_asset_path(library)
-        if mapped and not settings_mode:
-            root = Path(mapped)
+        default_relative = None
+        mapped_path = Path(mapped) if mapped else None
+        assets_root = Path(ASSETS_ROOT) if ASSETS_ROOT else None
+
+        assets_root_resolved: Path | None = None
+        if assets_root:
+            try:
+                assets_root_resolved = assets_root.resolve()
+            except FileNotFoundError:
+                raise HTTPException(
+                    status_code=404, detail=f"Assets library not found: {assets_root}"
+                )
+            except PermissionError:
+                raise HTTPException(status_code=403, detail="Permission denied")
+            except OSError:
+                raise HTTPException(
+                    status_code=400, detail="Unable to resolve assets path"
+                )
+            if not assets_root_resolved.is_dir():
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"Assets library not found: {assets_root_resolved}",
+                )
+
+        mapped_resolved: Path | None = None
+        if mapped_path:
+            try:
+                mapped_resolved = mapped_path.resolve()
+            except FileNotFoundError:
+                raise HTTPException(
+                    status_code=404, detail=f"Assets library not found: {mapped_path}"
+                )
+            except PermissionError:
+                raise HTTPException(status_code=403, detail="Permission denied")
+            except OSError:
+                raise HTTPException(
+                    status_code=400, detail="Unable to resolve assets path"
+                )
+
+        if mapped_resolved and not settings_mode:
+            can_expand = (
+                allow_beyond_mapping
+                and assets_root_resolved is not None
+                and mapped_resolved.is_relative_to(assets_root_resolved)
+            )
+            if can_expand:
+                root = assets_root_resolved
+                relative = mapped_resolved.relative_to(assets_root_resolved)
+                default_relative = str(relative) if str(relative) != "." else ""
+            else:
+                root = mapped_resolved
         else:
-            if not ASSETS_ROOT:
-                if mapped:
-                    root = Path(mapped)
+            if not assets_root_resolved:
+                if mapped_resolved:
+                    root = mapped_resolved
                 else:
                     raise HTTPException(
                         status_code=404,
                         detail=f"No assets mapping for library '{library}'",
                     )
             else:
-                assets_root = Path(ASSETS_ROOT)
-                if not assets_root.is_dir():
-                    raise HTTPException(
-                        status_code=404,
-                        detail=f"Assets library not found: {assets_root}",
-                    )
                 if settings_mode:
-                    root = assets_root
-                elif mapped:
-                    root = Path(mapped)
+                    root = assets_root_resolved
+                elif mapped_resolved:
+                    root = mapped_resolved
                 else:
-                    candidate = assets_root / library
-                    root = candidate if candidate.is_dir() else assets_root
+                    candidate = assets_root_resolved / library
+                    root = candidate if candidate.is_dir() else assets_root_resolved
 
     try:
         resolved_root = root.resolve()
@@ -69,7 +118,7 @@ def _library_root(library: str, *, settings_mode: bool = False) -> Path:
 
     if not resolved_root.is_dir():
         raise HTTPException(status_code=404, detail=f"Assets library not found: {resolved_root}")
-    return resolved_root
+    return resolved_root, default_relative
 
 
 def _ensure_within_root(root: Path, target: Path) -> Path:
@@ -86,8 +135,10 @@ def list_asset_folders(
     parent: str | None = Query(None),
     search: str | None = Query(None),
     settings: bool = Query(False),
+    allow_beyond_mapping: bool = Query(False, alias="allowBeyondMapping"),
 ):
     parent_value = parent if isinstance(parent, str) else None
+    parent_provided = parent is not None
     search_value = search if isinstance(search, str) else None
     if isinstance(settings, bool):
         settings_flag = settings
@@ -95,10 +146,14 @@ def list_asset_folders(
         default_value = getattr(settings, "default", settings)
         settings_flag = bool(default_value)
 
-    root = _library_root(library, settings_mode=settings_flag)
+    root, default_relative = _library_root(
+        library,
+        settings_mode=settings_flag,
+        allow_beyond_mapping=allow_beyond_mapping,
+    )
     current = root
-    if parent_value:
-        rel = Path(parent_value)
+    if parent_provided:
+        rel = Path(parent_value or ".")
         if settings and rel.is_absolute():
             current = _ensure_within_root(root, rel.resolve())
         else:
@@ -107,6 +162,10 @@ def list_asset_folders(
             current = _ensure_within_root(root, (root / rel).resolve())
         if not current.exists() or not current.is_dir():
             raise HTTPException(status_code=404, detail="Parent directory not found")
+    elif default_relative:
+        current = _ensure_within_root(root, (root / default_relative).resolve())
+        if not current.exists() or not current.is_dir():
+            current = root
 
     term = (search_value or "").strip().lower()
     items: List[dict] = []

--- a/frontend/src/components/FolderFinderModal.jsx
+++ b/frontend/src/components/FolderFinderModal.jsx
@@ -89,6 +89,7 @@ function FolderFinderModal({
   const [assigning, setAssigning] = useState(false);
   const [currentFolder, setCurrentFolder] = useState('');
   const debounceRef = useRef();
+  const isAtRootRef = useRef(false);
 
   useEffect(() => {
     if (!isOpen) {
@@ -149,7 +150,7 @@ function FolderFinderModal({
   ]);
 
   const loadFolders = useCallback(
-    async ({ path = '', query = '', preserveSelection = false } = {}) => {
+    async ({ path = '', query = '', preserveSelection = false, explicitParent = false } = {}) => {
       if (!effectiveLibrary) {
         setResults([]);
         setError(isSettingsMode ? 'Select a library before browsing folders.' : 'No library mapping available for this item.');
@@ -171,9 +172,11 @@ function FolderFinderModal({
       setIsSearching(Boolean(query));
       const params = new URLSearchParams();
       params.set('library', effectiveLibrary);
-      if (path) params.set('parent', path);
+      const shouldUseExplicitParent = explicitParent || (path === '' && isAtRootRef.current);
+      if (shouldUseExplicitParent || path) params.set('parent', path);
       if (query) params.set('search', query);
       if (isSettingsMode) params.set('settings', 'true');
+      if (!isSettingsMode) params.set('allowBeyondMapping', 'true');
 
       try {
         const response = await fetch(`/api/asset-folders?${params.toString()}`);
@@ -189,7 +192,8 @@ function FolderFinderModal({
           : [];
         const normalized = list.map(normalizeFolderEntry).filter(Boolean);
         setResults(normalized);
-        const parentPath = data?.parent ?? path ?? '';
+        const parentPath = typeof data?.parent === 'string' ? data.parent : path ?? '';
+        isAtRootRef.current = !parentPath;
         setCurrentPath(parentPath || '');
       } catch (err) {
         setResults([]);
@@ -283,7 +287,9 @@ function FolderFinderModal({
   };
 
   const handleBreadcrumbClick = (crumb) => {
-    loadFolders({ path: crumb.path || '', query: '', preserveSelection: false });
+    const crumbPath = crumb.path ?? '';
+    const isRoot = !crumb.path && !crumb.isSearch;
+    loadFolders({ path: crumbPath, query: '', preserveSelection: false, explicitParent: isRoot });
     setSearchInput('');
     setSearchTerm('');
   };

--- a/tests/test_libraries_settings_endpoints.py
+++ b/tests/test_libraries_settings_endpoints.py
@@ -397,3 +397,83 @@ def test_asset_folders_settings_mode_allows_assets_root(tmp_path, monkeypatch):
     assert outside.status_code == 400
 
 
+def test_asset_folders_allow_beyond_mapping(tmp_path, monkeypatch):
+    assets_root = tmp_path / "assets"
+    movies_dir = assets_root / "Movies"
+    featured_dir = movies_dir / "Featured"
+    posters_dir = featured_dir / "Posters"
+    loose_dir = assets_root / "LooseAssets"
+
+    posters_dir.mkdir(parents=True)
+    loose_dir.mkdir(parents=True)
+
+    monkeypatch.setenv("KAM_ASSETS_ROOT", str(assets_root))
+
+    resolve_module = importlib.reload(importlib.import_module("app.services.resolve"))
+    resolve_module.ASSETS_ROOT = str(assets_root)
+
+    settings_module = importlib.reload(importlib.import_module("app.services.settings"))
+    settings_module.set_settings_path(str(tmp_path / "settings.json"))
+    settings_module.save_settings(
+        {
+            "libraryMappings": [
+                {
+                    "library": "Movies",
+                    "assetPath": str(featured_dir),
+                    "collectionsPath": None,
+                }
+            ]
+        }
+    )
+
+    library_mappings_module = importlib.reload(
+        importlib.import_module("app.services.library_mappings")
+    )
+    library_mappings_module.clear_cache()
+
+    assets_router = importlib.reload(importlib.import_module("app.routers.assets"))
+
+    app = FastAPI()
+    app.include_router(assets_router.router)
+
+    client = TestClient(app)
+
+    scoped = client.get(
+        "/api/asset-folders",
+        params={"library": "Movies", "allowBeyondMapping": "true"},
+    )
+    assert scoped.status_code == 200
+    scoped_payload = scoped.json()
+    assert scoped_payload["parent"] == "Movies/Featured"
+    scoped_names = {item["name"] for item in scoped_payload["items"]}
+    assert scoped_names == {"Posters"}
+
+    ascended = client.get(
+        "/api/asset-folders",
+        params={
+            "library": "Movies",
+            "allowBeyondMapping": "true",
+            "parent": "Movies",
+        },
+    )
+    assert ascended.status_code == 200
+    ascended_payload = ascended.json()
+    assert ascended_payload["parent"] == "Movies"
+    ascended_names = {item["name"] for item in ascended_payload["items"]}
+    assert "Featured" in ascended_names
+
+    root_view = client.get(
+        "/api/asset-folders",
+        params={
+            "library": "Movies",
+            "allowBeyondMapping": "true",
+            "parent": "",
+        },
+    )
+    assert root_view.status_code == 200
+    root_payload = root_view.json()
+    assert root_payload["parent"] == ""
+    root_names = {item["name"] for item in root_payload["items"]}
+    assert {"Movies", "LooseAssets"}.issubset(root_names)
+
+


### PR DESCRIPTION
## Summary
- allow the asset folders endpoint to expose the assets root when explicitly requested
- update the folder finder modal to request the expanded scope and keep root navigation stable
- cover the new allowBeyondMapping flag with backend tests

## Testing
- pytest tests/test_libraries_settings_endpoints.py
- npm test -- --runInBand *(fails: vitest not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3e9426be48330a82682696d51c2ff