### PR TITLE
Add collection detail view with upload and import controls

### DIFF
--- a/app/routers/collections.py
+++ b/app/routers/collections.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, HTTPException, Query
 from math import ceil
 from typing import Optional, List, Dict, Any, Tuple
 from ..services.plex import get_plex
@@ -22,6 +22,11 @@ LOCAL_FILENAMES = (
     "folder.jpg", "cover.jpg", "cover.png", "cover.webp"
 )
 
+BACKGROUND_FILENAMES = (
+    "background.jpg", "background.png", "background.webp", "background.jpeg",
+    "art.jpg", "art.png", "art.webp", "fanart.jpg", "fanart.png"
+)
+
 def _case_insensitive_dir(base: Path, want: str) -> Path | None:
     """
     Return an existing subdir in `base` whose name matches `want` case-insensitively.
@@ -40,6 +45,15 @@ def _case_insensitive_dir(base: Path, want: str) -> Path | None:
 def _first_existing_poster(dir_path: Path) -> Path | None:
     """Return the first existing poster file in the given directory."""
     for name in LOCAL_FILENAMES:
+        p = dir_path / name
+        if p.exists():
+            return p
+    return None
+
+
+def _first_existing_background(dir_path: Path) -> Path | None:
+    """Return the first existing background file in the given directory."""
+    for name in BACKGROUND_FILENAMES:
         p = dir_path / name
         if p.exists():
             return p
@@ -132,6 +146,110 @@ def _url_for_local(base: Path, folder_name: str, file_path: Path) -> str:
     if ts:
         url = f"{url}&t={ts}" if "?" in url else f"{url}?t={ts}"
     return url
+
+
+@router.get("/collection", summary="Collection details")
+def collection(
+    library: str = Query(...),
+    ratingKey: int = Query(...),
+    sourceLibrary: Optional[str] = Query(None),
+    source: Optional[str] = Query(None),
+):
+    plex = get_plex()
+    try:
+        item = plex.fetchItem(int(ratingKey))
+    except Exception as exc:
+        raise HTTPException(404, f"Collection {ratingKey} not found: {exc}")
+
+    title = (getattr(item, "title", None) or "").strip() or "Untitled"
+    year = getattr(item, "year", None)
+
+    actual_library = sourceLibrary or source or getattr(item, "librarySectionTitle", None) or None
+    collections_base = _collections_root_for_library(actual_library)
+
+    poster_plex = None
+    background_plex = None
+    cfg = plex_settings.get_plex_config()
+    if cfg.url and cfg.token:
+        poster_plex = f"{cfg.url}/library/metadata/{int(ratingKey)}/thumb?X-Plex-Token={cfg.token}"
+        background_plex = f"{cfg.url}/library/metadata/{int(ratingKey)}/art?X-Plex-Token={cfg.token}"
+
+    override_folder = folder_overrides.get_override(actual_library or library, str(ratingKey))
+    folder_name = override_folder or sanitize_name(title)
+    folder_exists = False
+    poster_local = None
+    background_local = None
+
+    if collections_base and override_folder:
+        override_path = collections_base / override_folder
+        if override_path.is_dir():
+            folder_exists = True
+            poster_path = _first_existing_poster(override_path)
+            if poster_path:
+                poster_local = _url_for_local(collections_base, override_path.name, poster_path)
+            background_path = _first_existing_background(override_path)
+            if background_path:
+                background_local = _url_for_local(collections_base, override_path.name, background_path)
+    elif collections_base:
+        poster_path, poster_url, detected_folder, detected_exists = _local_poster_for_title(
+            title,
+            collections_base,
+        )
+        if detected_folder:
+            folder_name = detected_folder
+        folder_exists = detected_exists
+        if poster_url:
+            poster_local = poster_url
+        elif poster_path and folder_name:
+            poster_local = _url_for_local(collections_base, folder_name, poster_path)
+
+    if collections_base and folder_name:
+        folder_path = collections_base / folder_name
+        if folder_path.is_dir():
+            folder_exists = True
+            if not poster_local:
+                poster_path = _first_existing_poster(folder_path)
+                if poster_path:
+                    poster_local = _url_for_local(collections_base, folder_path.name, poster_path)
+            background_path = _first_existing_background(folder_path)
+            if background_path:
+                background_local = _url_for_local(collections_base, folder_path.name, background_path)
+
+    poster_exists = bool(poster_local)
+    background_exists = bool(background_local)
+
+    return {
+        "library": library,
+        "sourceLibrary": actual_library,
+        "title": title,
+        "year": year,
+        "ratingKey": int(ratingKey),
+        "folderName": folder_name or "",
+        "folderExists": folder_exists,
+        "posterExists": poster_exists,
+        "backgroundExists": background_exists,
+        "posterUrl": poster_local,
+        "posterUrlLocal": poster_local,
+        "posterUrlPlex": poster_plex,
+        "backgroundUrl": background_local,
+        "backgroundUrlLocal": background_local,
+        "backgroundUrlPlex": background_plex,
+    }
+
+
+@router.get("/api/collection", summary="Collection details (alias)")
+def collection_alias(
+    library: str = Query(...),
+    ratingKey: int = Query(...),
+    sourceLibrary: Optional[str] = Query(None),
+    source: Optional[str] = Query(None),
+):
+    return collection(
+        library=library,
+        ratingKey=ratingKey,
+        sourceLibrary=sourceLibrary,
+        source=source,
+    )
 
 
 @router.get("/collections", summary="Collections")

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,5 @@
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
+import CollectionDetailPage from './pages/CollectionDetailPage.jsx';
 import LibraryPage from './pages/LibraryPage.jsx';
 import MovieDetailPage from './pages/MovieDetailPage.jsx';
 import NotReadyPage from './pages/NotReadyPage.jsx';
@@ -15,9 +16,13 @@ function App() {
           <Routes>
             <Route path="/" element={<Navigate to="/libraries" replace />} />
             <Route path="/libraries" element={<LibraryPage />} />
+            <Route path="/libraries/:library" element={<LibraryPage />} />
             <Route path="/libraries/:library/not-ready" element={<NotReadyPage />} />
-            <Route path="/libraries/*" element={<LibraryPage />} />
+            <Route path="/libraries/:library/movies/:ratingKey" element={<MovieDetailPage />} />
+            <Route path="/libraries/:library/shows/:ratingKey" element={<ShowDetailPage />} />
+            <Route path="/libraries/:library/collections/:ratingKey" element={<CollectionDetailPage />} />
             <Route path="/settings" element={<SettingsPage />} />
+            <Route path="*" element={<Navigate to="/libraries" replace />} />
           </Routes>
         </LibraryItemsProvider>
       </BrowserRouter>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -661,6 +661,12 @@ main {
   font-size: 15px;
 }
 
+.detail-source {
+  color: var(--muted);
+  font-size: 14px;
+  margin-left: 8px;
+}
+
 .detail-header-gap {
   flex: 1 1 auto;
 }

--- a/frontend/src/pages/CollectionDetailPage.jsx
+++ b/frontend/src/pages/CollectionDetailPage.jsx
@@ -1,0 +1,326 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Link, useParams, useSearchParams } from 'react-router-dom';
+import ArtworkCard from '../components/ArtworkCard.jsx';
+import { responseErrorMessage, safeJson } from '../utils/api.js';
+
+const MISSING_FOLDER_MESSAGE = 'Create the Kometa collections folder first.';
+
+function createOperation() {
+  return {
+    uploading: false,
+    importing: false,
+    success: false,
+    error: null,
+    lastAction: null,
+  };
+}
+
+function CollectionDetailPage() {
+  const params = useParams();
+  const [searchParams] = useSearchParams();
+  const rawLibrary = params.library ?? searchParams.get('library') ?? searchParams.get('lib') ?? '';
+  const rawRatingKey = params.ratingKey ?? searchParams.get('ratingKey') ?? searchParams.get('id') ?? '';
+  const sourceParam = searchParams.get('source') ?? searchParams.get('sourceLibrary') ?? '';
+  const library = rawLibrary ? String(rawLibrary) : '';
+  const ratingKey = rawRatingKey ? String(rawRatingKey) : '';
+  const sourceLibrary = sourceParam ? String(sourceParam) : '';
+
+  const [detail, setDetail] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [statusMessage, setStatusMessage] = useState('');
+  const [operations, setOperations] = useState({
+    poster: createOperation(),
+    background: createOperation(),
+  });
+
+  useEffect(() => {
+    setDetail(null);
+    setError(null);
+    setStatusMessage('');
+    setOperations({ poster: createOperation(), background: createOperation() });
+  }, [library, ratingKey, sourceLibrary]);
+
+  const updateOperation = useCallback((kind, nextState) => {
+    setOperations((prev) => {
+      const prevState = prev[kind] ?? createOperation();
+      const next = typeof nextState === 'function' ? nextState(prevState) : nextState;
+      if (
+        prevState.uploading === next.uploading &&
+        prevState.importing === next.importing &&
+        prevState.success === next.success &&
+        prevState.error === next.error &&
+        prevState.lastAction === next.lastAction
+      ) {
+        return prev;
+      }
+      return { ...prev, [kind]: next };
+    });
+  }, []);
+
+  const fetchDetails = useCallback(async () => {
+    if (!library || !ratingKey) {
+      setError('Missing library or rating key.');
+      setLoading(false);
+      setDetail(null);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const query = new URLSearchParams({
+        library,
+        ratingKey,
+      });
+      if (sourceLibrary) {
+        query.set('source', sourceLibrary);
+      }
+      const response = await fetch(`/api/collection?${query.toString()}`);
+      const data = await safeJson(response);
+      if (!response.ok) {
+        throw new Error(responseErrorMessage(response, data));
+      }
+      setDetail(data || null);
+      if (typeof document !== 'undefined') {
+        const titlePieces = [];
+        if (data?.title) titlePieces.push(data.title);
+        if (data?.year) titlePieces.push(`(${data.year})`);
+        document.title = titlePieces.length
+          ? `KAM • ${titlePieces.join(' ')}`
+          : 'KAM • Collection Details';
+      }
+      setStatusMessage((prev) => {
+        if (!data?.folderExists) return MISSING_FOLDER_MESSAGE;
+        if (prev && prev !== MISSING_FOLDER_MESSAGE) return prev;
+        return '';
+      });
+    } catch (err) {
+      const message = err?.message || String(err);
+      setError(message);
+      setDetail(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [library, ratingKey, sourceLibrary]);
+
+  useEffect(() => {
+    fetchDetails();
+  }, [fetchDetails]);
+
+  const folderExists = Boolean(detail?.folderExists);
+  const folderName = detail?.folderName || '';
+  const effectiveRatingKey = detail?.ratingKey != null ? String(detail.ratingKey) : ratingKey;
+
+  const posterExists = useMemo(() => {
+    if (typeof detail?.posterExists === 'boolean') return detail.posterExists;
+    return Boolean(detail?.posterUrl);
+  }, [detail]);
+
+  const backgroundExists = useMemo(() => {
+    if (typeof detail?.backgroundExists === 'boolean') return detail.backgroundExists;
+    return Boolean(detail?.backgroundUrl);
+  }, [detail]);
+
+  const posterImage = detail?.posterUrl || detail?.posterUrlPlex || null;
+  const backgroundImage = detail?.backgroundUrl || detail?.backgroundUrlPlex || null;
+
+  const handleUpload = useCallback(
+    async (kind, file) => {
+      if (!folderExists) {
+        setStatusMessage(MISSING_FOLDER_MESSAGE);
+        throw new Error(MISSING_FOLDER_MESSAGE);
+      }
+      const label = kind === 'background' ? 'background' : 'poster';
+      updateOperation(kind, {
+        uploading: true,
+        importing: false,
+        success: false,
+        error: null,
+        lastAction: 'upload',
+      });
+      setStatusMessage(`Uploading ${label}…`);
+
+      const form = new FormData();
+      form.append('library', library);
+      if (effectiveRatingKey) form.append('ratingKey', effectiveRatingKey);
+      if (folderName) form.append('folderName', folderName);
+      form.append('kind', kind);
+      form.append('file', file);
+
+      try {
+        const response = await fetch('/api/upload', { method: 'POST', body: form });
+        const data = await safeJson(response);
+        if (!response.ok) {
+          throw new Error(responseErrorMessage(response, data));
+        }
+        updateOperation(kind, {
+          uploading: false,
+          importing: false,
+          success: true,
+          error: null,
+          lastAction: 'upload',
+        });
+        setStatusMessage('Upload complete.');
+        await fetchDetails();
+      } catch (err) {
+        const message = err?.message || String(err);
+        updateOperation(kind, {
+          uploading: false,
+          importing: false,
+          success: false,
+          error: message,
+          lastAction: 'upload',
+        });
+        setStatusMessage(message);
+        throw err;
+      }
+    },
+    [folderExists, library, effectiveRatingKey, folderName, fetchDetails, updateOperation]
+  );
+
+  const handleImport = useCallback(
+    async (kind) => {
+      if (!folderExists) {
+        setStatusMessage(MISSING_FOLDER_MESSAGE);
+        return;
+      }
+      const label = kind === 'background' ? 'background' : 'poster';
+      updateOperation(kind, {
+        uploading: false,
+        importing: true,
+        success: false,
+        error: null,
+        lastAction: 'import',
+      });
+      setStatusMessage(`Importing ${label}…`);
+
+      const form = new FormData();
+      form.append('library', library);
+      if (effectiveRatingKey) form.append('ratingKey', effectiveRatingKey);
+      if (folderName) form.append('folderName', folderName);
+      const plexUrl =
+        kind === 'background'
+          ? detail?.backgroundUrlPlex || detail?.plexBackgroundUrl || null
+          : detail?.posterUrlPlex || detail?.plexPosterUrl || null;
+      if (plexUrl) {
+        form.append('url', plexUrl);
+      }
+      const endpoint = kind === 'background' ? '/api/import/background' : '/api/import/poster';
+
+      try {
+        const response = await fetch(endpoint, { method: 'POST', body: form });
+        const data = await safeJson(response);
+        if (!response.ok || !(data && data.ok)) {
+          throw new Error(responseErrorMessage(response, data));
+        }
+        updateOperation(kind, {
+          uploading: false,
+          importing: false,
+          success: true,
+          error: null,
+          lastAction: 'import',
+        });
+        setStatusMessage('Import complete.');
+        await fetchDetails();
+      } catch (err) {
+        const message = err?.message || String(err);
+        updateOperation(kind, {
+          uploading: false,
+          importing: false,
+          success: false,
+          error: message,
+          lastAction: 'import',
+        });
+        setStatusMessage(message);
+      }
+    },
+    [folderExists, library, effectiveRatingKey, folderName, detail, fetchDetails, updateOperation]
+  );
+
+  const backLink = library ? `/libraries?lib=${encodeURIComponent(library)}` : '/libraries';
+  const folderDisplay = folderName || 'Not assigned';
+  const headerTitle = detail?.title || 'Collection Details';
+  const headerYear = detail?.year;
+  const displaySource = detail?.sourceLibrary || sourceLibrary || '';
+
+  return (
+    <div className="detail-page">
+      <header>
+        <Link className="btn" to={backLink}>
+          ← Back
+        </Link>
+        <h1>{headerTitle}</h1>
+        {headerYear ? <span className="detail-year">({headerYear})</span> : null}
+        {displaySource ? <span className="detail-source">• {displaySource}</span> : null}
+        <span className="detail-header-gap" aria-hidden="true" />
+        <Link className="settings-link" to="/settings" aria-label="Open settings">
+          <span aria-hidden="true">⚙</span>
+        </Link>
+      </header>
+      <main className="detail-main">
+        {loading ? (
+          <div className="detail-container">
+            <div className="status-text" aria-live="polite">
+              Loading…
+            </div>
+          </div>
+        ) : error ? (
+          <div className="detail-container">
+            <div className="status-text error" aria-live="polite">
+              {error}
+            </div>
+            <button type="button" className="btn" onClick={fetchDetails}>
+              Retry
+            </button>
+          </div>
+        ) : detail ? (
+          <div className="detail-container">
+            {!folderExists ? (
+              <div className="detail-warning" role="alert">
+                <strong>✖</strong>
+                <span>{MISSING_FOLDER_MESSAGE}</span>
+              </div>
+            ) : null}
+            <div className="detail-folder" aria-live="polite">
+              Collections folder:
+              <span className="detail-folder-name">{folderDisplay}</span>
+            </div>
+            <section className="asset-card-grid">
+              <ArtworkCard
+                label="Poster"
+                exists={posterExists}
+                imageUrl={posterImage}
+                folderExists={folderExists}
+                operation={operations.poster}
+                onUpload={(file) => handleUpload('poster', file)}
+                onImport={() => handleImport('poster')}
+              />
+              <ArtworkCard
+                label="Background"
+                exists={backgroundExists}
+                imageUrl={backgroundImage}
+                folderExists={folderExists}
+                operation={operations.background}
+                onUpload={(file) => handleUpload('background', file)}
+                onImport={() => handleImport('background')}
+              />
+            </section>
+            <div className="detail-status" aria-live="polite">
+              {statusMessage || '\u00a0'}
+            </div>
+          </div>
+        ) : (
+          <div className="detail-container">
+            <div className="status-text" aria-live="polite">
+              Details unavailable.
+            </div>
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}
+
+export default CollectionDetailPage;

--- a/frontend/src/utils/items.js
+++ b/frontend/src/utils/items.js
@@ -7,11 +7,15 @@ export function isShowItem(item, libraryName) {
 export function buildDetailPath(item, libraryName) {
   const lib = (libraryName || '').trim();
   if (!lib) return null;
-  if (lib.toLowerCase() === 'collections') return null;
   const ratingKey = item?.ratingKey ?? item?.key ?? item?.id;
   if (ratingKey == null) return null;
   const encodedLib = encodeURIComponent(lib);
   const encodedKey = encodeURIComponent(ratingKey);
+  if (lib.toLowerCase() === 'collections') {
+    const sourceLibrary = item?.library ? String(item.library).trim() : '';
+    const sourceParam = sourceLibrary ? `?source=${encodeURIComponent(sourceLibrary)}` : '';
+    return `/libraries/${encodedLib}/collections/${encodedKey}${sourceParam}`;
+  }
   if (isShowItem(item, libraryName)) {
     return `/libraries/${encodedLib}/shows/${encodedKey}`;
   }


### PR DESCRIPTION
## Summary
- add an API endpoint that returns detailed collection metadata, including existing artwork and folder information
- introduce a Collection detail page that exposes per-item upload and import actions and hook it up to the router
- allow collection cards to navigate to the new view and polish the header styling for the source library badge

## Testing
- npm test -- --runTestsByPath src/components/__tests__/FolderFinderModal.test.jsx *(fails: vitest binary unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3ecd5b0ec8330b7f7282dc129fd75