### PR TITLE
Update README to reflect React UI and correct .env sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ KAM only cares about the **internal** path (e.g., `/assets`). You choose what ho
 * Read/write access to your media **assets** directories (bind-mounted)
 * Optional: Reverse proxy (Caddy/Traefik/Nginx) if you want TLS or auth
 
+> 🆕 The web UI is now powered by **React**. We no longer ship the legacy Ninja templates, so make sure you rebuild/pull the latest image to get the updated frontend.
+
 ---
 
 ## Quick Start (Docker)
@@ -142,27 +144,24 @@ Bring it up:
 ```bash
 docker compose up -d
 ```
-Edit the .env file to configure
+Edit the `.env` file to configure the container before bringing it up:
 
-Sample .env
-```yaml
+Sample `.env`
+```dotenv
 # Example environment file for KAM
 # Copy to .env and edit values before running
 
 # Plex connection
 PLEX_URL=http://192.168.1.XXX:32400
 PLEX_TOKEN=CHANGE_ME
-
-# Map Plex libraries to asset folders inside container
-# e.g. Movies:/assets/Movies,Kids Movies:/assets/Kids Movies
-LIBRARIES=Movies:/assets/Movies,Kids Movies:/assets/Kids Movies
+# Set to false only if your Plex server has a self-signed cert
+PLEX_VERIFY_SSL=true
 
 # Runtime
 PORT=8000
-
-# Root path for collection posters
-COLLECTIONS_ROOT=/assets/Collections
 ```
+
+Library folder mappings and the collections root are now configured directly in the **Settings** page of the web UI—no more `LIBRARIES` or `COLLECTIONS_ROOT` variables are needed in the environment file.
 
 ---
 


### PR DESCRIPTION
## Summary
- note the React-based frontend and removal of the old Ninja templates
- refresh the sample .env configuration, removing obsolete `LIBRARIES`/`COLLECTIONS_ROOT` variables that are now managed from the UI

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e3fece8bd08330a6c196a368a35320