### PR TITLE
Fix config error handling for missing library mappings

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,17 +1,17 @@
 import os
 from typing import List
 
-from .services import plex_settings
+from .services import library_mappings, plex_settings
 
 PORT = int(os.environ.get("PORT", "8080"))
 
 LIBRARY_MAPPINGS = {}
 COLLECTIONS_ROOT = os.environ.get("COLLECTIONS_ROOT", "/assets/Collections")
-raw = os.environ.get("LIBRARIES", "")
-for e in filter(None, (x.strip() for x in raw.split(","))):
-    if ":" in e:
-        name, path = e.split(":", 1)
-        LIBRARY_MAPPINGS[name.strip()] = path.strip()
+for entry in library_mappings.seed_from_env():
+    name = str(entry.get("library") or "").strip()
+    path = str(entry.get("assetPath") or "").strip()
+    if name and path:
+        LIBRARY_MAPPINGS[name] = path
 
 def get_config_errors() -> List[str]:
     errors: List[str] = []
@@ -19,6 +19,4 @@ def get_config_errors() -> List[str]:
         errors.append("Missing PLEX_URL")
     if not plex_settings.get_plex_token():
         errors.append("Missing PLEX_TOKEN")
-    if not LIBRARY_MAPPINGS:
-        errors.append("Missing LIBRARIES (e.g. Movies:/assets/Movies,Collections:/assets/Collections)")
     return errors

--- a/app/routers/assets.py
+++ b/app/routers/assets.py
@@ -138,7 +138,7 @@ def list_asset_folders(
     allow_beyond_mapping: bool = Query(False, alias="allowBeyondMapping"),
 ):
     parent_value = parent if isinstance(parent, str) else None
-    parent_provided = parent is not None
+    parent_provided = parent_value is not None
     search_value = search if isinstance(search, str) else None
     if isinstance(settings, bool):
         settings_flag = settings
@@ -146,10 +146,16 @@ def list_asset_folders(
         default_value = getattr(settings, "default", settings)
         settings_flag = bool(default_value)
 
+    if isinstance(allow_beyond_mapping, bool):
+        allow_flag = allow_beyond_mapping
+    else:
+        default_allow = getattr(allow_beyond_mapping, "default", allow_beyond_mapping)
+        allow_flag = bool(default_allow)
+
     root, default_relative = _library_root(
         library,
         settings_mode=settings_flag,
-        allow_beyond_mapping=allow_beyond_mapping,
+        allow_beyond_mapping=allow_flag,
     )
     current = root
     if parent_provided:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,63 @@
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+MODULES_TO_RELOAD = [
+    "app.services.settings",
+    "app.services.library_mappings",
+    "app.services.plex_settings",
+    "app.config",
+]
+
+
+@pytest.fixture
+def reload_config(monkeypatch, tmp_path):
+    """Provide a helper that reloads config-related modules with a clean env."""
+
+    monkeypatch.setenv("KAM_SETTINGS_PATH", str(tmp_path / "settings.json"))
+
+    def _reload() -> object:
+        module = None
+        for name in MODULES_TO_RELOAD:
+            module = importlib.import_module(name)
+            module = importlib.reload(module)
+        assert module is not None
+        return sys.modules["app.config"]
+
+    try:
+        yield _reload
+    finally:
+        for name in MODULES_TO_RELOAD:
+            module = importlib.import_module(name)
+            importlib.reload(module)
+
+
+def test_config_errors_ignore_missing_library_mappings(reload_config, monkeypatch):
+    monkeypatch.delenv("LIBRARIES", raising=False)
+    monkeypatch.delenv("COLLECTIONS_ROOT", raising=False)
+    monkeypatch.setenv("PLEX_URL", "http://plex.example:32400")
+    monkeypatch.setenv("PLEX_TOKEN", "example-token")
+
+    config_module = reload_config()
+    errors = config_module.get_config_errors()
+
+    assert "Missing LIBRARIES" not in errors
+
+
+def test_config_errors_require_plex_credentials(reload_config, monkeypatch):
+    monkeypatch.delenv("PLEX_URL", raising=False)
+    monkeypatch.delenv("PLEX_TOKEN", raising=False)
+
+    config_module = reload_config()
+    errors = config_module.get_config_errors()
+
+    assert "Missing PLEX_URL" in errors
+    assert "Missing PLEX_TOKEN" in errors


### PR DESCRIPTION
## Summary
- stop treating missing library mappings as a fatal configuration error so Plex connections can succeed before assets are mapped
- add regression tests covering the revised configuration validation
- normalize asset folder query defaults to behave the same when called directly or through FastAPI

## Testing
- `pytest`
- `pytest tests/test_config.py tests/test_folder_overrides.py`


------
https://chatgpt.com/codex/tasks/task_e_68e4017822a08330b54f17c9cb846edc