### PR TITLE
Remove Plex env fallback when settings exist

### DIFF
--- a/app/services/plex_settings.py
+++ b/app/services/plex_settings.py
@@ -1,7 +1,6 @@
 """Helpers for resolving Plex connection details from persisted settings."""
 from __future__ import annotations
 
-import os
 import threading
 from dataclasses import dataclass
 from typing import Optional
@@ -41,8 +40,8 @@ def _normalize_url(url: str) -> str:
 
 def _resolve_uncached() -> PlexConfig:
     data = settings_service.load_settings()
-    url = _coalesce_setting(data, _URL_KEYS) or os.environ.get("PLEX_URL", "")
-    token = _coalesce_setting(data, _TOKEN_KEYS) or os.environ.get("PLEX_TOKEN", "")
+    url = _coalesce_setting(data, _URL_KEYS)
+    token = _coalesce_setting(data, _TOKEN_KEYS)
     return PlexConfig(url=_normalize_url(url), token=token.strip())
 
 

--- a/tests/test_plex_settings.py
+++ b/tests/test_plex_settings.py
@@ -1,0 +1,36 @@
+import importlib
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def test_clearing_settings_removes_env_fallback(monkeypatch, tmp_path):
+    settings_path = tmp_path / "settings.json"
+
+    with monkeypatch.context() as patch:
+        patch.setenv("KAM_SETTINGS_PATH", str(settings_path))
+        patch.setenv("PLEX_URL", "http://plex.example:32400")
+        patch.setenv("PLEX_TOKEN", "initial-token")
+
+        settings_service = importlib.reload(
+            importlib.import_module("app.services.settings")
+        )
+        plex_settings = importlib.reload(
+            importlib.import_module("app.services.plex_settings")
+        )
+
+        cfg = plex_settings.get_plex_config(force_refresh=True)
+        assert cfg.url == "http://plex.example:32400"
+        assert cfg.token == "initial-token"
+
+        settings_service.save_settings({"plexUrl": "", "plexToken": ""})
+
+        cfg = plex_settings.get_plex_config(force_refresh=True)
+        assert cfg.url == ""
+        assert cfg.token == ""
+
+    importlib.reload(importlib.import_module("app.services.settings"))
+    importlib.reload(importlib.import_module("app.services.plex_settings"))


### PR DESCRIPTION
## Summary
- stop resolving Plex URL/token from environment variables once settings are saved
- add a regression test that ensures clearing the settings removes the Plex connection

## Testing
- pytest tests/test_plex_settings.py tests/test_settings_route.py tests/test_config.py

------
https://chatgpt.com/codex/tasks/task_e_68e4082abcd483309f966bc79db5f581