### PR TITLE
Clear Plex libraries when credentials are removed

### DIFF
--- a/app/routers/libraries.py
+++ b/app/routers/libraries.py
@@ -116,7 +116,9 @@ def list_available_libraries() -> List[LibrarySectionInfo]:
     from ..services import plex_settings
     from ..services.plex import get_plex
 
-    plex_settings.get_plex_config()
+    cfg = plex_settings.get_plex_config()
+    if not cfg.url or not cfg.token:
+        return []
 
     plex = get_plex()
     try:

--- a/app/services/plex.py
+++ b/app/services/plex.py
@@ -23,3 +23,11 @@ def get_plex():
         except Exception as e:
             raise HTTPException(status_code=500, detail=f"Plex connect failed: {e}")
     return _plex
+
+
+def clear_cache() -> None:
+    """Reset the cached Plex client."""
+
+    global _plex, _last_creds
+    _plex = None
+    _last_creds = (None, None)

--- a/app/services/plex_settings.py
+++ b/app/services/plex_settings.py
@@ -1,7 +1,6 @@
 """Helpers for resolving Plex connection details from persisted settings."""
 from __future__ import annotations
 
-import os
 import threading
 from dataclasses import dataclass
 from typing import Optional
@@ -41,8 +40,8 @@ def _normalize_url(url: str) -> str:
 
 def _resolve_uncached() -> PlexConfig:
     data = settings_service.load_settings()
-    url = _coalesce_setting(data, _URL_KEYS) or os.environ.get("PLEX_URL", "")
-    token = _coalesce_setting(data, _TOKEN_KEYS) or os.environ.get("PLEX_TOKEN", "")
+    url = _coalesce_setting(data, _URL_KEYS)
+    token = _coalesce_setting(data, _TOKEN_KEYS)
     return PlexConfig(url=_normalize_url(url), token=token.strip())
 
 

--- a/app/services/settings.py
+++ b/app/services/settings.py
@@ -136,9 +136,11 @@ def _write_locked(data: Dict[str, Any]) -> None:
 
 def _clear_plex_cache() -> None:
     try:
+        from . import plex as plex_service  # Local import to avoid circular dependency
         from . import plex_settings  # Local import to avoid circular dependency
 
         plex_settings.clear_cache()
+        plex_service.clear_cache()
     except Exception:
         logger.debug("Unable to clear Plex settings cache", exc_info=True)
 

--- a/tests/test_libraries_settings_endpoints.py
+++ b/tests/test_libraries_settings_endpoints.py
@@ -34,6 +34,7 @@ def _create_libraries_client(
     monkeypatch: pytest.MonkeyPatch,
     load_settings_payload: dict,
     sections: List[_DummySection] | None = None,
+    plex_factory=None,
 ) -> TestClient:
     settings_module = importlib.reload(importlib.import_module("app.services.settings"))
     monkeypatch.setattr(settings_module, "load_settings", lambda: load_settings_payload)
@@ -47,7 +48,9 @@ def _create_libraries_client(
     ]
 
     plex_module = importlib.reload(importlib.import_module("app.services.plex"))
-    monkeypatch.setattr(plex_module, "get_plex", lambda: _DummyPlex(default_sections))
+    if plex_factory is None:
+        plex_factory = lambda: _DummyPlex(default_sections)
+    monkeypatch.setattr(plex_module, "get_plex", plex_factory)
 
     router_module = importlib.reload(importlib.import_module("app.routers.libraries"))
 
@@ -237,6 +240,31 @@ def test_settings_libraries_endpoint_handles_empty_mappings(monkeypatch):
             "collectionsPath": None,
         },
     ]
+
+
+def test_settings_libraries_endpoint_returns_empty_without_credentials(monkeypatch):
+    calls = {"count": 0}
+
+    def _should_not_run():
+        calls["count"] += 1
+        raise AssertionError("get_plex should not be called when credentials are missing")
+
+    client = _create_libraries_client(
+        monkeypatch,
+        {
+            "theme": "dark",
+            "plexUrl": "",
+            "plexToken": "",
+            "libraryMappings": [],
+        },
+        sections=[],
+        plex_factory=_should_not_run,
+    )
+
+    resp = client.get("/api/settings/libraries")
+    assert resp.status_code == 200
+    assert resp.json() == []
+    assert calls["count"] == 0
 
 
 def test_asset_folders_unmapped_library(tmp_path, monkeypatch):

--- a/tests/test_plex_settings.py
+++ b/tests/test_plex_settings.py
@@ -1,0 +1,36 @@
+import importlib
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def test_clearing_settings_removes_env_fallback(monkeypatch, tmp_path):
+    settings_path = tmp_path / "settings.json"
+
+    with monkeypatch.context() as patch:
+        patch.setenv("KAM_SETTINGS_PATH", str(settings_path))
+        patch.setenv("PLEX_URL", "http://plex.example:32400")
+        patch.setenv("PLEX_TOKEN", "initial-token")
+
+        settings_service = importlib.reload(
+            importlib.import_module("app.services.settings")
+        )
+        plex_settings = importlib.reload(
+            importlib.import_module("app.services.plex_settings")
+        )
+
+        cfg = plex_settings.get_plex_config(force_refresh=True)
+        assert cfg.url == "http://plex.example:32400"
+        assert cfg.token == "initial-token"
+
+        settings_service.save_settings({"plexUrl": "", "plexToken": ""})
+
+        cfg = plex_settings.get_plex_config(force_refresh=True)
+        assert cfg.url == ""
+        assert cfg.token == ""
+
+    importlib.reload(importlib.import_module("app.services.settings"))
+    importlib.reload(importlib.import_module("app.services.plex_settings"))


### PR DESCRIPTION
## Summary
- stop resolving Plex URL/token from environment variables once settings are saved
- add a regression test that ensures clearing the settings removes the Plex connection
- return no Plex libraries when credentials are cleared and reset the cached Plex client during saves

## Testing
- pytest tests/test_plex_settings.py tests/test_settings_route.py tests/test_config.py tests/test_libraries_settings_endpoints.py

------
https://chatgpt.com/codex/tasks/task_e_68e4082abcd483309f966bc79db5f581