### PR TITLE
Clear Plex libraries when credentials are removed

### DIFF
--- a/frontend/src/pages/SettingsPage.jsx
+++ b/frontend/src/pages/SettingsPage.jsx
@@ -70,6 +70,9 @@ function SettingsPage() {
 
   const savedPlexUrl = savedSettings?.plexUrl || '';
   const savedPlexToken = savedSettings?.plexToken || '';
+  const normalizedPlexUrl = normalizeText(plexUrl);
+  const normalizedPlexToken = normalizeText(plexToken);
+  const hasPlexCredentials = Boolean(normalizedPlexUrl && normalizedPlexToken);
 
   useEffect(() => {
     if (error) {
@@ -143,6 +146,9 @@ function SettingsPage() {
   const combinedBusy = busy || librariesLoading;
 
   const libraryRows = useMemo(() => {
+    if (!hasPlexCredentials) {
+      return [];
+    }
     const infoMap = new Map(
       (Array.isArray(libraries) ? libraries : []).map((entry) => {
         const name = normalizeLibraryName(entry?.name ?? entry?.library);
@@ -299,7 +305,7 @@ function SettingsPage() {
           collectionOverrides,
         };
       });
-  }, [libraries, libraryMappings, savedLibraryMappings]);
+  }, [hasPlexCredentials, libraries, libraryMappings, savedLibraryMappings]);
 
   const libraryRowMap = useMemo(() => new Map(libraryRows.map((row) => [row.name, row])), [libraryRows]);
 
@@ -633,6 +639,13 @@ function SettingsPage() {
 
   const handleRefreshLibraries = async () => {
     setStatus(null);
+    if (!hasPlexCredentials) {
+      setStatus({
+        type: 'error',
+        message: 'Enter your Plex URL and token before refreshing libraries.',
+      });
+      return;
+    }
     try {
       await refreshLibraries();
       setStatus({ type: 'success', message: 'Plex libraries refreshed.' });
@@ -785,7 +798,11 @@ function SettingsPage() {
               </button>
             </div>
             <div className="settings-libraries-group">
-              <button type="button" onClick={handleRefreshLibraries} disabled={combinedBusy}>
+              <button
+                type="button"
+                onClick={handleRefreshLibraries}
+                disabled={combinedBusy || !hasPlexCredentials}
+              >
                 {librariesLoading ? 'Refreshing…' : 'Refresh libraries'}
               </button>
             </div>
@@ -793,7 +810,11 @@ function SettingsPage() {
           <div className="settings-libraries-table-wrapper" aria-live="polite">
             {librariesLoading ? <p className="settings-libraries-status">Loading libraries…</p> : null}
             {!librariesLoading && !libraryRows.length ? (
-              <p className="settings-libraries-status">No libraries are available. Configure Plex and refresh.</p>
+              <p className="settings-libraries-status">
+                {hasPlexCredentials
+                  ? 'No libraries are available. Configure Plex and refresh.'
+                  : 'Enter your Plex URL and token, then save and refresh to load Plex libraries.'}
+              </p>
             ) : null}
             {libraryRows.length ? (
               <table className="settings-libraries-table">

--- a/frontend/src/pages/__tests__/SettingsPage.test.jsx
+++ b/frontend/src/pages/__tests__/SettingsPage.test.jsx
@@ -114,9 +114,9 @@ describe('SettingsPage', () => {
     useTheme.mockReturnValue({
       theme: 'dark',
       savedTheme: 'dark',
-      plexUrl: '',
-      plexToken: '',
-      savedSettings: { plexUrl: '', plexToken: '' },
+      plexUrl: 'http://plex.local',
+      plexToken: 'token',
+      savedSettings: { plexUrl: 'http://plex.local', plexToken: 'token' },
       libraryMappings: [],
       savedLibraryMappings: [],
       libraries: [],
@@ -146,6 +146,53 @@ describe('SettingsPage', () => {
 
     expect(mockRefresh).toHaveBeenCalled();
     expect(await screen.findByRole('status')).toHaveTextContent('Plex libraries refreshed.');
+  });
+
+  it('prevents refreshing libraries when Plex credentials are missing', async () => {
+    const mockRefresh = vi.fn();
+    useTheme.mockReturnValue({
+      theme: 'dark',
+      savedTheme: 'dark',
+      plexUrl: '',
+      plexToken: '',
+      savedSettings: { plexUrl: '', plexToken: '' },
+      libraryMappings: [],
+      savedLibraryMappings: [],
+      libraries: [
+        { name: 'Movies', type: 'movie', key: '1', assetPath: '/assets/Movies', collectionsPath: '' },
+      ],
+      librariesLoading: false,
+      librariesError: null,
+      loading: false,
+      saving: false,
+      error: null,
+      libraryMappingsDirty: false,
+      hasUnsavedChanges: false,
+      applyTheme: vi.fn(),
+      updateSettings: vi.fn(),
+      saveSettings: vi.fn(),
+      revertSettings: vi.fn(),
+      refreshLibraries: mockRefresh,
+      setLibraryMappings: vi.fn(),
+    });
+
+    render(
+      <MemoryRouter>
+        <SettingsPage />
+      </MemoryRouter>
+    );
+
+    const refreshButton = screen.getByRole('button', { name: /Refresh libraries/i });
+    expect(refreshButton).toBeDisabled();
+
+    fireEvent.click(refreshButton);
+
+    expect(mockRefresh).not.toHaveBeenCalled();
+    expect(
+      await screen.findByText(
+        'Enter your Plex URL and token, then save and refresh to load Plex libraries.'
+      )
+    ).toBeInTheDocument();
   });
 
   it('shows loading status when settings are loading', async () => {

--- a/frontend/src/theme/ThemeProvider.jsx
+++ b/frontend/src/theme/ThemeProvider.jsx
@@ -244,35 +244,51 @@ export function ThemeProvider({ children }) {
     }
   }, []);
 
-  const refreshLibraries = useCallback(async () => {
-    if (isMountedRef.current) {
-      setLibrariesLoading(true);
-      setLibrariesError(null);
-    }
-    try {
-      const response = await fetch('/api/settings/libraries');
-      const data = await safeJson(response);
-      if (!response.ok) {
-        throw new Error(responseErrorMessage(response, data));
+  const hasPlexCredentials = useMemo(
+    () => Boolean(settings.plexUrl && settings.plexToken),
+    [settings.plexUrl, settings.plexToken]
+  );
+
+  const refreshLibraries = useCallback(
+    async (options = {}) => {
+      const force = Boolean(options?.force);
+      if (!hasPlexCredentials && !force) {
+        if (isMountedRef.current) {
+          setLibraries([]);
+          setLibrariesError(null);
+        }
+        return [];
       }
-      const next = sanitizeLibrariesList(data);
       if (isMountedRef.current) {
-        setLibraries(next);
+        setLibrariesLoading(true);
+        setLibrariesError(null);
       }
-      return next;
-    } catch (err) {
-      const message = err?.message || 'Failed to load libraries';
-      if (isMountedRef.current) {
-        setLibraries([]);
-        setLibrariesError(message);
+      try {
+        const response = await fetch('/api/settings/libraries');
+        const data = await safeJson(response);
+        if (!response.ok) {
+          throw new Error(responseErrorMessage(response, data));
+        }
+        const next = sanitizeLibrariesList(data);
+        if (isMountedRef.current) {
+          setLibraries(next);
+        }
+        return next;
+      } catch (err) {
+        const message = err?.message || 'Failed to load libraries';
+        if (isMountedRef.current) {
+          setLibraries([]);
+          setLibrariesError(message);
+        }
+        throw new Error(message);
+      } finally {
+        if (isMountedRef.current) {
+          setLibrariesLoading(false);
+        }
       }
-      throw new Error(message);
-    } finally {
-      if (isMountedRef.current) {
-        setLibrariesLoading(false);
-      }
-    }
-  }, []);
+    },
+    [hasPlexCredentials]
+  );
 
   const saveSettings = useCallback(
     async (overrides = null) => {
@@ -296,7 +312,8 @@ export function ThemeProvider({ children }) {
           setSavedSettings(next);
           setSettings(next);
         }
-        await refreshLibraries().catch(() => {});
+        const nextHasCredentials = Boolean(next.plexUrl && next.plexToken);
+        await refreshLibraries({ force: nextHasCredentials }).catch(() => {});
         return next;
       } catch (err) {
         const message = err?.message || 'Failed to save settings';


### PR DESCRIPTION
## Summary
- hide Plex libraries in settings when credentials are absent and surface a clearer empty state message
- prevent client-side refreshes without credentials and adjust the library fetch logic to avoid stale data
- extend settings page tests to cover the credential requirements for refreshing libraries

## Testing
- npm test -- --runInBand *(fails: vitest binary not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e6f009fdc48330b30afa205965678f