### PR TITLE
Improve Plex credential error feedback

### DIFF
--- a/app/services/plex.py
+++ b/app/services/plex.py
@@ -1,3 +1,5 @@
+import logging
+
 from plexapi.server import PlexServer
 from fastapi import HTTPException
 
@@ -7,12 +9,18 @@ from . import plex_settings
 _plex = None
 _last_creds = (None, None)
 
+logger = logging.getLogger(__name__)
+
 
 def get_plex():
     global _plex, _last_creds
     errors = config.get_config_errors()
     if errors:
-        raise HTTPException(status_code=500, detail="; ".join(errors))
+        logger.error("Plex credentials missing: %s", "; ".join(errors))
+        raise HTTPException(
+            status_code=400,
+            detail="Please go to the settings and enter Plex credentials.",
+        )
 
     cfg = plex_settings.get_plex_config()
     creds = (cfg.url, cfg.token)
@@ -21,7 +29,13 @@ def get_plex():
             _plex = PlexServer(cfg.url, cfg.token)
             _last_creds = creds
         except Exception as e:
-            raise HTTPException(status_code=500, detail=f"Plex connect failed: {e}")
+            logger.exception("Failed to connect to Plex")
+            message = str(e)
+            detail = "Plex connect failed: {0}".format(message)
+            lowered = message.lower()
+            if "unauthorized" in lowered or "401" in lowered:
+                detail = "Plex credentials incorrect."
+            raise HTTPException(status_code=400, detail=detail)
     return _plex
 
 

--- a/frontend/src/hooks/useLibraryItems.js
+++ b/frontend/src/hooks/useLibraryItems.js
@@ -1,14 +1,17 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
+import { responseErrorMessage, safeJson } from '../utils/api.js';
+
 const PAGE_SIZE = 60;
 
 async function fetchJson(url, options) {
   const response = await fetch(url, options);
+  const data = await safeJson(response);
   if (!response.ok) {
-    const message = `${response.status} ${response.statusText}`;
+    const message = responseErrorMessage(response, data);
     throw new Error(message);
   }
-  return response.json();
+  return data;
 }
 
 export function useLibraryItems({ initialLibrary } = {}) {
@@ -95,11 +98,11 @@ export function useLibraryItems({ initialLibrary } = {}) {
 
       try {
         const response = await fetch(`${base}?${params.toString()}`, { signal: controller.signal });
+        const data = await safeJson(response);
         if (!response.ok) {
-          const message = `${response.status} ${response.statusText}`;
+          const message = responseErrorMessage(response, data);
           throw new Error(message);
         }
-        const data = await response.json();
         setItems(Array.isArray(data?.items) ? data.items : []);
         setTotalPages(data?.total_pages || 1);
         setTotalCount(data?.total_count || (Array.isArray(data?.items) ? data.items.length : 0));
@@ -165,11 +168,11 @@ export function useLibraryItems({ initialLibrary } = {}) {
       params.set('page_size', '1');
       try {
         const response = await fetch(`${base}?${params.toString()}`);
+        const data = await safeJson(response);
         if (!response.ok) {
-          const message = `${response.status} ${response.statusText}`;
+          const message = responseErrorMessage(response, data);
           throw new Error(message);
         }
-        const data = await response.json();
         const nextNotReady =
           typeof data?.not_ready_count === 'number'
             ? data.not_ready_count
@@ -210,11 +213,11 @@ export function useLibraryItems({ initialLibrary } = {}) {
       };
 
       const firstResponse = await fetch(makeUrl(1));
+      const firstData = await safeJson(firstResponse);
       if (!firstResponse.ok) {
-        const message = `${firstResponse.status} ${firstResponse.statusText}`;
+        const message = responseErrorMessage(firstResponse, firstData);
         throw new Error(message);
       }
-      const firstData = await firstResponse.json();
       const allItems = Array.isArray(firstData?.items) ? [...firstData.items] : [];
       const totalPagesResp = firstData?.total_pages || 1;
       const totalCountResp = firstData?.total_count || allItems.length;
@@ -222,11 +225,11 @@ export function useLibraryItems({ initialLibrary } = {}) {
 
       for (let p = 2; p <= totalPagesResp; p += 1) {
         const response = await fetch(makeUrl(p));
+        const data = await safeJson(response);
         if (!response.ok) {
-          const message = `${response.status} ${response.statusText}`;
+          const message = responseErrorMessage(response, data);
           throw new Error(message);
         }
-        const data = await response.json();
         if (Array.isArray(data?.items)) {
           allItems.push(...data.items);
         }


### PR DESCRIPTION
## Summary
- surface friendly API errors when Plex credentials are missing or invalid
- ensure the UI propagates backend error details instead of generic HTTP codes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e6f28f98548330890f607b12dc9cc5