### PR TITLE
Stop reading Plex credentials and library mappings from env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,16 +1,10 @@
 # Example environment file for KAM
 # Copy to .env and edit values before running
 
-# Plex connection
-PLEX_URL=http://192.168.1.XXX:32400
-PLEX_TOKEN=CHANGE_ME
-
-# Map Plex libraries to asset folders inside container
-# e.g. Movies:/assets/Movies,Kids Movies:/assets/Kids Movies
-LIBRARIES=Movies:/assets/Movies,Kids Movies:/assets/Kids Movies
-
 # Runtime
 PORT=8000
 
 # Root path for collection posters
 COLLECTIONS_ROOT=/assets/Collections
+
+# Plex credentials and library mappings are now configured through the web UI.

--- a/README.md
+++ b/README.md
@@ -142,26 +142,20 @@ Bring it up:
 ```bash
 docker compose up -d
 ```
-Edit the .env file to configure
+Edit the .env file to configure runtime basics.
 
 Sample .env
 ```yaml
 # Example environment file for KAM
 # Copy to .env and edit values before running
 
-# Plex connection
-PLEX_URL=http://192.168.1.XXX:32400
-PLEX_TOKEN=CHANGE_ME
-
-# Map Plex libraries to asset folders inside container
-# e.g. Movies:/assets/Movies,Kids Movies:/assets/Kids Movies
-LIBRARIES=Movies:/assets/Movies,Kids Movies:/assets/Kids Movies
-
 # Runtime
 PORT=8000
 
 # Root path for collection posters
 COLLECTIONS_ROOT=/assets/Collections
+
+# Plex credentials and library mappings are now configured through the web UI.
 ```
 
 ---

--- a/app/config.py
+++ b/app/config.py
@@ -1,17 +1,9 @@
 import os
 from typing import List
 
-from .services import library_mappings, plex_settings
+from .services import plex_settings
 
 PORT = int(os.environ.get("PORT", "8080"))
-
-LIBRARY_MAPPINGS = {}
-COLLECTIONS_ROOT = os.environ.get("COLLECTIONS_ROOT", "/assets/Collections")
-for entry in library_mappings.seed_from_env():
-    name = str(entry.get("library") or "").strip()
-    path = str(entry.get("assetPath") or "").strip()
-    if name and path:
-        LIBRARY_MAPPINGS[name] = path
 
 def get_config_errors() -> List[str]:
     errors: List[str] = []

--- a/app/routers/libraries.py
+++ b/app/routers/libraries.py
@@ -1,10 +1,5 @@
 # app/routers/libraries.py
-"""
-Libraries router: only expose libraries explicitly mapped in the environment.
-
-Env format (in your .env):
-  LIBRARIES=Movies:/assets/Movies,Kids Movies:/assets/Kids Movies,TV Shows:/assets/TV Shows
-"""
+"""Libraries router: exposes libraries configured via the settings service."""
 
 from __future__ import annotations
 
@@ -48,8 +43,8 @@ def _ensure_any_mapped() -> Dict[str, str]:
         raise HTTPException(
             status_code=500,
             detail=(
-                "No mapped libraries were found. Set LIBRARIES=Name:/path,... "
-                "in your environment (or ensure config.LIBRARY_MAPPINGS is populated)."
+                "No mapped libraries were found. Configure library mappings "
+                "on the Settings page."
             ),
         )
     return mapping

--- a/app/services/library_mappings.py
+++ b/app/services/library_mappings.py
@@ -10,7 +10,6 @@ __all__ = [
     "normalize_path",
     "normalize_collection_sections",
     "sanitize_library_mappings",
-    "seed_from_env",
     "set_cached_mappings",
     "get_cached_mappings",
     "clear_cache",
@@ -123,28 +122,6 @@ def sanitize_library_mappings(raw: Any) -> List[Dict[str, Any]]:
     return [copy.deepcopy(value) for value in ordered.values()]
 
 
-def seed_from_env() -> List[Dict[str, Any]]:
-    """Return library mappings derived from the LIBRARIES/COLLECTIONS_ROOT envs."""
-    env_raw = os.environ.get("LIBRARIES", "")
-    collection_root = normalize_path(os.environ.get("COLLECTIONS_ROOT"))
-
-    candidates = []
-    for part in env_raw.split(","):
-        part = part.strip()
-        if not part or ":" not in part:
-            continue
-        name, path = part.split(":", 1)
-        candidates.append(
-            {
-                "library": name,
-                "assetPath": path,
-                "collectionsPath": collection_root or None,
-            }
-        )
-
-    return sanitize_library_mappings(candidates)
-
-
 def set_cached_mappings(mappings: List[Dict[str, Any]] | None) -> None:
     """Persist a copy of the mappings in memory for fast reuse."""
     global _CACHE
@@ -164,7 +141,7 @@ def clear_cache() -> None:
 
 
 def _load_from_settings() -> List[Dict[str, Any]]:
-    """Return sanitized mappings from persisted settings with env fallback."""
+    """Return sanitized mappings from persisted settings."""
     try:
         from . import settings as settings_service  # Local import to avoid cycle
 
@@ -174,9 +151,7 @@ def _load_from_settings() -> List[Dict[str, Any]]:
         raw = None
 
     mappings = sanitize_library_mappings(raw)
-    if mappings:
-        return mappings
-    return seed_from_env()
+    return mappings
 
 
 def load_library_mappings() -> List[Dict[str, Any]]:
@@ -220,7 +195,7 @@ def get_asset_path(library: str) -> Optional[str]:
 
 
 def _default_collections_root() -> Optional[str]:
-    return normalize_path(os.environ.get("COLLECTIONS_ROOT"))
+    return None
 
 
 def get_collections_path(library: Optional[str] = None) -> Optional[str]:

--- a/app/services/settings.py
+++ b/app/services/settings.py
@@ -15,9 +15,9 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_SETTINGS: Dict[str, Any] = {
     "theme": "dark",
-    "plexUrl": os.environ.get("PLEX_URL") or "",
-    "plexToken": os.environ.get("PLEX_TOKEN") or "",
-    "libraryMappings": library_mappings.seed_from_env(),
+    "plexUrl": "",
+    "plexToken": "",
+    "libraryMappings": [],
 }
 
 _DEF_BASE = (

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -40,22 +40,22 @@ def reload_config(monkeypatch, tmp_path):
             importlib.reload(module)
 
 
-def test_config_errors_ignore_missing_library_mappings(reload_config, monkeypatch):
-    monkeypatch.delenv("LIBRARIES", raising=False)
-    monkeypatch.delenv("COLLECTIONS_ROOT", raising=False)
-    monkeypatch.setenv("PLEX_URL", "http://plex.example:32400")
-    monkeypatch.setenv("PLEX_TOKEN", "example-token")
-
+def test_config_errors_use_persisted_settings(reload_config):
     config_module = reload_config()
+    settings_service = sys.modules["app.services.settings"]
+    plex_settings = sys.modules["app.services.plex_settings"]
+
+    settings_service.save_settings(
+        {"plexUrl": "http://plex.example:32400", "plexToken": "example-token"}
+    )
+    plex_settings.clear_cache()
+
     errors = config_module.get_config_errors()
 
-    assert "Missing LIBRARIES" not in errors
+    assert errors == []
 
 
-def test_config_errors_require_plex_credentials(reload_config, monkeypatch):
-    monkeypatch.delenv("PLEX_URL", raising=False)
-    monkeypatch.delenv("PLEX_TOKEN", raising=False)
-
+def test_config_errors_require_plex_credentials(reload_config):
     config_module = reload_config()
     errors = config_module.get_config_errors()
 

--- a/tests/test_plex_settings.py
+++ b/tests/test_plex_settings.py
@@ -2,24 +2,27 @@ import importlib
 import sys
 from pathlib import Path
 
+
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 
-def test_clearing_settings_removes_env_fallback(monkeypatch, tmp_path):
+def test_clearing_settings_resets_cached_values(monkeypatch, tmp_path):
     settings_path = tmp_path / "settings.json"
 
     with monkeypatch.context() as patch:
         patch.setenv("KAM_SETTINGS_PATH", str(settings_path))
-        patch.setenv("PLEX_URL", "http://plex.example:32400")
-        patch.setenv("PLEX_TOKEN", "initial-token")
 
         settings_service = importlib.reload(
             importlib.import_module("app.services.settings")
         )
         plex_settings = importlib.reload(
             importlib.import_module("app.services.plex_settings")
+        )
+
+        settings_service.save_settings(
+            {"plexUrl": "http://plex.example:32400", "plexToken": "initial-token"}
         )
 
         cfg = plex_settings.get_plex_config(force_refresh=True)

--- a/tests/test_settings_route.py
+++ b/tests/test_settings_route.py
@@ -16,13 +16,6 @@ if str(ROOT) not in sys.path:
 def settings_modules(tmp_path, monkeypatch):
     settings_path = tmp_path / "state" / "settings.json"
     monkeypatch.setenv("KAM_SETTINGS_PATH", str(settings_path))
-    monkeypatch.setenv("PLEX_URL", "http://plex.example:32400")
-    monkeypatch.setenv("PLEX_TOKEN", "initial-token")
-    monkeypatch.setenv(
-        "LIBRARIES",
-        "Movies:/assets/Movies,TV Shows:/assets/TV Shows",
-    )
-    monkeypatch.setenv("COLLECTIONS_ROOT", " /assets/Collections ")
 
     library_module = importlib.reload(
         importlib.import_module("app.services.library_mappings")
@@ -33,21 +26,10 @@ def settings_modules(tmp_path, monkeypatch):
     return settings_router, settings_service, settings_path, library_module
 
 
-def test_defaults_without_library_env(tmp_path, monkeypatch):
-    settings_path = tmp_path / "state" / "settings.json"
-    monkeypatch.setenv("KAM_SETTINGS_PATH", str(settings_path))
-    monkeypatch.delenv("LIBRARIES", raising=False)
-    monkeypatch.delenv("COLLECTIONS_ROOT", raising=False)
+def test_get_settings_returns_defaults_when_missing_file(settings_modules):
+    router, _, _, _ = settings_modules
 
-    library_module = importlib.reload(
-        importlib.import_module("app.services.library_mappings")
-    )
-    settings_service = importlib.reload(importlib.import_module("app.services.settings"))
-    settings_router = importlib.reload(importlib.import_module("app.routers.settings"))
-
-    assert library_module.seed_from_env() == []
-
-    resp = settings_router.get_settings()
+    resp = router.get_settings()
     assert resp.model_dump() == {
         "theme": "dark",
         "plexUrl": "",
@@ -56,8 +38,28 @@ def test_defaults_without_library_env(tmp_path, monkeypatch):
     }
 
 
-def test_get_settings_returns_defaults(settings_modules):
-    router, _, _, _ = settings_modules
+def test_get_settings_returns_stored_values(settings_modules):
+    router, service, _, _ = settings_modules
+
+    service.save_settings(
+        {
+            "theme": "dark",
+            "plexUrl": "http://plex.example:32400",
+            "plexToken": "initial-token",
+            "libraryMappings": [
+                {
+                    "library": "Movies",
+                    "assetPath": "/assets/Movies",
+                    "collectionsPath": "/assets/Collections",
+                },
+                {
+                    "library": "TV Shows",
+                    "assetPath": "/assets/TV Shows",
+                    "collectionsPath": "/assets/Collections",
+                },
+            ],
+        }
+    )
 
     resp = router.get_settings()
     assert resp.model_dump() == {


### PR DESCRIPTION
## Summary
- remove environment fallbacks for Plex connection details and library mappings in the backend services
- update API error messaging and documentation to reflect UI-driven configuration
- refresh automated tests to work with persisted settings only

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e6f4dd3584833095f4e8b3b4986b2b