### PR TITLE
Allow fileproxy to serve default assets root

### DIFF
--- a/app/routers/fileproxy.py
+++ b/app/routers/fileproxy.py
@@ -3,6 +3,7 @@ import os, mimetypes
 from fastapi import APIRouter, HTTPException, Query
 from fastapi.responses import FileResponse
 from ..services import library_mappings as library_mappings_service
+from ..services import resolve as resolve_service
 
 router = APIRouter()
 
@@ -18,7 +19,15 @@ def _allowed_roots():
     fallback_coll = library_mappings_service.get_collections_path()
     if fallback_coll:
         roots.add(fallback_coll)
-    return [os.path.realpath(p) for p in roots if p]
+    assets_root = resolve_service.ASSETS_ROOT
+    if assets_root:
+        roots.add(assets_root)
+    normalized = []
+    for root in roots:
+        if not root:
+            continue
+        normalized.append(os.path.realpath(os.path.abspath(root)))
+    return normalized
 
 def _is_allowed(path: str) -> bool:
     rp = os.path.realpath(path)

--- a/app/routers/items.py
+++ b/app/routers/items.py
@@ -12,8 +12,6 @@ from ..services.resolve import resolve_existing_dir_or_422
 
 router = APIRouter()
 
-ASSETS_ROOT = os.environ.get("KAM_ASSETS_ROOT", "/assets")
-
 # ---------- Plex helpers ----------
 
 def _require_plex() -> Tuple[str, str]:
@@ -89,43 +87,73 @@ def _to_int(x) -> Optional[int]:
 
 # ---------- Local folder & poster helpers ----------
 
-def _try_existing_asset_folder(library: str, title: Optional[str], year: Optional[int]) -> Optional[str]:
+def _try_existing_asset_folder(
+    library: str, title: Optional[str], year: Optional[int]
+) -> Tuple[Optional[str], Optional[str]]:
     """
     Use your resolver to find an actual, existing Kometa folder.
     Try 'Title (Year)' first, then 'Title'. Never create anything.
     """
     if not title:
-        return None
+        return None, None
     candidates: List[str] = []
     if year: candidates.append(f"{title} ({year})")
     candidates.append(title)
     for cand in candidates:
         try:
             full = resolve_existing_dir_or_422(library, cand)
-            return os.path.basename(full.rstrip(os.sep))
+            return os.path.basename(full.rstrip(os.sep)), full
         except Exception:
             continue
+    return None, None
+
+def _resolve_override_folder(library: str, folder: Optional[str]) -> Tuple[Optional[str], Optional[str]]:
+    if not folder:
+        return None, None
+    try:
+        full = resolve_existing_dir_or_422(library, folder)
+    except Exception:
+        return folder, None
+    name = os.path.basename(full.rstrip(os.sep))
+    return name, full
+
+def _local_poster_path(folder_path: Optional[str]) -> Optional[str]:
+    if not folder_path:
+        return None
+    poster_path = os.path.join(folder_path, "poster.jpg")
+    try:
+        if os.path.isfile(poster_path) and os.path.getsize(poster_path) > 0:
+            return poster_path
+    except Exception:
+        return None
     return None
 
-def _local_poster_exists(library: str, folder: str) -> bool:
-    p = os.path.join(ASSETS_ROOT, library, folder, "poster.jpg")
+def _fileproxy_poster_url(poster_path: str) -> str:
+    url = f"/fileproxy?path={quote(poster_path, safe='')}"
     try:
-        return os.path.isfile(p) and os.path.getsize(p) > 0
+        ts = int(os.path.getmtime(poster_path))
     except Exception:
-        return False
-
-def _fileproxy_poster_url(library: str, folder: str) -> str:
-    # Correct route: /fileproxy (no /api prefix)
-    lib_enc = quote(library, safe="")
-    fol_enc = quote(folder,  safe="")
-    return f"/fileproxy?path=/assets/{lib_enc}/{fol_enc}/poster.jpg&t=0"
+        ts = 0
+    if ts:
+        url = f"{url}&t={ts}" if "?" in url else f"{url}?t={ts}"
+    return url
 
 def _plex_poster_url(rating_key: Optional[str], thumb: Optional[str]) -> str:
     plex_url, plex_token = _require_plex()
     path = thumb or (f"/library/metadata/{rating_key}/thumb" if rating_key else None)
     if not path:
         return "/fallback.png"
-    return f"{plex_url}{path}?X-Plex-Token={plex_token}"
+
+    if path.startswith("http://") or path.startswith("https://"):
+        base = path
+    else:
+        base = f"{plex_url}{path}"
+
+    if "X-Plex-Token=" in base:
+        return base
+
+    separator = "&" if "?" in base else "?"
+    return f"{base}{separator}X-Plex-Token={plex_token}"
 
 # ---------- API ----------
 
@@ -167,23 +195,36 @@ def list_items(
     not_ready_count = 0
     for it in rows:
         override = folder_overrides.get_override(library, it["ratingKey"])
-        folder = override or _try_existing_asset_folder(library, it["title"], it["year"])
-        asset_ready = True if override else bool(folder)
+
+        folder_name, folder_path = _resolve_override_folder(library, override)
+        if not folder_path:
+            auto_name, auto_path = _try_existing_asset_folder(
+                library, it["title"], it["year"]
+            )
+            if auto_name:
+                folder_name = folder_name or auto_name
+            if auto_path:
+                folder_path = folder_path or auto_path
+
+        asset_ready = bool(folder_path)
         if not asset_ready:
             not_ready_count += 1
-        if folder and _local_poster_exists(library, folder):
-            poster = _fileproxy_poster_url(library, folder)   # <-- /fileproxy now
-        else:
-            poster = _plex_poster_url(it["ratingKey"], it["thumb"])
+
+        local_poster = _local_poster_path(folder_path)
+        poster_local = _fileproxy_poster_url(local_poster) if local_poster else None
+        poster_plex = _plex_poster_url(it["ratingKey"], it["thumb"])
+        poster = poster_local or poster_plex
         enriched.append({
             "ratingKey": it["ratingKey"],
             "title": it["title"],
             "year": it["year"],
             "type": it["type"],
-            "folder": folder,
-            "folderName": folder,
+            "folder": folder_name,
+            "folderName": folder_name,
             "assetReady": asset_ready,
             "posterUrl": poster,
+            "posterUrlLocal": poster_local,
+            "posterUrlPlex": poster_plex,
         })
 
     if not_ready_only:

--- a/tests/test_fileproxy_route.py
+++ b/tests/test_fileproxy_route.py
@@ -1,0 +1,36 @@
+import importlib
+
+from starlette.responses import FileResponse
+
+
+def test_fileproxy_allows_assets_root(tmp_path, monkeypatch):
+    assets_root = tmp_path / "assets"
+    poster_dir = assets_root / "Movies" / "My Film (2024)"
+    poster_dir.mkdir(parents=True)
+    poster_path = poster_dir / "poster.jpg"
+    poster_path.write_bytes(b"poster")
+
+    settings_module = importlib.reload(importlib.import_module("app.services.settings"))
+    settings_module.set_settings_path(str(tmp_path / "settings.json"))
+    settings_module.save_settings(
+        {
+            "theme": "dark",
+            "plexUrl": "http://plex.test",
+            "plexToken": "token",
+            "libraryMappings": [],
+        }
+    )
+
+    monkeypatch.setenv("KAM_ASSETS_ROOT", str(assets_root))
+
+    resolve_module = importlib.reload(importlib.import_module("app.services.resolve"))
+    resolve_module.ASSETS_ROOT = str(assets_root)
+
+    library_mappings = importlib.reload(importlib.import_module("app.services.library_mappings"))
+    library_mappings.clear_cache()
+
+    fileproxy_router = importlib.reload(importlib.import_module("app.routers.fileproxy"))
+
+    response = fileproxy_router.fileproxy(path=str(poster_path))
+
+    assert isinstance(response, FileResponse)

--- a/tests/test_items_route.py
+++ b/tests/test_items_route.py
@@ -63,7 +63,7 @@ def items_env(tmp_path, monkeypatch):
                     "year": 2020,
                     "ratingKey": "22",
                     "type": "movie",
-                    "thumb": "/thumb2",
+                    "thumb": "/thumb2?width=500&height=750",
                 },
             ]
         return []
@@ -98,6 +98,8 @@ def test_items_route_prefers_override(items_env):
     assert overridden["folderName"] == items_env.folder.name
     assert overridden["assetReady"] is True
     assert overridden["posterUrl"].startswith("/fileproxy")
+    assert overridden["posterUrlLocal"].startswith("/fileproxy")
+    assert overridden["posterUrlPlex"].startswith("http://plex.test")
 
 
 def test_items_route_reports_not_ready_count_and_filters(items_env):
@@ -108,6 +110,9 @@ def test_items_route_reports_not_ready_count_and_filters(items_env):
     by_key = {it["ratingKey"]: it for it in data["items"]}
     assert by_key["22"]["assetReady"] is False
     assert by_key["22"]["posterUrl"].startswith("http://plex.test")
+    assert by_key["22"]["posterUrlPlex"].startswith("http://plex.test")
+    assert "?" in by_key["22"]["posterUrlPlex"]
+    assert "X-Plex-Token=token" in by_key["22"]["posterUrlPlex"].split("?")[-1]
 
     filtered = items_env.call(not_ready_only=True)
 


### PR DESCRIPTION
## Summary
- allow the fileproxy route to treat the configured assets root as an allowed source in addition to stored library mappings
- normalize the allowed roots to absolute real paths to cover relative configuration values
- add a regression test ensuring posters stored under the default assets root can be served without explicit mappings

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e6fad15adc8330b3f791edc693dbec