### PR TITLE
Serve React movie detail route

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -57,7 +57,9 @@ MOVIE_PAGE = WEB_DIR / "movie.html"
 
 @app.get("/libraries/{library}/movies/{ratingKey}", include_in_schema=False)
 async def movie_details_page(library: str, ratingKey: str):
-    """Serve the dedicated movie HTML shell."""
+    """Serve the SPA shell for movie details when available."""
+    if SPA_INDEX.exists():
+        return FileResponse(SPA_INDEX)
     return FileResponse(MOVIE_PAGE)
 
 

--- a/app/routers/movie.py
+++ b/app/routers/movie.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, HTTPException, Query
 import os
 from typing import Optional, Tuple
+from urllib.parse import quote
 
 from ..services import folder_overrides
 from ..services import plex_settings
@@ -19,11 +20,25 @@ def _section_by_name(name: str):
     raise HTTPException(404, f"Library '{name}' not found in Plex")
 
 def _first_existing(base_no_ext: str):
-    for ext in (".jpg",".jpeg",".png",".webp"):
+    for ext in (".jpg", ".jpeg", ".png", ".webp"):
         p = base_no_ext + ext
         if os.path.isfile(p):
             return p
     return None
+
+
+def _fileproxy_url(path: Optional[str]) -> Optional[str]:
+    if not path:
+        return None
+
+    url = f"/fileproxy?path={quote(path, safe='')}"
+    try:
+        ts = int(os.path.getmtime(path))
+    except Exception:
+        ts = 0
+    if ts:
+        url = f"{url}&t={ts}"
+    return url
 
 
 def _resolve_existing_folder_basename(library: str, title: Optional[str], year: Optional[int]) -> Optional[str]:
@@ -89,20 +104,12 @@ def movie(library: str = Query(...), ratingKey: int = Query(...)):
         p = _first_existing(os.path.join(movie_folder, "poster"))
         if p:
             poster_exists = True
-            try:
-                ts = int(os.path.getmtime(p))
-            except Exception:
-                ts = None
-            poster_url_local = "/fileproxy?path=" + p + (("&t=" + str(ts)) if ts else "")
+            poster_url_local = _fileproxy_url(p)
         # background
         b = _first_existing(os.path.join(movie_folder, "background"))
         if b:
             background_exists = True
-            try:
-                ts2 = int(os.path.getmtime(b))
-            except Exception:
-                ts2 = None
-            background_url_local = "/fileproxy?path=" + b + (("&t=" + str(ts2)) if ts2 else "")
+            background_url_local = _fileproxy_url(b)
 
     plex_url, plex_token = _plex_url_parts()
 

--- a/app/web/movie.html
+++ b/app/web/movie.html
@@ -59,8 +59,13 @@
 
 <script>
   (function () {
-    const t = localStorage.getItem('kam-theme') || 'light';
-    document.documentElement.setAttribute('data-theme', t);
+    try {
+      const stored = localStorage.getItem('kam-theme');
+      const theme = stored === 'light' ? 'light' : 'dark';
+      document.documentElement.setAttribute('data-theme', theme);
+    } catch (error) {
+      document.documentElement.setAttribute('data-theme', 'dark');
+    }
   })();
 
   const $ = (sel) => document.querySelector(sel);

--- a/frontend/src/components/ItemGrid.jsx
+++ b/frontend/src/components/ItemGrid.jsx
@@ -83,13 +83,7 @@ function ItemCard({ item, library, onRequestFolder }) {
 
   if (detailPath) {
     return (
-      <Link
-        className="card"
-        data-ready={ready ? 'true' : 'false'}
-        title={cardTitle}
-        to={detailPath}
-        reloadDocument
-      >
+      <Link className="card" data-ready={ready ? 'true' : 'false'} title={cardTitle} to={detailPath}>
         {content}
       </Link>
     );


### PR DESCRIPTION
## Summary
- Serve the SPA shell on movie detail routes when the React bundle exists, falling back to the legacy page otherwise
- Encode fileproxy URLs for local posters/backgrounds so uploaded artwork is immediately reflected
- Default the legacy movie page theme to dark and rely on client-side navigation for detail links

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e7d6689eb88330ad1b040b6f626ae3