### PR TITLE
Fix poster preview sizing on detail page

### DIFF
--- a/frontend/src/components/ArtworkCard.jsx
+++ b/frontend/src/components/ArtworkCard.jsx
@@ -10,6 +10,7 @@ const IDLE_OPERATION = Object.freeze({
 
 function ArtworkCard({
   label,
+  variant: variantProp = null,
   exists = false,
   imageUrl = null,
   folderExists = false,
@@ -79,6 +80,11 @@ function ArtworkCard({
     statusText = uploading ? 'Uploading…' : 'Importing…';
   }
 
+  const normalizedLabel = typeof label === 'string' ? label.trim().toLowerCase() : '';
+  const variant = variantProp || (normalizedLabel === 'poster' ? 'poster' : 'default');
+  const imageWrapperClassName = ['asset-image-wrapper'];
+  if (variant === 'poster') imageWrapperClassName.push('asset-image-wrapper--poster');
+
   return (
     <div className="asset-card">
       <div className="asset-label">
@@ -87,13 +93,15 @@ function ArtworkCard({
           {exists ? 'exists' : 'missing'}
         </span>
       </div>
-      {imageUrl ? (
-        <img className="asset-image" src={imageUrl} alt={label} loading="lazy" />
-      ) : (
-        <div className="asset-placeholder" aria-hidden="true">
-          No preview available
-        </div>
-      )}
+      <div className={imageWrapperClassName.join(' ')}>
+        {imageUrl ? (
+          <img className="asset-image" src={imageUrl} alt={label} loading="lazy" />
+        ) : (
+          <div className="asset-placeholder" aria-hidden="true">
+            No preview available
+          </div>
+        )}
+      </div>
       <div className="asset-actions">
         {hasUpload ? (
           <input

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -708,16 +708,34 @@ main {
   color: var(--muted);
 }
 
+.asset-image-wrapper {
+  width: 100%;
+  border-radius: 12px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.04);
+  aspect-ratio: 16 / 9;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.asset-image-wrapper--poster {
+  background: #000;
+}
+
 .asset-image {
   width: 100%;
-  height: auto;
-  border-radius: 12px;
+  height: 100%;
   object-fit: cover;
-  background: #000;
+}
+
+.asset-image-wrapper--poster .asset-image {
+  object-fit: contain;
 }
 
 .asset-placeholder {
   width: 100%;
+  height: 100%;
   border-radius: 12px;
   background: rgba(255, 255, 255, 0.04);
   color: var(--muted);
@@ -725,7 +743,7 @@ main {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 40px 12px;
+  padding: 12px;
   text-align: center;
 }
 


### PR DESCRIPTION
## Summary
- wrap artwork previews in a fixed aspect ratio container so posters no longer dwarf backgrounds
- auto-detect poster cards to switch to a contain fit that keeps the full image visible

## Testing
- npm test -- --watch=false *(fails: vitest missing because npm install is blocked with 403 errors in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e83271c68883308441c582f55173e7