### PR TITLE
Clear stale library error message after fetching

### DIFF
--- a/frontend/src/hooks/useLibraryItems.js
+++ b/frontend/src/hooks/useLibraryItems.js
@@ -32,6 +32,7 @@ export function useLibraryItems({ initialLibrary } = {}) {
 
   const fetchLibraries = useCallback(async () => {
     try {
+      setError(null);
       const data = await fetchJson('/api/libraries');
       let libs = Array.isArray(data?.libraries) ? data.libraries : Array.isArray(data) ? data : [];
       libs = libs.map((name) => String(name));
@@ -46,6 +47,7 @@ export function useLibraryItems({ initialLibrary } = {}) {
       }
 
       setLibraries(libs);
+      setError(null);
       if (!libs.length) return;
 
       const desired = initialLibraryRef.current;


### PR DESCRIPTION
## Summary
- clear the library fetch error state before and after refreshing the libraries so stale missing Plex credential messages are removed once credentials exist

## Testing
- npm test -- --watch=false *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e83557b8b883309fe48ffccaf1c750