### PR TITLE
Fix show detail posters to match movie card sizing

### DIFF
--- a/frontend/src/components/ArtworkCard.jsx
+++ b/frontend/src/components/ArtworkCard.jsx
@@ -81,7 +81,7 @@ function ArtworkCard({
   }
 
   const normalizedLabel = typeof label === 'string' ? label.trim().toLowerCase() : '';
-  const variant = variantProp || (normalizedLabel === 'poster' ? 'poster' : 'default');
+  const variant = variantProp || (normalizedLabel.includes('poster') ? 'poster' : 'default');
   const imageWrapperClassName = ['asset-image-wrapper'];
   if (variant === 'poster') imageWrapperClassName.push('asset-image-wrapper--poster');
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -721,6 +721,7 @@ main {
 
 .asset-image-wrapper--poster {
   background: #000;
+  aspect-ratio: 2 / 3;
 }
 
 .asset-image {

--- a/frontend/src/pages/ShowDetailPage.jsx
+++ b/frontend/src/pages/ShowDetailPage.jsx
@@ -452,6 +452,7 @@ function ShowDetailPage() {
             <section className="asset-card-grid">
               <ArtworkCard
                 label="Series Poster"
+                variant="poster"
                 exists={showPosterExists}
                 imageUrl={showPosterImage}
                 folderExists={folderExists}
@@ -479,6 +480,7 @@ function ShowDetailPage() {
                       <ArtworkCard
                         key={season.index}
                         label={season.title}
+                        variant="poster"
                         exists={season.exists}
                         imageUrl={season.posterUrl}
                         folderExists={folderExists}


### PR DESCRIPTION
## Summary
- ensure the artwork card treats any poster-labeled assets as portrait variants
- render series and season posters on the show detail page using the poster variant
- adjust poster variant styling to use a portrait aspect ratio like the movie cards

## Testing
- Not run (npm install blocked by 403 from registry)


------
https://chatgpt.com/codex/tasks/task_e_68e83c8f62d0833099c66e7d90683e98