### PR TITLE
Fix show detail card layout

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -686,6 +686,7 @@ main {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: 16px;
+  align-items: start;
 }
 
 .asset-card {
@@ -696,6 +697,7 @@ main {
   display: flex;
   flex-direction: column;
   gap: 12px;
+  height: 100%;
 }
 
 .asset-label {
@@ -717,6 +719,7 @@ main {
   display: flex;
   align-items: center;
   justify-content: center;
+  flex: 0 0 auto;
 }
 
 .asset-image-wrapper--poster {
@@ -752,6 +755,7 @@ main {
   display: flex;
   flex-direction: column;
   gap: 8px;
+  margin-top: auto;
 }
 
 @media (min-width: 640px) {
@@ -1141,9 +1145,7 @@ main {
 }
 
 .season-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 }
 
 .folder-open {

--- a/frontend/src/pages/ShowDetailPage.jsx
+++ b/frontend/src/pages/ShowDetailPage.jsx
@@ -473,7 +473,7 @@ function ShowDetailPage() {
             <section>
               <h2 className="detail-section-title">Seasons</h2>
               {seasons.length ? (
-                <div className="season-grid">
+                <div className="asset-card-grid season-grid">
                   {seasons.map((season) => {
                     const op = operations.seasons?.[String(season.index)] ?? createOperation();
                     return (


### PR DESCRIPTION
## Summary
- align the show detail season grid with the shared artwork card grid styles
- adjust artwork card styling so poster variants keep their portrait ratio and controls stay beneath the preview

## Testing
- npm install *(fails: 403 Forbidden fetching @testing-library/jest-dom)*

------
https://chatgpt.com/codex/tasks/task_e_68e845695b3c8330b2b54604439c9d0a