### PR TITLE
Adjust poster layout sizing on show detail page

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -689,6 +689,16 @@ main {
   align-items: start;
 }
 
+.asset-card-grid--show {
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  justify-items: center;
+}
+
+.asset-card-grid--show .asset-card {
+  width: 100%;
+  max-width: 220px;
+}
+
 .asset-card {
   background: var(--card);
   border: 1px solid var(--border);

--- a/frontend/src/pages/ShowDetailPage.jsx
+++ b/frontend/src/pages/ShowDetailPage.jsx
@@ -449,7 +449,7 @@ function ShowDetailPage() {
               Asset folder:
               <span className="detail-folder-name">{folderDisplay}</span>
             </div>
-            <section className="asset-card-grid">
+            <section className="asset-card-grid asset-card-grid--show">
               <ArtworkCard
                 label="Series Poster"
                 variant="poster"
@@ -473,7 +473,7 @@ function ShowDetailPage() {
             <section>
               <h2 className="detail-section-title">Seasons</h2>
               {seasons.length ? (
-                <div className="asset-card-grid season-grid">
+                <div className="asset-card-grid asset-card-grid--show season-grid">
                   {seasons.map((season) => {
                     const op = operations.seasons?.[String(season.index)] ?? createOperation();
                     return (


### PR DESCRIPTION
## Summary
- add a show-specific grid modifier class to the show detail page
- constrain the grid column sizing to keep posters more compact and centered

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e91b73bca8833099911521ff57ee19