### PR TITLE
Fix show detail poster sizing and action layout

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -690,13 +690,13 @@ main {
 }
 
 .asset-card-grid--show {
-  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
   justify-items: center;
 }
 
 .asset-card-grid--show .asset-card {
   width: 100%;
-  max-width: 220px;
+  max-width: 200px;
 }
 
 .asset-card {
@@ -764,15 +764,10 @@ main {
 .asset-actions {
   display: flex;
   flex-direction: column;
+  align-items: stretch;
   gap: 8px;
   margin-top: auto;
-}
-
-@media (min-width: 640px) {
-  .asset-actions {
-    flex-direction: row;
-    align-items: center;
-  }
+  width: 100%;
 }
 
 .settings-page {


### PR DESCRIPTION
## Summary
- reduce the maximum width of show artwork cards so the series poster matches season thumbnails
- keep artwork actions stacked vertically and stretch them to the card width so buttons no longer overlap the preview image

## Testing
- not run (npm install fails in the container: 403 from registry)


------
https://chatgpt.com/codex/tasks/task_e_68e91d6d96c88330883d0a61f9f16595