### PR TITLE
Fix season poster layout on show detail page

### DIFF
--- a/frontend/src/components/ArtworkCard.jsx
+++ b/frontend/src/components/ArtworkCard.jsx
@@ -85,6 +85,11 @@ function ArtworkCard({
   const imageWrapperClassName = ['asset-image-wrapper'];
   if (variant === 'poster') imageWrapperClassName.push('asset-image-wrapper--poster');
 
+  const imageWrapperStyle = {
+    '--asset-aspect-ratio': variant === 'poster' ? '2 / 3' : '16 / 9',
+    '--asset-aspect-fallback': variant === 'poster' ? '150%' : '56.25%',
+  };
+
   return (
     <div className="asset-card">
       <div className="asset-label">
@@ -93,7 +98,7 @@ function ArtworkCard({
           {exists ? 'exists' : 'missing'}
         </span>
       </div>
-      <div className={imageWrapperClassName.join(' ')}>
+      <div className={imageWrapperClassName.join(' ')} style={imageWrapperStyle}>
         {imageUrl ? (
           <img className="asset-image" src={imageUrl} alt={label} loading="lazy" />
         ) : (

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -727,34 +727,27 @@ main {
   overflow: hidden;
   background: rgba(255, 255, 255, 0.04);
   flex: 0 0 auto;
+  --asset-aspect-ratio: 16 / 9;
+  --asset-aspect-fallback: 56.25%;
+  aspect-ratio: var(--asset-aspect-ratio, 16 / 9);
 }
 
 .asset-image-wrapper::before {
   content: '';
   display: block;
   width: 100%;
-  padding-bottom: 56.25%;
+  padding-bottom: var(--asset-aspect-fallback, 56.25%);
 }
 
 .asset-image-wrapper--poster {
   background: #000;
-}
-
-.asset-image-wrapper--poster::before {
-  padding-bottom: 150%;
+  --asset-aspect-ratio: 2 / 3;
+  --asset-aspect-fallback: 150%;
 }
 
 @supports (aspect-ratio: 1) {
-  .asset-image-wrapper {
-    aspect-ratio: 16 / 9;
-  }
-
   .asset-image-wrapper::before {
     content: none;
-  }
-
-  .asset-image-wrapper--poster {
-    aspect-ratio: 2 / 3;
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure ArtworkCard passes aspect ratio hints via inline styles so poster wrappers keep their portrait proportions
- update asset image wrapper CSS to honour the supplied ratios while retaining a fallback for browsers without aspect-ratio support

## Testing
- Tests not run (npm install blocked by 403 from registry)

------
https://chatgpt.com/codex/tasks/task_e_68ead07773cc8330849c59119f68ab73