### PR TITLE
Stabilize show season grid layout

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -699,6 +699,14 @@ main {
   max-width: 200px;
 }
 
+.asset-card-grid--show.season-grid {
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.asset-card-grid--show.season-grid .asset-card {
+  max-width: 240px;
+}
+
 .asset-card {
   background: var(--card);
   border: 1px solid var(--border);
@@ -1164,10 +1172,6 @@ main {
 
 .status-text.error {
   color: #f87171;
-}
-
-.season-grid {
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 }
 
 .folder-open {


### PR DESCRIPTION
## Summary
- ensure the show-season grid uses a combined selector so CSS order cannot randomly change the column definition
- let season cards use the intended width while removing the duplicate `.season-grid` rule that caused inconsistent layouts

## Testing
- not run (frontend dependencies unavailable in execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68eb002678208330a97c6ff695c6787d