### PR TITLE
Fix show detail layout to match movie styling

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -689,22 +689,8 @@ main {
   align-items: start;
 }
 
-.asset-card-grid--show {
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-  justify-items: center;
-}
-
-.asset-card-grid--show .asset-card {
-  width: 100%;
-  max-width: 200px;
-}
-
-.asset-card-grid--show.season-grid {
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-}
-
-.asset-card-grid--show.season-grid .asset-card {
-  max-width: 240px;
+.asset-card-grid--seasons {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
 .asset-card {

--- a/frontend/src/pages/ShowDetailPage.jsx
+++ b/frontend/src/pages/ShowDetailPage.jsx
@@ -458,7 +458,7 @@ function ShowDetailPage() {
               Asset folder:
               <span className="detail-folder-name">{folderDisplay}</span>
             </div>
-            <section className="asset-card-grid asset-card-grid--show">
+            <section className="asset-card-grid">
               <ArtworkCard
                 label="Series Poster"
                 variant="poster"
@@ -482,7 +482,7 @@ function ShowDetailPage() {
             <section>
               <h2 className="detail-section-title">Seasons</h2>
               {seasons.length ? (
-                <div className="asset-card-grid asset-card-grid--show season-grid">
+                <div className="asset-card-grid asset-card-grid--seasons">
                   {seasons.map((season) => {
                     const op = operations.seasons?.[String(season.index)] ?? createOperation();
                     return (


### PR DESCRIPTION
## Summary
- align the show detail asset grid markup with the movie page so poster and background cards share the same layout
- remove the show-specific grid overrides and introduce a seasons grid modifier that keeps season cards consistent without shrinking posters

## Testing
- npm install *(fails: 403 Forbidden - GET https://registry.npmjs.org/@testing-library%2fjest-dom)*

------
https://chatgpt.com/codex/tasks/task_e_68eb0529792883308758f3f3a202d326