### PR TITLE
Fix season detail poster aspect ratio and button layout

### DIFF
--- a/frontend/src/components/ArtworkCard.jsx
+++ b/frontend/src/components/ArtworkCard.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 
 const IDLE_OPERATION = Object.freeze({
   uploading: false,
@@ -20,7 +20,6 @@ function ArtworkCard({
   uploadLabel = 'Upload',
   importLabel = 'Import',
 }) {
-  const [file, setFile] = useState(null);
   const inputRef = useRef(null);
 
   const uploading = Boolean(operation?.uploading);
@@ -34,24 +33,24 @@ function ArtworkCard({
   const hasUpload = typeof onUpload === 'function';
 
   useEffect(() => {
-    if (!busy && success && lastAction === 'upload') {
-      setFile(null);
-      if (inputRef.current) {
-        inputRef.current.value = '';
-      }
-    }
-  }, [busy, success, lastAction]);
-
-  useEffect(() => {
     if (!folderExists && inputRef.current) {
       inputRef.current.value = '';
-      setFile(null);
     }
   }, [folderExists]);
 
   const handleUploadClick = () => {
-    if (!hasUpload || !file) return;
-    const result = onUpload(file);
+    if (!hasUpload || busy || !folderExists) return;
+    if (inputRef.current) {
+      inputRef.current.value = '';
+      inputRef.current.click();
+    }
+  };
+
+  const handleFileChange = (event) => {
+    if (!hasUpload || busy || !folderExists) return;
+    const selected = event.target.files && event.target.files[0] ? event.target.files[0] : null;
+    if (!selected) return;
+    const result = onUpload(selected);
     if (result && typeof result.catch === 'function') {
       result.catch(() => {});
     }
@@ -65,7 +64,7 @@ function ArtworkCard({
     }
   };
 
-  const uploadDisabled = !folderExists || !file || busy;
+  const uploadDisabled = !folderExists || busy;
   const importDisabled = !folderExists || busy;
 
   let statusText = '\u00a0';
@@ -113,11 +112,10 @@ function ArtworkCard({
             ref={inputRef}
             type="file"
             accept="image/*"
+            className="asset-file-input"
+            tabIndex={-1}
             disabled={!folderExists || busy}
-            onChange={(event) => {
-              const selected = event.target.files && event.target.files[0] ? event.target.files[0] : null;
-              setFile(selected);
-            }}
+            onChange={handleFileChange}
           />
         ) : null}
         {hasUpload ? (

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -723,7 +723,6 @@ main {
   flex: 0 0 auto;
   --asset-aspect-ratio: 16 / 9;
   --asset-aspect-fallback: 56.25%;
-  aspect-ratio: var(--asset-aspect-ratio, 16 / 9);
 }
 
 .asset-image-wrapper::before {
@@ -739,9 +738,13 @@ main {
   --asset-aspect-fallback: 150%;
 }
 
-@supports (aspect-ratio: 1) {
+@supports (aspect-ratio: 1 / 1) {
+  .asset-image-wrapper {
+    aspect-ratio: var(--asset-aspect-ratio, 16 / 9);
+  }
+
   .asset-image-wrapper::before {
-    content: none;
+    display: none;
   }
 }
 
@@ -758,7 +761,7 @@ main {
 }
 
 .asset-image-wrapper--poster .asset-image {
-  object-fit: contain;
+  object-fit: cover;
 }
 
 .asset-placeholder {
@@ -778,6 +781,14 @@ main {
   align-items: stretch;
   gap: 8px;
   margin-top: auto;
+  width: 100%;
+}
+
+.asset-file-input {
+  display: none;
+}
+
+.asset-actions .btn {
   width: 100%;
 }
 


### PR DESCRIPTION
## Summary
- ensure poster cards keep a 2:3 aspect ratio with a reliable fallback and cover-fit images
- simplify artwork upload controls to display consistent Upload/Import buttons under each card

## Testing
- npm test -- --run *(fails: vitest missing because dependencies cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eb0742224c83309b59adfc24225dbf