### PR TITLE
Hide native file input on artwork cards

### DIFF
--- a/frontend/src/components/ArtworkCard.jsx
+++ b/frontend/src/components/ArtworkCard.jsx
@@ -115,6 +115,8 @@ function ArtworkCard({
             tabIndex={-1}
             disabled={!folderExists || busy}
             onChange={handleFileChange}
+            hidden
+            style={{ display: 'none' }}
           />
         ) : null}
         {hasUpload ? (


### PR DESCRIPTION
## Summary
- ensure the hidden season artwork file input stays visually hidden by applying the HTML hidden attribute and inline display rule

## Testing
- npm test -- --run *(fails: vitest binary missing because dependencies are not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eb0ce0b094833080feb7eabf5d48c1