### PR TITLE
Redesign show detail page background layout

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -621,6 +621,99 @@ main {
   gap: 16px;
 }
 
+.detail-hero {
+  display: flex;
+  flex-direction: column;
+  border-radius: 16px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  background: var(--card);
+}
+
+.detail-hero-image {
+  position: relative;
+  width: 100%;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.detail-hero-image::before {
+  content: '';
+  display: block;
+  width: 100%;
+  padding-bottom: 42%;
+}
+
+@supports (aspect-ratio: 1 / 1) {
+  .detail-hero-image {
+    aspect-ratio: 16 / 9;
+  }
+
+  .detail-hero-image::before {
+    display: none;
+  }
+}
+
+.detail-hero-image-src,
+.detail-hero-placeholder {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.detail-hero-image-src {
+  object-fit: cover;
+}
+
+.detail-hero-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--muted);
+  font-size: 15px;
+  padding: 16px;
+  text-align: center;
+}
+
+.detail-hero-body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  border-top: 1px solid var(--border);
+}
+
+.detail-hero-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--muted);
+}
+
+.detail-hero-title {
+  font-weight: 600;
+}
+
+.detail-hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.detail-hero-actions .btn {
+  flex: 0 0 auto;
+  min-width: 120px;
+}
+
+.detail-series-cards {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
 .detail-warning {
   display: flex;
   align-items: flex-start;

--- a/frontend/src/pages/ShowDetailPage.jsx
+++ b/frontend/src/pages/ShowDetailPage.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useParams, useSearchParams } from 'react-router-dom';
 import ArtworkCard from '../components/ArtworkCard.jsx';
 import { responseErrorMessage, safeJson } from '../utils/api.js';
@@ -32,6 +32,8 @@ function ShowDetailPage() {
     background: createOperation(),
     seasons: {},
   });
+
+  const backgroundInputRef = useRef(null);
 
   useEffect(() => {
     setDetail(null);
@@ -150,6 +152,12 @@ function ShowDetailPage() {
   const folderName = detail?.folderName || '';
   const effectiveRatingKey = detail?.ratingKey != null ? String(detail.ratingKey) : ratingKey;
 
+  useEffect(() => {
+    if (!folderExists && backgroundInputRef.current) {
+      backgroundInputRef.current.value = '';
+    }
+  }, [folderExists]);
+
   const showPosterExists = useMemo(() => {
     if (typeof detail?.posterExists === 'boolean') return detail.posterExists;
     return Boolean(detail?.posterUrl);
@@ -162,6 +170,27 @@ function ShowDetailPage() {
 
   const showPosterImage = detail?.posterUrl || detail?.posterUrlPlex || detail?.plexPosterUrl || null;
   const showBackgroundImage = detail?.backgroundUrl || detail?.backgroundUrlPlex || detail?.plexBackgroundUrl || null;
+
+  const backgroundOperation = operations.background ?? createOperation();
+  const backgroundUploading = Boolean(backgroundOperation.uploading);
+  const backgroundImporting = Boolean(backgroundOperation.importing);
+  const backgroundBusy = backgroundUploading || backgroundImporting;
+  const backgroundStatus = (() => {
+    if (backgroundOperation.error) {
+      return { text: backgroundOperation.error, className: 'status-text error' };
+    }
+    if (backgroundOperation.success) {
+      const label = backgroundOperation.lastAction === 'upload' ? 'Upload complete.' : 'Import complete.';
+      return { text: label, className: 'status-text success' };
+    }
+    if (backgroundUploading) {
+      return { text: 'Uploading…', className: 'status-text' };
+    }
+    if (backgroundImporting) {
+      return { text: 'Importing…', className: 'status-text' };
+    }
+    return { text: '\u00a0', className: 'status-text' };
+  })();
 
   const seasons = useMemo(() => {
     if (!Array.isArray(detail?.seasons)) return [];
@@ -417,6 +446,32 @@ function ShowDetailPage() {
   const headerTitle = detail?.title || 'Show Details';
   const headerYear = detail?.year;
 
+  const handleBackgroundUploadClick = () => {
+    if (!folderExists || backgroundBusy) return;
+    if (backgroundInputRef.current) {
+      backgroundInputRef.current.value = '';
+      backgroundInputRef.current.click();
+    }
+  };
+
+  const handleBackgroundFileChange = (event) => {
+    if (!folderExists || backgroundBusy) return;
+    const file = event.target.files && event.target.files[0] ? event.target.files[0] : null;
+    if (!file) return;
+    const result = handleShowUpload('background', file);
+    if (result && typeof result.catch === 'function') {
+      result.catch(() => {});
+    }
+  };
+
+  const handleBackgroundImportClick = () => {
+    if (!folderExists || backgroundBusy) return;
+    const result = handleShowImport('background');
+    if (result && typeof result.catch === 'function') {
+      result.catch(() => {});
+    }
+  };
+
   return (
     <div className="detail-page">
       <header>
@@ -448,6 +503,54 @@ function ShowDetailPage() {
           </div>
         ) : detail ? (
           <div className="detail-container">
+            <section className="detail-hero">
+              <div className="detail-hero-image">
+                {showBackgroundImage ? (
+                  <img className="detail-hero-image-src" src={showBackgroundImage} alt="Series background" loading="lazy" />
+                ) : (
+                  <div className="detail-hero-placeholder" aria-hidden="true">
+                    No background available
+                  </div>
+                )}
+              </div>
+              <div className="detail-hero-body">
+                <div className="detail-hero-header">
+                  <span className="detail-hero-title">Background</span>
+                  <span className={`asset-flag ${showBackgroundExists ? 'exists' : 'missing'}`}>
+                    {showBackgroundExists ? 'exists' : 'missing'}
+                  </span>
+                </div>
+                <div className="detail-hero-actions">
+                  <input
+                    ref={backgroundInputRef}
+                    type="file"
+                    accept="image/*"
+                    className="asset-file-input"
+                    disabled={!folderExists || backgroundBusy}
+                    onChange={handleBackgroundFileChange}
+                  />
+                  <button
+                    type="button"
+                    className="btn"
+                    onClick={handleBackgroundUploadClick}
+                    disabled={!folderExists || backgroundBusy}
+                  >
+                    {backgroundUploading ? 'Uploading…' : 'Upload'}
+                  </button>
+                  <button
+                    type="button"
+                    className="btn"
+                    onClick={handleBackgroundImportClick}
+                    disabled={!folderExists || backgroundBusy}
+                  >
+                    {backgroundImporting ? 'Importing…' : 'Import'}
+                  </button>
+                </div>
+                <div className={backgroundStatus.className} aria-live="polite">
+                  {backgroundStatus.text}
+                </div>
+              </div>
+            </section>
             {!folderExists ? (
               <div className="detail-warning" role="alert">
                 <strong>✖</strong>
@@ -458,26 +561,19 @@ function ShowDetailPage() {
               Asset folder:
               <span className="detail-folder-name">{folderDisplay}</span>
             </div>
-            <section className="asset-card-grid">
-              <ArtworkCard
-                label="Series Poster"
-                variant="poster"
-                exists={showPosterExists}
-                imageUrl={showPosterImage}
-                folderExists={folderExists}
-                operation={operations.poster}
-                onUpload={(file) => handleShowUpload('poster', file)}
-                onImport={() => handleShowImport('poster')}
-              />
-              <ArtworkCard
-                label="Background"
-                exists={showBackgroundExists}
-                imageUrl={showBackgroundImage}
-                folderExists={folderExists}
-                operation={operations.background}
-                onUpload={(file) => handleShowUpload('background', file)}
-                onImport={() => handleShowImport('background')}
-              />
+            <section className="detail-series-cards">
+              <div className="asset-card-grid">
+                <ArtworkCard
+                  label="Series Poster"
+                  variant="poster"
+                  exists={showPosterExists}
+                  imageUrl={showPosterImage}
+                  folderExists={folderExists}
+                  operation={operations.poster}
+                  onUpload={(file) => handleShowUpload('poster', file)}
+                  onImport={() => handleShowImport('poster')}
+                />
+              </div>
             </section>
             <section>
               <h2 className="detail-section-title">Seasons</h2>


### PR DESCRIPTION
## Summary
- redesign the show detail page to feature the series background in a hero section
- keep series and season poster artwork grouped beneath the hero with upload and import controls
- add supporting layout styles for the new hero presentation

## Testing
- npm test -- --runInBand *(fails: vitest not found because npm dependencies cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eb0e95b07c8330934e913b2d3f7997