### PR TITLE
Fix collections readiness fallback

### DIFF
--- a/app/routers/collections.py
+++ b/app/routers/collections.py
@@ -46,10 +46,31 @@ def _first_existing_background(dir_path: Path) -> Path | None:
     return None
 
 def _collections_root_for_library(library: str | None) -> Path | None:
+    """Return the best-known collections root for *library*.
+
+    The settings UI may omit explicit ``collectionsPath`` entries when they
+    match the general Kometa layout. In that case fall back to the legacy
+    ``COLLECTIONS_ROOT`` environment variable or the library's ``assetPath`` so
+    we can still detect ready folders.
+    """
+
     path = library_mappings_service.get_collections_path(library)
+
     if not path:
-        return None
-    return Path(path)
+        env_root = os.environ.get("COLLECTIONS_ROOT")
+        if env_root:
+            path = env_root
+
+    if not path and library:
+        # Library-specific fallback – older installs only configured assetPath.
+        fallback_asset = library_mappings_service.get_asset_path(library)
+        if fallback_asset:
+            path = fallback_asset
+
+    if path:
+        return Path(path)
+
+    return None
 
 
 def _local_poster_for_title(

--- a/tests/test_collections_route.py
+++ b/tests/test_collections_route.py
@@ -107,6 +107,68 @@ def collections_env(tmp_path, monkeypatch):
     )
 
 
+@pytest.fixture
+def collections_env_without_mapping(tmp_path, monkeypatch):
+    assets_root = tmp_path / "assets"
+    collections_root = assets_root / "Collections"
+    movies_root = assets_root / "Movies"
+    movies_root.mkdir(parents=True)
+    ready_folder = collections_root / "my cool collection"
+    ready_folder.mkdir(parents=True)
+    sanitized_only_folder = collections_root / "Mission Impossible Collection"
+    sanitized_only_folder.mkdir()
+
+    settings_module = importlib.reload(importlib.import_module("app.services.settings"))
+    settings_module.set_settings_path(str(tmp_path / "settings.json"))
+    settings_module.save_settings(
+        {
+            "theme": "dark",
+            "plexUrl": "http://plex.test",
+            "plexToken": "token",
+            "libraryMappings": [
+                {
+                    "library": "Movies",
+                    "assetPath": str(movies_root),
+                    "collectionsPath": None,
+                }
+            ],
+        }
+    )
+    plex_settings = importlib.reload(importlib.import_module("app.services.plex_settings"))
+    plex_settings.clear_cache()
+
+    monkeypatch.setenv("KAM_ASSETS_ROOT", str(assets_root))
+    monkeypatch.setenv("COLLECTIONS_ROOT", str(collections_root))
+    overrides_path = tmp_path / "overrides.json"
+    monkeypatch.setenv("KAM_FOLDER_OVERRIDES_PATH", str(overrides_path))
+
+    resolve_module = importlib.reload(importlib.import_module("app.services.resolve"))
+    resolve_module.ASSETS_ROOT = str(assets_root)
+
+    folder_overrides = importlib.reload(importlib.import_module("app.services.folder_overrides"))
+    folder_overrides.set_storage_path(str(overrides_path))
+
+    collections_router = importlib.reload(importlib.import_module("app.routers.collections"))
+
+    sections = [_DummySection(
+        "Movies",
+        [
+            _DummyCollection("My Cool Collection", 1),
+            _DummyCollection("Missing Assets", 2),
+            _DummyCollection("Mission: Impossible Collection", 3),
+        ],
+    )]
+
+    monkeypatch.setattr(collections_router, "get_plex", lambda: _DummyPlex(sections))
+
+    def _call(**kwargs):
+        params = {"query": None, "page": 1, "page_size": 60, "not_ready_only": False}
+        params.update(kwargs)
+        return collections_router.collections(**params)
+
+    return SimpleNamespace(call=_call)
+
+
 def test_collections_route_marks_asset_readiness(collections_env):
     data = collections_env.call()
     items = {it["title"]: it for it in data["items"]}
@@ -127,6 +189,22 @@ def test_collections_route_marks_asset_readiness(collections_env):
     assert sanitized["assetReady"] is True
     assert sanitized["folderName"] == "Mission Impossible Collection"
     assert sanitized["library"] == "Movies"
+
+
+def test_collections_route_falls_back_to_env_path(collections_env_without_mapping):
+    data = collections_env_without_mapping.call()
+    items = {it["title"]: it for it in data["items"]}
+
+    ready = items["My Cool Collection"]
+    assert ready["assetReady"] is True
+    assert ready["folderName"] == "my cool collection"
+
+    sanitized = items["Mission: Impossible Collection"]
+    assert sanitized["assetReady"] is True
+    assert sanitized["folderName"] == "Mission Impossible Collection"
+
+    missing = items["Missing Assets"]
+    assert missing["assetReady"] is False
 
 
 INDEX_HTML = ROOT / "app" / "web" / "index.html"


### PR DESCRIPTION
## Summary
- fall back to COLLECTIONS_ROOT or the library assetPath when no collectionsPath is configured
- add regression coverage for the collections API when only COLLECTIONS_ROOT is provided

## Testing
- pytest tests/test_collections_route.py

------
https://chatgpt.com/codex/tasks/task_e_68ec3574bedc83309957ffd0110f0685