### PR TITLE
Respect collection section overrides for auto mapping

### DIFF
--- a/app/services/library_mappings.py
+++ b/app/services/library_mappings.py
@@ -198,6 +198,30 @@ def _default_collections_root() -> Optional[str]:
     return None
 
 
+def _section_override_path(entry: Dict[str, Any], library: str) -> Optional[str]:
+    """Return a collectionsPath override within *entry* matching *library*."""
+
+    if not entry or not library:
+        return None
+
+    raw_sections = entry.get("collectionSections")
+    if not raw_sections:
+        return None
+
+    library_key = library.casefold()
+    for section in raw_sections:
+        name = str(section.get("name") or "").strip()
+        if not name:
+            continue
+        if name.casefold() != library_key:
+            continue
+        path = normalize_path(section.get("collectionsPath"))
+        if path:
+            return path
+
+    return None
+
+
 def get_collections_path(library: Optional[str] = None) -> Optional[str]:
     """Return the collections path for *library* or the global default."""
     if library:
@@ -206,9 +230,16 @@ def get_collections_path(library: Optional[str] = None) -> Optional[str]:
             path = normalize_path(entry.get("collectionsPath"))
             if path:
                 return path
+            override = _section_override_path(entry, library)
+            if override:
+                return override
 
     explicit = get_library_entry("Collections")
     if explicit:
+        if library:
+            override = _section_override_path(explicit, library)
+            if override:
+                return override
         explicit_coll = normalize_path(explicit.get("collectionsPath") or explicit.get("assetPath"))
         if explicit_coll:
             return explicit_coll
@@ -218,6 +249,10 @@ def get_collections_path(library: Optional[str] = None) -> Optional[str]:
         return fallback
 
     for entry in load_library_mappings():
+        if library:
+            override = _section_override_path(entry, library)
+            if override:
+                return override
         candidate = normalize_path(entry.get("collectionsPath"))
         if candidate:
             return candidate

--- a/tests/test_collections_route.py
+++ b/tests/test_collections_route.py
@@ -43,13 +43,14 @@ class _DummyPlex:
 def collections_env(tmp_path, monkeypatch):
     assets_root = tmp_path / "assets"
     collections_root = assets_root / "Collections"
+    movies_section_root = collections_root / "Movies"
     movies_root = assets_root / "Movies"
     movies_root.mkdir(parents=True)
-    ready_folder = collections_root / "my cool collection"
+    ready_folder = movies_section_root / "my cool collection"
     ready_folder.mkdir(parents=True)
-    override_folder = collections_root / "override folder"
+    override_folder = movies_section_root / "override folder"
     override_folder.mkdir()
-    sanitized_only_folder = collections_root / "Mission Impossible Collection"
+    sanitized_only_folder = movies_section_root / "Mission Impossible Collection"
     sanitized_only_folder.mkdir()
 
     settings_module = importlib.reload(importlib.import_module("app.services.settings"))
@@ -61,9 +62,19 @@ def collections_env(tmp_path, monkeypatch):
             "plexToken": "token",
             "libraryMappings": [
                 {
+                    "library": "Collections",
+                    "assetPath": str(collections_root),
+                    "collectionSections": [
+                        {
+                            "name": "Movies",
+                            "collectionsPath": str(movies_section_root),
+                        }
+                    ],
+                },
+                {
                     "library": "Movies",
                     "assetPath": str(movies_root),
-                    "collectionsPath": str(collections_root),
+                    "collectionsPath": None,
                 }
             ],
         }
@@ -103,7 +114,7 @@ def collections_env(tmp_path, monkeypatch):
         call=_call,
         folder_overrides=folder_overrides,
         override_folder=override_folder,
-        collections_root=collections_root,
+        collections_root=movies_section_root,
     )
 
 

--- a/tests/test_library_mappings.py
+++ b/tests/test_library_mappings.py
@@ -1,0 +1,39 @@
+import importlib
+
+def test_get_collections_path_uses_section_override(tmp_path):
+    settings_path = tmp_path / "settings.json"
+    assets_root = tmp_path / "assets"
+    collections_root = assets_root / "Collections"
+    movies_section_root = collections_root / "Movies"
+    movies_asset_root = assets_root / "Movies"
+
+    settings_module = importlib.reload(importlib.import_module("app.services.settings"))
+    settings_module.set_settings_path(str(settings_path))
+    settings_module.save_settings(
+        {
+            "libraryMappings": [
+                {
+                    "library": "Collections",
+                    "assetPath": str(collections_root),
+                    "collectionSections": [
+                        {
+                            "name": "Movies",
+                            "collectionsPath": str(movies_section_root),
+                        }
+                    ],
+                },
+                {
+                    "library": "Movies",
+                    "assetPath": str(movies_asset_root),
+                    "collectionsPath": None,
+                },
+            ]
+        }
+    )
+
+    library_mappings = importlib.reload(importlib.import_module("app.services.library_mappings"))
+    library_mappings.clear_cache()
+
+    expected = library_mappings.normalize_path(str(movies_section_root))
+    assert library_mappings.get_collections_path("Movies") == expected
+


### PR DESCRIPTION
## Summary
- allow collection section overrides to control the auto-detected collections root
- adjust collection route tests to exercise per-library collection section mappings
- add coverage for get_collections_path respecting collection section overrides

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ec38ff31c8833083cd9fd411c23a46