### PR TITLE
Fix collection folder detection for yearless directories

### DIFF
--- a/app/routers/collections.py
+++ b/app/routers/collections.py
@@ -9,6 +9,7 @@ from ..services.assets import sanitize_name
 from ..services.resolve import find_existing_dir_in_base
 
 import os
+import re
 from pathlib import Path
 from urllib.parse import quote
 
@@ -73,6 +74,16 @@ def _collections_root_for_library(library: str | None) -> Path | None:
     return None
 
 
+def _strip_year_suffix(name: str) -> str:
+    """Return *name* without a trailing ``(YYYY)`` suffix."""
+
+    if not name:
+        return ""
+
+    stripped = re.sub(r"\s*\(\d{4}\)\s*$", "", name).strip()
+    return stripped
+
+
 def _local_poster_for_title(
     title: str, base: Path | None
 ) -> Tuple[Path | None, str | None, str, bool]:
@@ -81,11 +92,24 @@ def _local_poster_for_title(
     if not title or not base:
         return None, None, "", False
 
-    resolved = find_existing_dir_in_base(str(base), title)
-    if not resolved:
-        sanitized = sanitize_name(title)
-        if sanitized and sanitized != title:
-            resolved = find_existing_dir_in_base(str(base), sanitized)
+    candidates: List[str] = []
+    for candidate in (
+        title,
+        sanitize_name(title),
+        _strip_year_suffix(title),
+        _strip_year_suffix(sanitize_name(title)),
+    ):
+        candidate = (candidate or "").strip()
+        if not candidate:
+            continue
+        if candidate not in candidates:
+            candidates.append(candidate)
+
+    resolved: str | None = None
+    for candidate in candidates:
+        resolved = find_existing_dir_in_base(str(base), candidate)
+        if resolved:
+            break
 
     if not resolved:
         return None, None, "", False

--- a/tests/test_collections_route.py
+++ b/tests/test_collections_route.py
@@ -52,6 +52,8 @@ def collections_env(tmp_path, monkeypatch):
     override_folder.mkdir()
     sanitized_only_folder = movies_section_root / "Mission Impossible Collection"
     sanitized_only_folder.mkdir()
+    yearless_folder = movies_section_root / "Franchise Collection"
+    yearless_folder.mkdir()
 
     settings_module = importlib.reload(importlib.import_module("app.services.settings"))
     settings_module.set_settings_path(str(tmp_path / "settings.json"))
@@ -100,6 +102,7 @@ def collections_env(tmp_path, monkeypatch):
             _DummyCollection("My Cool Collection", 1),
             _DummyCollection("Missing Assets", 2),
             _DummyCollection("Mission: Impossible Collection", 3),
+            _DummyCollection("Franchise Collection (2024)", 4),
         ],
     )]
 
@@ -128,6 +131,8 @@ def collections_env_without_mapping(tmp_path, monkeypatch):
     ready_folder.mkdir(parents=True)
     sanitized_only_folder = collections_root / "Mission Impossible Collection"
     sanitized_only_folder.mkdir()
+    yearless_folder = collections_root / "Franchise Collection"
+    yearless_folder.mkdir()
 
     settings_module = importlib.reload(importlib.import_module("app.services.settings"))
     settings_module.set_settings_path(str(tmp_path / "settings.json"))
@@ -167,6 +172,7 @@ def collections_env_without_mapping(tmp_path, monkeypatch):
             _DummyCollection("My Cool Collection", 1),
             _DummyCollection("Missing Assets", 2),
             _DummyCollection("Mission: Impossible Collection", 3),
+            _DummyCollection("Franchise Collection (2024)", 4),
         ],
     )]
 
@@ -198,6 +204,10 @@ def test_collections_route_marks_asset_readiness(collections_env):
 
     sanitized = items["Mission: Impossible Collection"]
     assert sanitized["assetReady"] is True
+
+    yearless = items["Franchise Collection (2024)"]
+    assert yearless["assetReady"] is True
+    assert yearless["folderName"] == "Franchise Collection"
     assert sanitized["folderName"] == "Mission Impossible Collection"
     assert sanitized["library"] == "Movies"
 
@@ -216,6 +226,10 @@ def test_collections_route_falls_back_to_env_path(collections_env_without_mappin
 
     missing = items["Missing Assets"]
     assert missing["assetReady"] is False
+
+    yearless = items["Franchise Collection (2024)"]
+    assert yearless["assetReady"] is True
+    assert yearless["folderName"] == "Franchise Collection"
 
 
 INDEX_HTML = ROOT / "app" / "web" / "index.html"


### PR DESCRIPTION
## Summary
- enhance the collections router to try matching folders without trailing year suffixes
- expand collections route tests with a yearless folder case to cover the new matching logic

## Testing
- pytest tests/test_collections_route.py

------
https://chatgpt.com/codex/tasks/task_e_68ec3e8050f8833096a6692313db5954