### PR TITLE
Trim whitespace when resolving library mapping lookups

### DIFF
--- a/app/services/library_mappings.py
+++ b/app/services/library_mappings.py
@@ -177,11 +177,14 @@ def get_library_map() -> Dict[str, Dict[str, Any]]:
     return lookup
 
 
-def get_library_entry(library: str) -> Optional[Dict[str, Any]]:
+def get_library_entry(library: str | None) -> Optional[Dict[str, Any]]:
     """Return the mapping entry for *library* (if any)."""
-    if not library:
+    if library is None:
         return None
-    mapping = get_library_map().get(str(library))
+    key = str(library).strip()
+    if not key:
+        return None
+    mapping = get_library_map().get(key)
     return dict(mapping) if mapping else None
 
 

--- a/tests/test_library_mappings.py
+++ b/tests/test_library_mappings.py
@@ -37,3 +37,32 @@ def test_get_collections_path_uses_section_override(tmp_path):
     expected = library_mappings.normalize_path(str(movies_section_root))
     assert library_mappings.get_collections_path("Movies") == expected
 
+
+def test_library_lookup_trims_whitespace(tmp_path):
+    settings_path = tmp_path / "settings.json"
+    movies_root = tmp_path / "assets" / "Movies"
+    collections_root = tmp_path / "collections" / "Movies"
+
+    settings_module = importlib.reload(importlib.import_module("app.services.settings"))
+    settings_module.set_settings_path(str(settings_path))
+    settings_module.save_settings(
+        {
+            "libraryMappings": [
+                {
+                    "library": "Movies",
+                    "assetPath": str(movies_root),
+                    "collectionsPath": str(collections_root),
+                }
+            ]
+        }
+    )
+
+    library_mappings = importlib.reload(importlib.import_module("app.services.library_mappings"))
+    library_mappings.clear_cache()
+
+    expected_asset = library_mappings.normalize_path(str(movies_root))
+    expected_collections = library_mappings.normalize_path(str(collections_root))
+
+    assert library_mappings.get_asset_path("  Movies  ") == expected_asset
+    assert library_mappings.get_collections_path("\tMovies\n") == expected_collections
+


### PR DESCRIPTION
## Summary
- trim whitespace from library identifiers before resolving cached mapping entries so fallback collection detection works
- cover whitespace handling with a regression test for asset and collection path lookups

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ec4acba9c48330b51205944bdd5a5a