### PR TITLE
Fix nested collection folder detection

### DIFF
--- a/app/routers/collections.py
+++ b/app/routers/collections.py
@@ -7,6 +7,7 @@ from ..services import plex_settings
 from ..services import library_mappings as library_mappings_service
 from ..services.assets import sanitize_name
 from ..services.resolve import find_existing_dir_in_base
+from ..services.sanitize import kometa_sanitize_folder
 
 import os
 import re
@@ -47,29 +48,49 @@ def _first_existing_background(dir_path: Path) -> Path | None:
     return None
 
 def _collections_root_for_library(library: str | None) -> Path | None:
-    """Return the best-known collections root for *library*.
+    """Return the best-known collections root for *library*."""
 
-    The settings UI may omit explicit ``collectionsPath`` entries when they
-    match the general Kometa layout. In that case fall back to the legacy
-    ``COLLECTIONS_ROOT`` environment variable or the library's ``assetPath`` so
-    we can still detect ready folders.
-    """
+    library = (library or "").strip() or None
 
-    path = library_mappings_service.get_collections_path(library)
+    direct = library_mappings_service.get_collections_path(library)
+    direct_path = Path(direct) if direct else None
 
-    if not path:
-        env_root = os.environ.get("COLLECTIONS_ROOT")
-        if env_root:
-            path = env_root
+    base_candidates: List[Path] = []
+    if direct_path:
+        base_candidates.append(direct_path)
 
-    if not path and library:
-        # Library-specific fallback – older installs only configured assetPath.
+    env_root = os.environ.get("COLLECTIONS_ROOT")
+    if env_root:
+        base_candidates.append(Path(env_root))
+
+    global_root = library_mappings_service.get_collections_path(None)
+    if global_root:
+        candidate = Path(global_root)
+        if candidate not in base_candidates:
+            base_candidates.append(candidate)
+
+    for base in base_candidates:
+        if library:
+            search_names = {
+                library,
+                sanitize_name(library),
+                kometa_sanitize_folder(library),
+            }
+            for name in filter(None, search_names):
+                candidate = base / name
+                if candidate.is_dir():
+                    return candidate
+
+        if base.is_dir():
+            return base
+
+    if direct_path:
+        return direct_path
+
+    if library:
         fallback_asset = library_mappings_service.get_asset_path(library)
         if fallback_asset:
-            path = fallback_asset
-
-    if path:
-        return Path(path)
+            return Path(fallback_asset)
 
     return None
 

--- a/tests/test_collections_route.py
+++ b/tests/test_collections_route.py
@@ -122,6 +122,81 @@ def collections_env(tmp_path, monkeypatch):
 
 
 @pytest.fixture
+def collections_env_with_nested_root(tmp_path, monkeypatch):
+    assets_root = tmp_path / "assets"
+    collections_root = assets_root / "Collections"
+    nested_root = collections_root / "Movies"
+    movies_root = assets_root / "Movies"
+    movies_root.mkdir(parents=True)
+    ready_folder = nested_root / "my cool collection"
+    ready_folder.mkdir(parents=True)
+    override_folder = nested_root / "override folder"
+    override_folder.mkdir()
+    sanitized_only_folder = nested_root / "Mission Impossible Collection"
+    sanitized_only_folder.mkdir()
+    yearless_folder = nested_root / "Franchise Collection"
+    yearless_folder.mkdir()
+
+    settings_module = importlib.reload(importlib.import_module("app.services.settings"))
+    settings_module.set_settings_path(str(tmp_path / "settings.json"))
+    settings_module.save_settings(
+        {
+            "theme": "dark",
+            "plexUrl": "http://plex.test",
+            "plexToken": "token",
+            "libraryMappings": [
+                {
+                    "library": "Collections",
+                    "assetPath": str(collections_root),
+                },
+                {
+                    "library": "Movies",
+                    "assetPath": str(movies_root),
+                },
+            ],
+        }
+    )
+    plex_settings = importlib.reload(importlib.import_module("app.services.plex_settings"))
+    plex_settings.clear_cache()
+
+    monkeypatch.setenv("KAM_ASSETS_ROOT", str(assets_root))
+    overrides_path = tmp_path / "overrides.json"
+    monkeypatch.setenv("KAM_FOLDER_OVERRIDES_PATH", str(overrides_path))
+
+    resolve_module = importlib.reload(importlib.import_module("app.services.resolve"))
+    resolve_module.ASSETS_ROOT = str(assets_root)
+
+    folder_overrides = importlib.reload(importlib.import_module("app.services.folder_overrides"))
+    folder_overrides.set_storage_path(str(overrides_path))
+
+    collections_router = importlib.reload(importlib.import_module("app.routers.collections"))
+
+    sections = [_DummySection(
+        "Movies",
+        [
+            _DummyCollection("My Cool Collection", 1),
+            _DummyCollection("Missing Assets", 2),
+            _DummyCollection("Mission: Impossible Collection", 3),
+            _DummyCollection("Franchise Collection (2024)", 4),
+        ],
+    )]
+
+    monkeypatch.setattr(collections_router, "get_plex", lambda: _DummyPlex(sections))
+
+    def _call(**kwargs):
+        params = {"query": None, "page": 1, "page_size": 60, "not_ready_only": False}
+        params.update(kwargs)
+        return collections_router.collections(**params)
+
+    return SimpleNamespace(
+        call=_call,
+        folder_overrides=folder_overrides,
+        override_folder=override_folder,
+        collections_root=nested_root,
+    )
+
+
+@pytest.fixture
 def collections_env_without_mapping(tmp_path, monkeypatch):
     assets_root = tmp_path / "assets"
     collections_root = assets_root / "Collections"
@@ -210,6 +285,26 @@ def test_collections_route_marks_asset_readiness(collections_env):
     assert yearless["folderName"] == "Franchise Collection"
     assert sanitized["folderName"] == "Mission Impossible Collection"
     assert sanitized["library"] == "Movies"
+
+
+def test_collections_route_handles_nested_collections_root(collections_env_with_nested_root):
+    data = collections_env_with_nested_root.call()
+    items = {it["title"]: it for it in data["items"]}
+
+    ready = items["My Cool Collection"]
+    assert ready["assetReady"] is True
+    assert ready["folderName"] == "my cool collection"
+
+    sanitized = items["Mission: Impossible Collection"]
+    assert sanitized["assetReady"] is True
+    assert sanitized["folderName"] == "Mission Impossible Collection"
+
+    missing = items["Missing Assets"]
+    assert missing["assetReady"] is False
+
+    yearless = items["Franchise Collection (2024)"]
+    assert yearless["assetReady"] is True
+    assert yearless["folderName"] == "Franchise Collection"
 
 
 def test_collections_route_falls_back_to_env_path(collections_env_without_mapping):


### PR DESCRIPTION
## Summary
- enhance the collections resolver to walk nested library directories under the configured Kometa collections root
- add regression coverage proving collections with library-scoped subdirectories are auto-detected as ready

## Testing
- pytest tests/test_collections_route.py

------
https://chatgpt.com/codex/tasks/task_e_68ec4d43b0348330b159aad176e29cb5