### PR TITLE
Prevent short titles from mapping to unrelated asset folders

### DIFF
--- a/app/services/resolve.py
+++ b/app/services/resolve.py
@@ -63,11 +63,14 @@ def _best_match(candidates, want: str) -> Optional[str]:
     # fallback: closest fuzzy match when the similarity is very high
     best_score = 0.0
     best_candidate = None
+    best_base_ratio = 0.0
+    best_lengths: tuple[int, int] = (0, 0)
     for original, normalized in normalized_candidates:
         if not normalized:
             continue
         matcher = SequenceMatcher(a=normalized, b=want_key)
-        score = matcher.ratio()
+        base_ratio = matcher.ratio()
+        score = base_ratio
 
         # Evaluate how much of the shorter string aligns contiguously with the
         # longer one to tolerate small insertions like "Extended Edition".
@@ -87,9 +90,28 @@ def _best_match(candidates, want: str) -> Optional[str]:
         if score > best_score:
             best_score = score
             best_candidate = original
+            best_base_ratio = base_ratio
+            best_lengths = (len_norm, len_want)
 
     # require a conservative minimum similarity to avoid unrelated matches
-    if best_score >= 0.86:
+    if best_candidate and best_score >= 0.86:
+        len_norm, len_want = best_lengths
+        shorter = min(len_norm, len_want)
+        longer = max(len_norm, len_want)
+
+        # Disallow fuzzy matches for extremely short titles or wildly
+        # different-length strings so "It" does not match
+        # "In association with Marvel".
+        if shorter < 4:
+            return None
+        if longer and shorter and (longer / shorter) > 2.5:
+            return None
+
+        # Also require the overall ratio to be reasonably close; this ensures
+        # we only accept near-identical titles.
+        if best_base_ratio < 0.7:
+            return None
+
         return best_candidate
     return None
 

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -111,3 +111,25 @@ def test_resolve_rejects_low_similarity_titles(tmp_path, monkeypatch):
 
     with pytest.raises(FileNotFoundError):
         resolve_module.resolve_existing_dir_or_422(library, target)
+
+
+def test_resolve_does_not_match_short_titles_to_longer_phrases(tmp_path, monkeypatch):
+    assets_root = tmp_path / "assets"
+    library = "Collections"
+    target = "It"
+    existing = "In association With Marvel"
+
+    library_path = assets_root / library
+    library_path.mkdir(parents=True)
+    (library_path / existing).mkdir()
+
+    monkeypatch.setenv("KAM_ASSETS_ROOT", str(assets_root))
+
+    settings_module = importlib.reload(importlib.import_module("app.services.settings"))
+    settings_module.set_settings_path(str(tmp_path / "settings.json"))
+    settings_module.save_library_mappings([])
+
+    resolve_module = _reload_with_assets_root(str(assets_root))
+
+    with pytest.raises(FileNotFoundError):
+        resolve_module.resolve_existing_dir_or_422(library, target)


### PR DESCRIPTION
## Summary
- tighten fuzzy folder matching heuristics to require similar length and ratio
- add a regression test preventing short titles like "It" from matching longer phrases

## Testing
- pytest tests/test_resolve.py

------
https://chatgpt.com/codex/tasks/task_e_68ec50afee9083308ba153fbf3db4159