### PR TITLE
Fix settings folder picker to store absolute asset paths

### DIFF
--- a/app/routers/assets.py
+++ b/app/routers/assets.py
@@ -194,6 +194,7 @@ def list_asset_folders(
                     "name": child.name,
                     "isDir": child.is_dir(),
                     "path": rel_path,
+                    "absolutePath": str(child),
                 })
         else:
             for child in sorted(current.iterdir(), key=lambda p: (not p.is_dir(), p.name.lower())):
@@ -202,6 +203,7 @@ def list_asset_folders(
                     "name": child.name,
                     "isDir": child.is_dir(),
                     "path": rel_path,
+                    "absolutePath": str(child),
                 })
     except PermissionError:
         raise HTTPException(status_code=403, detail="Permission denied")
@@ -210,7 +212,9 @@ def list_asset_folders(
 
     return {
         "library": library,
+        "root": str(root),
         "parent": parent_rel,
+        "parentAbsolute": str(current),
         "items": items,
     }
 

--- a/frontend/src/components/FolderFinderModal.jsx
+++ b/frontend/src/components/FolderFinderModal.jsx
@@ -1,14 +1,42 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
+const normalizeFsPath = (value) => {
+  if (value == null) return '';
+  const text = String(value).trim();
+  if (!text) return '';
+  return text.replace(/\\+/g, '/');
+};
+
+const isAbsoluteFsPath = (value) => {
+  const text = normalizeFsPath(value);
+  if (!text) return false;
+  return /^(?:[a-zA-Z]:\/|\/\/|\/)/.test(text);
+};
+
+const joinFsPath = (base, child) => {
+  const childPath = normalizeFsPath(child);
+  if (!childPath) return normalizeFsPath(base);
+  if (isAbsoluteFsPath(childPath)) return childPath;
+  const basePath = normalizeFsPath(base);
+  if (!basePath) return childPath;
+  const trimmedBase = basePath.replace(/\/+$/, '');
+  const trimmedChild = childPath.replace(/^\/+/, '');
+  return trimmedBase ? `${trimmedBase}/${trimmedChild}` : trimmedChild;
+};
+
 function normalizeFolderEntry(entry) {
   if (!entry) return null;
   const name = entry.name || entry.folderName || entry.label || entry.title;
   if (!name) return null;
   const path = entry.path ?? entry.folderPath ?? '';
+  const absoluteCandidate =
+    entry.absolutePath ?? entry.absolute_path ?? entry.fullPath ?? entry.absolute ?? '';
+  const absolutePath = normalizeFsPath(absoluteCandidate);
   const hasChildren = entry.hasChildren !== false && entry.isDir !== false;
   return {
     name: String(name),
     path: path === '' ? '' : String(path),
+    absolutePath,
     hasChildren,
   };
 }
@@ -64,6 +92,8 @@ function FolderFinderModal({
   const isSettingsMode = context === 'settings';
   const normalizedInitialAsset = normalizeText(initialAssetPath);
   const normalizedInitialCollections = normalizeText(initialCollectionsPath);
+  const normalizedInitialAssetAbsolute = normalizeFsPath(initialAssetPath);
+  const normalizedInitialCollectionsAbsolute = normalizeFsPath(initialCollectionsPath);
   const effectiveLibrary = useMemo(() => {
     if (isSettingsMode) {
       const provided = normalizeText(library);
@@ -88,12 +118,16 @@ function FolderFinderModal({
   const [isSearching, setIsSearching] = useState(false);
   const [assigning, setAssigning] = useState(false);
   const [currentFolder, setCurrentFolder] = useState('');
+  const [rootPath, setRootPath] = useState('');
+  const [currentAbsolute, setCurrentAbsolute] = useState('');
   const debounceRef = useRef();
   const isAtRootRef = useRef(false);
 
   useEffect(() => {
     if (!isOpen) {
       setCurrentFolder('');
+      setRootPath('');
+      setCurrentAbsolute('');
       return;
     }
     setSearchInput('');
@@ -192,9 +226,22 @@ function FolderFinderModal({
           : [];
         const normalized = list.map(normalizeFolderEntry).filter(Boolean);
         setResults(normalized);
+        let effectiveRoot = normalizeFsPath(data?.root);
+        setRootPath((prev) => {
+          if (effectiveRoot) {
+            return effectiveRoot;
+          }
+          effectiveRoot = prev || '';
+          return prev || '';
+        });
         const parentPath = typeof data?.parent === 'string' ? data.parent : path ?? '';
+        const parentAbsoluteRaw =
+          data?.parentAbsolute ??
+          (parentPath ? joinFsPath(effectiveRoot, parentPath) : effectiveRoot);
+        const normalizedParentAbsolute = normalizeFsPath(parentAbsoluteRaw);
         isAtRootRef.current = !parentPath;
         setCurrentPath(parentPath || '');
+        setCurrentAbsolute(normalizedParentAbsolute);
       } catch (err) {
         setResults([]);
         setError(err.message || 'Failed to load folders');
@@ -266,6 +313,15 @@ function FolderFinderModal({
 
   const displayCurrentFolder = currentFolder ? currentFolder : '';
 
+  const resolveEntryAbsolute = (entry) => {
+    if (!entry) return '';
+    const explicit = normalizeFsPath(entry.absolutePath);
+    if (explicit) return explicit;
+    const relative = normalizeFsPath(entry.path);
+    if (!relative) return '';
+    return joinFsPath(rootPath, relative);
+  };
+
   const handleSelect = (entry) => {
     if (isSettingsMode) {
       if (target === 'collections') {
@@ -295,10 +351,11 @@ function FolderFinderModal({
   };
 
   const resolvedAssetPath =
-    assetSelection?.path ||
-    normalizedInitialAsset ||
-    (isSettingsMode ? normalizeText(currentPath) : '');
-  const resolvedCollectionsPath = collectionsSelection?.path || normalizedInitialCollections;
+    resolveEntryAbsolute(assetSelection) ||
+    normalizedInitialAssetAbsolute ||
+    (isSettingsMode ? normalizeFsPath(currentAbsolute) : '');
+  const resolvedCollectionsPath =
+    resolveEntryAbsolute(collectionsSelection) || normalizedInitialCollectionsAbsolute;
   const requireAsset = settingsIntent !== 'collections';
   const requireCollections = settingsIntent === 'collections';
   const canConfirmSettings =
@@ -334,11 +391,15 @@ function FolderFinderModal({
       const payload = {};
       if (requireAsset) {
         payload.assetPath = resolvedAssetPath;
-      } else if (assetSelection?.path) {
-        payload.assetPath = assetSelection.path;
+      } else {
+        const optionalAsset = resolveEntryAbsolute(assetSelection);
+        if (optionalAsset) {
+          payload.assetPath = optionalAsset;
+        }
       }
-      if (collectionsSelection?.path) {
-        payload.collectionsPath = collectionsSelection.path;
+      const collectionsAbsolute = resolveEntryAbsolute(collectionsSelection);
+      if (collectionsAbsolute) {
+        payload.collectionsPath = collectionsAbsolute;
       } else if (requireCollections && resolvedCollectionsPath) {
         payload.collectionsPath = resolvedCollectionsPath;
       }

--- a/frontend/src/components/__tests__/FolderFinderModal.test.jsx
+++ b/frontend/src/components/__tests__/FolderFinderModal.test.jsx
@@ -8,10 +8,17 @@ describe('FolderFinderModal - settings mode', () => {
       ok: true,
       json: () =>
         Promise.resolve({
+          root: '/assets',
           parent: '',
+          parentAbsolute: '/assets',
           items: [
-            { name: 'Assets', path: 'Assets', isDir: true },
-            { name: 'Collections', path: 'Collections', isDir: true },
+            { name: 'Assets', path: 'Assets', absolutePath: '/assets/Assets', isDir: true },
+            {
+              name: 'Collections',
+              path: 'Collections',
+              absolutePath: '/assets/Collections',
+              isDir: true,
+            },
           ],
         }),
     });
@@ -45,7 +52,7 @@ describe('FolderFinderModal - settings mode', () => {
 
     await waitFor(() => {
       expect(onSettingsConfirm).toHaveBeenCalledWith(
-        { assetPath: 'Assets' },
+        { assetPath: '/assets/Assets' },
         expect.objectContaining({ assetSelection: expect.any(Object) })
       );
     });
@@ -56,11 +63,17 @@ describe('FolderFinderModal - settings mode', () => {
 
     const payloads = {
       '': {
+        root: '/assets',
         parent: '',
-        items: [{ name: 'Kids TV', path: 'Kids TV', isDir: true }],
+        parentAbsolute: '/assets',
+        items: [
+          { name: 'Kids TV', path: 'Kids TV', absolutePath: '/assets/Kids TV', isDir: true },
+        ],
       },
       'Kids TV': {
+        root: '/assets',
         parent: 'Kids TV',
+        parentAbsolute: '/assets/Kids TV',
         items: [],
       },
     };
@@ -110,7 +123,7 @@ describe('FolderFinderModal - settings mode', () => {
 
     await waitFor(() => {
       expect(onSettingsConfirm).toHaveBeenCalledWith(
-        { assetPath: 'Kids TV' },
+        { assetPath: '/assets/Kids TV' },
         expect.objectContaining({ assetSelection: null, collectionsSelection: null })
       );
     });
@@ -147,7 +160,7 @@ describe('FolderFinderModal - settings mode', () => {
 
     await waitFor(() => {
       expect(onSettingsConfirm).toHaveBeenCalledWith(
-        { assetPath: 'Assets', collectionsPath: 'Collections' },
+        { assetPath: '/assets/Assets', collectionsPath: '/assets/Collections' },
         expect.objectContaining({
           assetSelection: expect.any(Object),
           collectionsSelection: expect.any(Object),
@@ -164,26 +177,57 @@ describe('FolderFinderModal - settings mode', () => {
       });
 
     const payloads = {
-      '': { parent: '', items: [
-        { name: 'Movies', path: 'Movies', isDir: true },
-        { name: 'LooseAssets', path: 'LooseAssets', isDir: true },
-      ] },
-      '/assets/Movies/Featured': {
-        parent: 'Movies/Featured',
+      '': {
+        root: '/assets',
+        parent: '',
+        parentAbsolute: '/assets',
         items: [
-          { name: 'Posters', path: 'Movies/Featured/Posters', isDir: true },
+          { name: 'Movies', path: 'Movies', absolutePath: '/assets/Movies', isDir: true },
+          {
+            name: 'LooseAssets',
+            path: 'LooseAssets',
+            absolutePath: '/assets/LooseAssets',
+            isDir: true,
+          },
+        ],
+      },
+      '/assets/Movies/Featured': {
+        root: '/assets',
+        parent: 'Movies/Featured',
+        parentAbsolute: '/assets/Movies/Featured',
+        items: [
+          {
+            name: 'Posters',
+            path: 'Movies/Featured/Posters',
+            absolutePath: '/assets/Movies/Featured/Posters',
+            isDir: true,
+          },
         ],
       },
       'Movies/Featured': {
+        root: '/assets',
         parent: 'Movies/Featured',
+        parentAbsolute: '/assets/Movies/Featured',
         items: [
-          { name: 'Posters', path: 'Movies/Featured/Posters', isDir: true },
+          {
+            name: 'Posters',
+            path: 'Movies/Featured/Posters',
+            absolutePath: '/assets/Movies/Featured/Posters',
+            isDir: true,
+          },
         ],
       },
       Movies: {
+        root: '/assets',
         parent: 'Movies',
+        parentAbsolute: '/assets/Movies',
         items: [
-          { name: 'Featured', path: 'Movies/Featured', isDir: true },
+          {
+            name: 'Featured',
+            path: 'Movies/Featured',
+            absolutePath: '/assets/Movies/Featured',
+            isDir: true,
+          },
         ],
       },
     };

--- a/tests/test_libraries_settings_endpoints.py
+++ b/tests/test_libraries_settings_endpoints.py
@@ -307,9 +307,15 @@ def test_asset_folders_unmapped_library(tmp_path, monkeypatch):
     resp = client.get("/api/asset-folders", params={"library": "Documentaries"})
     assert resp.status_code == 200
     data = resp.json()
+    assert data["root"] == str(assets_root)
+    assert data["parent"] == ""
+    assert data["parentAbsolute"] == str(assets_root)
     names = {item["name"] for item in data["items"]}
     assert "LooseAssets" in names
     assert "Movies" in names
+    items_by_name = {item["name"]: item for item in data["items"]}
+    assert items_by_name["LooseAssets"]["absolutePath"] == str(loose)
+    assert items_by_name["Movies"]["absolutePath"] == str(movies_dir)
 
     nested = client.get(
         "/api/asset-folders",
@@ -317,8 +323,13 @@ def test_asset_folders_unmapped_library(tmp_path, monkeypatch):
     )
     assert nested.status_code == 200
     nested_data = nested.json()
+    assert nested_data["root"] == str(assets_root)
+    assert nested_data["parent"] == "LooseAssets"
+    assert nested_data["parentAbsolute"] == str(loose)
     nested_names = {item["name"] for item in nested_data["items"]}
     assert "Clips" in nested_names
+    nested_items = {item["name"]: item for item in nested_data["items"]}
+    assert nested_items["Clips"]["absolutePath"] == str(loose / "Clips")
 
     invalid = client.get(
         "/api/asset-folders", params={"library": "Documentaries", "parent": "../"}
@@ -371,8 +382,13 @@ def test_asset_folders_settings_mode_allows_assets_root(tmp_path, monkeypatch):
     restricted = client.get("/api/asset-folders", params={"library": "Movies"})
     assert restricted.status_code == 200
     restricted_data = restricted.json()
+    assert restricted_data["root"] == str(featured_dir)
+    assert restricted_data["parent"] == ""
+    assert restricted_data["parentAbsolute"] == str(featured_dir)
     restricted_names = {item["name"] for item in restricted_data["items"]}
     assert restricted_names == {"Posters"}
+    restricted_item = restricted_data["items"][0]
+    assert restricted_item["absolutePath"] == str(posters_dir)
 
     # Settings browsing exposes the assets root even when a mapping exists
     settings_root = client.get(
@@ -381,8 +397,14 @@ def test_asset_folders_settings_mode_allows_assets_root(tmp_path, monkeypatch):
     )
     assert settings_root.status_code == 200
     root_payload = settings_root.json()
+    assert root_payload["root"] == str(assets_root)
+    assert root_payload["parent"] == ""
+    assert root_payload["parentAbsolute"] == str(assets_root)
     root_names = {item["name"] for item in root_payload["items"]}
     assert {"Movies", "LooseAssets"}.issubset(root_names)
+    root_items = {item["name"]: item for item in root_payload["items"]}
+    assert root_items["Movies"]["absolutePath"] == str(movies_dir)
+    assert root_items["LooseAssets"]["absolutePath"] == str(loose_dir)
 
     # Absolute parent paths resolve relative to the assets root in settings mode
     absolute = client.get(
@@ -396,8 +418,12 @@ def test_asset_folders_settings_mode_allows_assets_root(tmp_path, monkeypatch):
     assert absolute.status_code == 200
     absolute_payload = absolute.json()
     assert absolute_payload["parent"] == "Movies/Featured"
+    assert absolute_payload["root"] == str(assets_root)
+    assert absolute_payload["parentAbsolute"] == str(featured_dir)
     absolute_names = {item["name"] for item in absolute_payload["items"]}
     assert "Posters" in absolute_names
+    absolute_item = absolute_payload["items"][0]
+    assert absolute_item["absolutePath"] == str(posters_dir)
 
     # Relative navigation within settings mode continues to work
     relative = client.get(
@@ -411,8 +437,12 @@ def test_asset_folders_settings_mode_allows_assets_root(tmp_path, monkeypatch):
     assert relative.status_code == 200
     relative_payload = relative.json()
     assert relative_payload["parent"] == "Movies"
+    assert relative_payload["root"] == str(assets_root)
+    assert relative_payload["parentAbsolute"] == str(movies_dir)
     relative_names = {item["name"] for item in relative_payload["items"]}
     assert "Featured" in relative_names
+    relative_item = relative_payload["items"][0]
+    assert relative_item["absolutePath"] == str(featured_dir)
 
     outside = client.get(
         "/api/asset-folders",
@@ -473,8 +503,12 @@ def test_asset_folders_allow_beyond_mapping(tmp_path, monkeypatch):
     assert scoped.status_code == 200
     scoped_payload = scoped.json()
     assert scoped_payload["parent"] == "Movies/Featured"
+    assert scoped_payload["root"] == str(assets_root)
+    assert scoped_payload["parentAbsolute"] == str(featured_dir)
     scoped_names = {item["name"] for item in scoped_payload["items"]}
     assert scoped_names == {"Posters"}
+    scoped_item = scoped_payload["items"][0]
+    assert scoped_item["absolutePath"] == str(posters_dir)
 
     ascended = client.get(
         "/api/asset-folders",
@@ -487,8 +521,12 @@ def test_asset_folders_allow_beyond_mapping(tmp_path, monkeypatch):
     assert ascended.status_code == 200
     ascended_payload = ascended.json()
     assert ascended_payload["parent"] == "Movies"
+    assert ascended_payload["root"] == str(assets_root)
+    assert ascended_payload["parentAbsolute"] == str(movies_dir)
     ascended_names = {item["name"] for item in ascended_payload["items"]}
     assert "Featured" in ascended_names
+    ascended_item = ascended_payload["items"][0]
+    assert ascended_item["absolutePath"] == str(featured_dir)
 
     root_view = client.get(
         "/api/asset-folders",
@@ -501,7 +539,12 @@ def test_asset_folders_allow_beyond_mapping(tmp_path, monkeypatch):
     assert root_view.status_code == 200
     root_payload = root_view.json()
     assert root_payload["parent"] == ""
+    assert root_payload["root"] == str(assets_root)
+    assert root_payload["parentAbsolute"] == str(assets_root)
     root_names = {item["name"] for item in root_payload["items"]}
     assert {"Movies", "LooseAssets"}.issubset(root_names)
+    root_items = {item["name"]: item for item in root_payload["items"]}
+    assert root_items["Movies"]["absolutePath"] == str(movies_dir)
+    assert root_items["LooseAssets"]["absolutePath"] == str(loose_dir)
 
 


### PR DESCRIPTION
## Summary
- include absolute paths and parent metadata in `/api/asset-folders` responses so clients can build full filesystem paths
- update the FolderFinderModal to resolve and submit absolute asset and collections paths when saving library mappings
- adjust frontend and backend tests to exercise the new absolute-path behaviour

## Testing
- pytest
- npm test -- --run *(fails: vitest dependency unavailable in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ed26a12ecc83308103e985cac09261