### PR TITLE
Document exclusions workflow in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ KAM is a small web app that makes Kometa/Plex artwork management painless. It le
 * **Replace** existing `poster.*`, `background.*`, or `SeasonNN.*` in the correct asset folder
 * Keep everything in the **same structure Kometa expects**
 * Provide a simple web UI with a **fallback** image to quickly spot missing artwork
+* Let you **exclude** specific movies, shows, or collections from KAM until you re-include them
 
 ---
 
@@ -157,6 +158,20 @@ COLLECTIONS_ROOT=/assets/Collections
 
 # Plex credentials and library mappings are now configured through the web UI.
 ```
+
+---
+
+## Managing exclusions
+
+Sometimes you may want to temporarily hide a title from KAM—for example, if you are
+still preparing artwork or simply do not want it managed. Any movie, TV show, or
+collection can be excluded directly from its detail page. The item will disappear from
+library searches and lists while excluded.
+
+To re-include an item, visit **Settings → Exclusions**. The page lists every excluded
+item, including its library and type, with a one-click **Include** button that restores
+it immediately. You can also refresh the list from the same screen if you make changes
+from another browser tab.
 
 ---
 

--- a/app/main.py
+++ b/app/main.py
@@ -26,6 +26,7 @@ app.add_middleware(
 from .routers import (
     assets,
     collections,
+    exclusions,
     fileproxy,
     imports,
     items,
@@ -40,6 +41,7 @@ from .routers import (
 app.include_router(libraries.router)
 app.include_router(items.router)
 app.include_router(collections.router)
+app.include_router(exclusions.router)
 app.include_router(upload.router)
 app.include_router(tv.router)
 app.include_router(movie.router)

--- a/app/routers/collections.py
+++ b/app/routers/collections.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, HTTPException, Query
 from math import ceil
 from typing import Optional, List, Dict, Any, Tuple
 from ..services.plex import get_plex
-from ..services import folder_overrides
+from ..services import exclusions, folder_overrides
 from ..services import plex_settings
 from ..services import library_mappings as library_mappings_service
 from ..services.assets import sanitize_name
@@ -275,6 +275,7 @@ def collection(
         "backgroundUrl": background_local,
         "backgroundUrlLocal": background_local,
         "backgroundUrlPlex": background_plex,
+        "excluded": exclusions.is_excluded(library, str(ratingKey)),
     }
 
 

--- a/app/routers/exclusions.py
+++ b/app/routers/exclusions.py
@@ -1,0 +1,79 @@
+"""API endpoints for managing excluded items."""
+from __future__ import annotations
+
+from typing import List, Literal, Optional
+
+from fastapi import APIRouter, HTTPException, Response
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from ..services import exclusions as exclusions_service
+
+router = APIRouter()
+
+
+class ExclusionPayload(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    library: str = Field(..., description="Plex library name")
+    ratingKey: str = Field(..., description="Plex rating key")
+    type: Literal["movie", "show", "collection"]
+    title: Optional[str] = Field(default=None, description="Item title for display")
+    year: Optional[int] = Field(default=None, description="Release year")
+
+    @field_validator("library", mode="before")
+    @classmethod
+    def _validate_library(cls, value: str | None) -> str:
+        if value in (None, ""):
+            raise ValueError("Library is required")
+        text = str(value).strip()
+        if not text:
+            raise ValueError("Library is required")
+        return text
+
+    @field_validator("ratingKey", mode="before")
+    @classmethod
+    def _validate_rating_key(cls, value: str | None) -> str:
+        if value in (None, ""):
+            raise ValueError("ratingKey is required")
+        text = str(value).strip()
+        if not text:
+            raise ValueError("ratingKey is required")
+        return text
+
+    @field_validator("title", mode="before")
+    @classmethod
+    def _normalize_title(cls, value: str | None) -> Optional[str]:
+        if value in (None, ""):
+            return None
+        text = str(value).strip()
+        return text or None
+
+
+class ExclusionResponse(ExclusionPayload):
+    excludedAt: str = Field(description="ISO 8601 timestamp when the exclusion was saved")
+
+
+@router.get("/api/exclusions", response_model=List[ExclusionResponse])
+def get_exclusions() -> List[ExclusionResponse]:
+    entries = exclusions_service.list_exclusions()
+    return [ExclusionResponse(**entry) for entry in entries]
+
+
+@router.post("/api/exclusions", response_model=ExclusionResponse, status_code=201)
+def create_exclusion(payload: ExclusionPayload) -> ExclusionResponse:
+    stored = exclusions_service.add_exclusion(
+        payload.library,
+        payload.ratingKey,
+        payload.type,
+        title=payload.title,
+        year=payload.year,
+    )
+    return ExclusionResponse(**stored)
+
+
+@router.delete("/api/exclusions/{library}/{rating_key}", status_code=204)
+def delete_exclusion(library: str, rating_key: str) -> Response:
+    removed = exclusions_service.remove_exclusion(library, rating_key)
+    if not removed:
+        raise HTTPException(status_code=404, detail="Exclusion not found")
+    return Response(status_code=204)

--- a/app/routers/items.py
+++ b/app/routers/items.py
@@ -6,7 +6,7 @@ import requests
 import xml.etree.ElementTree as ET
 from urllib.parse import quote
 
-from ..services import folder_overrides
+from ..services import exclusions, folder_overrides
 from ..services import plex_settings
 from ..services.resolve import resolve_existing_dir_or_422
 
@@ -194,6 +194,9 @@ def list_items(
     enriched: List[Dict[str, Any]] = []
     not_ready_count = 0
     for it in rows:
+        if exclusions.is_excluded(library, it["ratingKey"]):
+            continue
+
         override = folder_overrides.get_override(library, it["ratingKey"])
 
         folder_name, folder_path = _resolve_override_folder(library, override)

--- a/app/routers/movie.py
+++ b/app/routers/movie.py
@@ -3,7 +3,7 @@ import os
 from typing import Optional, Tuple
 from urllib.parse import quote
 
-from ..services import folder_overrides
+from ..services import exclusions, folder_overrides
 from ..services import plex_settings
 from ..services import library_mappings as library_mappings_service
 from ..services.plex import get_plex
@@ -143,6 +143,7 @@ def movie(library: str = Query(...), ratingKey: int = Query(...)):
         "posterUrlPlex": f"{plex_url}/library/metadata/{int(ratingKey)}/thumb?X-Plex-Token={plex_token}",
         "backgroundUrl": background_url_local,
         "backgroundUrlPlex": f"{plex_url}/library/metadata/{int(ratingKey)}/art?X-Plex-Token={plex_token}",
+        "excluded": exclusions.is_excluded(library, str(ratingKey)),
     }
 
 @router.get("/api/movie", summary="Single movie details (alias)")

--- a/app/routers/tv.py
+++ b/app/routers/tv.py
@@ -6,7 +6,7 @@ import requests
 import xml.etree.ElementTree as ET
 from urllib.parse import quote
 
-from ..services import folder_overrides
+from ..services import exclusions, folder_overrides
 from ..services import plex_settings
 from ..services.resolve import resolve_existing_dir_or_422
 from ..services.sanitize import kometa_sanitize_folder
@@ -207,4 +207,5 @@ def get_show(library: str = Query(...), ratingKey: str = Query(...)):
         "plexPosterUrl": plex_poster_url,
         "plexBackgroundUrl": plex_background_url,
         "seasons": seasons_out,
+        "excluded": exclusions.is_excluded(library, ratingKey),
     }

--- a/app/services/exclusions.py
+++ b/app/services/exclusions.py
@@ -1,0 +1,272 @@
+"""Helpers for persisting per-item exclusion preferences."""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+_LOCK = threading.Lock()
+
+_DEF_BASE = (
+    os.environ.get("KAM_STATE_ROOT")
+    or os.environ.get("KAM_CONFIG_ROOT")
+    or "/data"
+)
+_STORAGE_PATH = os.environ.get("KAM_EXCLUSIONS_PATH") or os.path.join(
+    _DEF_BASE, "exclusions.json"
+)
+
+_VALID_TYPES = {"movie", "show", "collection"}
+
+
+def set_storage_path(path: str) -> None:
+    """Override the JSON persistence path (primarily for tests)."""
+
+    global _STORAGE_PATH
+    _STORAGE_PATH = path
+    logger.debug("Exclusions storage path set to %s", path)
+
+
+def _get_storage_path() -> Path:
+    return Path(_STORAGE_PATH)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _normalize_type(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip().lower()
+    if not text:
+        return None
+    if text in {"series", "tv", "tv show", "television"}:
+        text = "show"
+    if text in {"collection", "collections", "collection set"}:
+        text = "collection"
+    if text not in _VALID_TYPES:
+        return None
+    return text
+
+
+def _normalize_title(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _normalize_year(value: Any) -> Optional[int]:
+    if value in (None, ""):
+        return None
+    try:
+        year = int(str(value).strip())
+    except Exception:
+        return None
+    if year <= 0:
+        return None
+    return year
+
+
+def _normalize_rating_key(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _normalize_library(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _normalize_timestamp(value: Any) -> str:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return _now_iso()
+
+
+def _sanitize_entry(entry: Any) -> Optional[Dict[str, Any]]:
+    if not isinstance(entry, dict):
+        return None
+
+    library = _normalize_library(entry.get("library"))
+    rating_key = _normalize_rating_key(entry.get("ratingKey"))
+    item_type = _normalize_type(entry.get("type"))
+
+    if not library or not rating_key or not item_type:
+        return None
+
+    sanitized: Dict[str, Any] = {
+        "library": library,
+        "ratingKey": rating_key,
+        "type": item_type,
+        "excludedAt": _normalize_timestamp(entry.get("excludedAt")),
+    }
+
+    title = _normalize_title(entry.get("title"))
+    if title:
+        sanitized["title"] = title
+
+    year = _normalize_year(entry.get("year"))
+    if year:
+        sanitized["year"] = year
+
+    return sanitized
+
+
+def _load_locked() -> List[Dict[str, Any]]:
+    path = _get_storage_path()
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return []
+    except Exception as exc:
+        logger.warning("Unable to read exclusions file %s: %s", path, exc)
+        return []
+
+    try:
+        data = json.loads(raw) or []
+    except Exception as exc:
+        logger.warning("Invalid JSON in exclusions file %s: %s", path, exc)
+        return []
+
+    if not isinstance(data, list):
+        return []
+
+    sanitized: List[Dict[str, Any]] = []
+    for entry in data:
+        clean = _sanitize_entry(entry)
+        if clean:
+            sanitized.append(clean)
+    return sanitized
+
+
+def _write_locked(entries: List[Dict[str, Any]]) -> None:
+    path = _get_storage_path()
+    parent = path.parent
+    try:
+        parent.mkdir(parents=True, exist_ok=True)
+    except Exception as exc:
+        logger.warning("Unable to create exclusions parent %s: %s", parent, exc)
+
+    payload = sorted(
+        entries,
+        key=lambda item: (
+            item.get("library", "").lower(),
+            item.get("type", ""),
+            item.get("title", "").lower(),
+            item.get("ratingKey", ""),
+        ),
+    )
+
+    tmp_path = path.with_suffix(".tmp")
+    tmp_path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    tmp_path.replace(path)
+
+
+def list_exclusions() -> List[Dict[str, Any]]:
+    """Return all stored exclusions."""
+
+    with _LOCK:
+        data = _load_locked()
+        return [dict(entry) for entry in data]
+
+
+def is_excluded(library: str, rating_key: str) -> bool:
+    library_norm = _normalize_library(library)
+    rating_norm = _normalize_rating_key(rating_key)
+    if not library_norm or not rating_norm:
+        return False
+
+    with _LOCK:
+        for entry in _load_locked():
+            if entry["library"] == library_norm and entry["ratingKey"] == rating_norm:
+                return True
+    return False
+
+
+def add_exclusion(
+    library: str,
+    rating_key: str,
+    item_type: str,
+    *,
+    title: Optional[str] = None,
+    year: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Store an exclusion and return the persisted payload."""
+
+    library_norm = _normalize_library(library)
+    rating_norm = _normalize_rating_key(rating_key)
+    type_norm = _normalize_type(item_type)
+
+    if not library_norm:
+        raise ValueError("library is required")
+    if not rating_norm:
+        raise ValueError("rating_key is required")
+    if not type_norm:
+        raise ValueError("type must be movie, show, or collection")
+
+    payload = {
+        "library": library_norm,
+        "ratingKey": rating_norm,
+        "type": type_norm,
+        "title": _normalize_title(title),
+        "year": _normalize_year(year),
+        "excludedAt": _now_iso(),
+    }
+
+    # Remove ``None`` values so the JSON stays tidy
+    payload = {k: v for k, v in payload.items() if v is not None}
+
+    with _LOCK:
+        entries = _load_locked()
+        filtered = [
+            entry
+            for entry in entries
+            if not (
+                entry["library"] == library_norm
+                and entry["ratingKey"] == rating_norm
+            )
+        ]
+        filtered.append(payload)
+        _write_locked(filtered)
+
+    logger.debug(
+        "Stored exclusion: library=%s ratingKey=%s type=%s", library_norm, rating_norm, type_norm
+    )
+    return dict(payload)
+
+
+def remove_exclusion(library: str, rating_key: str) -> bool:
+    library_norm = _normalize_library(library)
+    rating_norm = _normalize_rating_key(rating_key)
+    if not library_norm or not rating_norm:
+        return False
+
+    removed = False
+    with _LOCK:
+        entries = _load_locked()
+        filtered: List[Dict[str, Any]] = []
+        for entry in entries:
+            if entry["library"] == library_norm and entry["ratingKey"] == rating_norm:
+                removed = True
+                continue
+            filtered.append(entry)
+        if removed:
+            _write_locked(filtered)
+
+    if removed:
+        logger.debug(
+            "Removed exclusion: library=%s ratingKey=%s", library_norm, rating_norm
+        )
+    return removed

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -764,6 +764,56 @@ main {
   flex: 1 1 auto;
 }
 
+.detail-action-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 6px 14px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--muted);
+  font-weight: 600;
+  font-size: 14px;
+}
+
+.detail-action-button:enabled:hover,
+.detail-action-button:enabled:focus-visible {
+  color: var(--accent);
+  border-color: var(--accent);
+  outline: none;
+}
+
+.detail-action-button--exclude {
+  color: #fca5a5;
+  border-color: rgba(248, 113, 113, 0.6);
+  background: rgba(248, 113, 113, 0.12);
+}
+
+.detail-action-button--exclude:enabled:hover,
+.detail-action-button--exclude:enabled:focus-visible {
+  color: #f87171;
+  border-color: rgba(248, 113, 113, 0.85);
+}
+
+[data-theme='light'] .detail-action-button--exclude {
+  color: #b91c1c;
+  border-color: rgba(248, 113, 113, 0.7);
+  background: rgba(248, 113, 113, 0.18);
+}
+
+.detail-action-button--include {
+  color: var(--accent);
+  border-color: var(--accent);
+  background: rgba(94, 161, 255, 0.14);
+}
+
+.detail-action-button--include:enabled:hover,
+.detail-action-button--include:enabled:focus-visible {
+  background: rgba(94, 161, 255, 0.22);
+}
+
 .detail-status {
   font-size: 14px;
   color: var(--muted);
@@ -1116,6 +1166,75 @@ main {
   margin-top: 4px;
   font-size: 12px;
   color: var(--muted);
+}
+
+.settings-exclusions-toolbar {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.settings-exclusions-toolbar button {
+  min-width: 160px;
+}
+
+.settings-exclusions-empty {
+  border: 1px dashed var(--border);
+  border-radius: 14px;
+  padding: 16px;
+  color: var(--muted);
+  text-align: center;
+}
+
+.settings-exclusions-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.settings-exclusion-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 16px;
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.settings-exclusion-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.settings-exclusion-title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.settings-exclusion-details {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.settings-exclusion-type {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--accent);
+}
+
+.settings-exclusion-include {
+  min-width: 120px;
 }
 
 .settings-libraries-table .collection-suggestions code {

--- a/frontend/src/pages/CollectionDetailPage.jsx
+++ b/frontend/src/pages/CollectionDetailPage.jsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link, useParams, useSearchParams } from 'react-router-dom';
 import ArtworkCard from '../components/ArtworkCard.jsx';
 import { responseErrorMessage, safeJson } from '../utils/api.js';
+import { useTheme } from '../theme/ThemeProvider.jsx';
 
 const MISSING_FOLDER_MESSAGE = 'Create the Kometa collections folder first.';
 
@@ -25,6 +26,8 @@ function CollectionDetailPage() {
   const ratingKey = rawRatingKey ? String(rawRatingKey) : '';
   const sourceLibrary = sourceParam ? String(sourceParam) : '';
 
+  const { excludeItem, includeItem, isItemExcluded, exclusionsLoading } = useTheme();
+
   const [detail, setDetail] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -33,6 +36,7 @@ function CollectionDetailPage() {
     poster: createOperation(),
     background: createOperation(),
   });
+  const [exclusionPending, setExclusionPending] = useState(false);
 
   useEffect(() => {
     setDetail(null);
@@ -112,6 +116,21 @@ function CollectionDetailPage() {
   const folderExists = Boolean(detail?.folderExists);
   const folderName = detail?.folderName || '';
   const effectiveRatingKey = detail?.ratingKey != null ? String(detail.ratingKey) : ratingKey;
+
+  const isExcluded = useMemo(() => {
+    if (detail?.excluded != null) {
+      return Boolean(detail.excluded);
+    }
+    if (!library || !effectiveRatingKey) {
+      return false;
+    }
+    return isItemExcluded(library, effectiveRatingKey);
+  }, [detail, isItemExcluded, library, effectiveRatingKey]);
+
+  const exclusionBusy = exclusionPending || exclusionsLoading;
+
+  const headerTitle = detail?.title || 'Collection Details';
+  const headerYear = detail?.year;
 
   const posterExists = useMemo(() => {
     if (typeof detail?.posterExists === 'boolean') return detail.posterExists;
@@ -239,10 +258,46 @@ function CollectionDetailPage() {
     [folderExists, library, effectiveRatingKey, folderName, detail, fetchDetails, updateOperation]
   );
 
+  const handleExclude = useCallback(async () => {
+    if (!library || !effectiveRatingKey) return;
+    setExclusionPending(true);
+    setStatusMessage('Excluding item…');
+    try {
+      await excludeItem({
+        library,
+        ratingKey: effectiveRatingKey,
+        type: 'collection',
+        title: detail?.title || headerTitle,
+        year: detail?.year,
+      });
+      setDetail((prev) => (prev ? { ...prev, excluded: true } : prev));
+      setStatusMessage('Item excluded. Restore it from Settings → Exclusions.');
+    } catch (err) {
+      const message = err?.message || 'Failed to exclude item.';
+      setStatusMessage(message);
+    } finally {
+      setExclusionPending(false);
+    }
+  }, [library, effectiveRatingKey, excludeItem, detail, headerTitle]);
+
+  const handleInclude = useCallback(async () => {
+    if (!library || !effectiveRatingKey) return;
+    setExclusionPending(true);
+    setStatusMessage('Including item…');
+    try {
+      await includeItem(library, effectiveRatingKey);
+      setDetail((prev) => (prev ? { ...prev, excluded: false } : prev));
+      setStatusMessage('Item included again.');
+    } catch (err) {
+      const message = err?.message || 'Failed to include item.';
+      setStatusMessage(message);
+    } finally {
+      setExclusionPending(false);
+    }
+  }, [library, effectiveRatingKey, includeItem]);
+
   const backLink = library ? `/libraries?lib=${encodeURIComponent(library)}` : '/libraries';
   const folderDisplay = folderName || 'Not assigned';
-  const headerTitle = detail?.title || 'Collection Details';
-  const headerYear = detail?.year;
   const displaySource = detail?.sourceLibrary || sourceLibrary || '';
 
   return (
@@ -255,6 +310,22 @@ function CollectionDetailPage() {
         {headerYear ? <span className="detail-year">({headerYear})</span> : null}
         {displaySource ? <span className="detail-source">• {displaySource}</span> : null}
         <span className="detail-header-gap" aria-hidden="true" />
+        <button
+          type="button"
+          className={`detail-action-button ${
+            isExcluded ? 'detail-action-button--include' : 'detail-action-button--exclude'
+          }`}
+          onClick={isExcluded ? handleInclude : handleExclude}
+          disabled={exclusionBusy || !library || !effectiveRatingKey}
+        >
+          {exclusionBusy
+            ? isExcluded
+              ? 'Including…'
+              : 'Excluding…'
+            : isExcluded
+            ? 'Include item'
+            : 'Exclude item'}
+        </button>
         <Link className="settings-link" to="/settings" aria-label="Open settings">
           <span aria-hidden="true">⚙</span>
         </Link>

--- a/frontend/src/pages/MovieDetailPage.jsx
+++ b/frontend/src/pages/MovieDetailPage.jsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link, useParams, useSearchParams } from 'react-router-dom';
 import ArtworkCard from '../components/ArtworkCard.jsx';
 import { responseErrorMessage, safeJson } from '../utils/api.js';
+import { useTheme } from '../theme/ThemeProvider.jsx';
 
 const MISSING_FOLDER_MESSAGE = 'Create the Kometa asset folder first.';
 
@@ -23,6 +24,7 @@ function MovieDetailPage() {
   const library = rawLibrary ? String(rawLibrary) : '';
   const ratingKey = rawRatingKey ? String(rawRatingKey) : '';
 
+  const { excludeItem, includeItem, isItemExcluded, exclusionsLoading } = useTheme();
 
   const [detail, setDetail] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -32,6 +34,7 @@ function MovieDetailPage() {
     poster: createOperation(),
     background: createOperation(),
   });
+  const [exclusionPending, setExclusionPending] = useState(false);
 
   useEffect(() => {
     setDetail(null);
@@ -106,6 +109,21 @@ function MovieDetailPage() {
   const folderExists = Boolean(detail?.folderExists);
   const folderName = detail?.folderName || '';
   const effectiveRatingKey = detail?.ratingKey != null ? String(detail.ratingKey) : ratingKey;
+
+  const isExcluded = useMemo(() => {
+    if (detail?.excluded != null) {
+      return Boolean(detail.excluded);
+    }
+    if (!library || !effectiveRatingKey) {
+      return false;
+    }
+    return isItemExcluded(library, effectiveRatingKey);
+  }, [detail, isItemExcluded, library, effectiveRatingKey]);
+
+  const exclusionBusy = exclusionPending || exclusionsLoading;
+
+  const headerTitle = detail?.title || 'Movie Details';
+  const headerYear = detail?.year;
 
   const posterExists = useMemo(() => {
     if (typeof detail?.posterExists === 'boolean') return detail.posterExists;
@@ -233,11 +251,46 @@ function MovieDetailPage() {
     [folderExists, library, effectiveRatingKey, folderName, detail, fetchDetails, updateOperation]
   );
 
+  const handleExclude = useCallback(async () => {
+    if (!library || !effectiveRatingKey) return;
+    setExclusionPending(true);
+    setStatusMessage('Excluding item…');
+    try {
+      await excludeItem({
+        library,
+        ratingKey: effectiveRatingKey,
+        type: 'movie',
+        title: detail?.title || headerTitle,
+        year: detail?.year,
+      });
+      setDetail((prev) => (prev ? { ...prev, excluded: true } : prev));
+      setStatusMessage('Item excluded. Restore it from Settings → Exclusions.');
+    } catch (err) {
+      const message = err?.message || 'Failed to exclude item.';
+      setStatusMessage(message);
+    } finally {
+      setExclusionPending(false);
+    }
+  }, [library, effectiveRatingKey, excludeItem, detail, headerTitle]);
+
+  const handleInclude = useCallback(async () => {
+    if (!library || !effectiveRatingKey) return;
+    setExclusionPending(true);
+    setStatusMessage('Including item…');
+    try {
+      await includeItem(library, effectiveRatingKey);
+      setDetail((prev) => (prev ? { ...prev, excluded: false } : prev));
+      setStatusMessage('Item included again.');
+    } catch (err) {
+      const message = err?.message || 'Failed to include item.';
+      setStatusMessage(message);
+    } finally {
+      setExclusionPending(false);
+    }
+  }, [library, effectiveRatingKey, includeItem]);
+
   const backLink = library ? `/libraries?lib=${encodeURIComponent(library)}` : '/libraries';
   const folderDisplay = folderName || 'Not assigned';
-
-  const headerTitle = detail?.title || 'Movie Details';
-  const headerYear = detail?.year;
 
   return (
     <div className="detail-page">
@@ -248,6 +301,22 @@ function MovieDetailPage() {
         <h1>{headerTitle}</h1>
         {headerYear ? <span className="detail-year">({headerYear})</span> : null}
         <span className="detail-header-gap" aria-hidden="true" />
+        <button
+          type="button"
+          className={`detail-action-button ${
+            isExcluded ? 'detail-action-button--include' : 'detail-action-button--exclude'
+          }`}
+          onClick={isExcluded ? handleInclude : handleExclude}
+          disabled={exclusionBusy || !library || !effectiveRatingKey}
+        >
+          {exclusionBusy
+            ? isExcluded
+              ? 'Including…'
+              : 'Excluding…'
+            : isExcluded
+            ? 'Include item'
+            : 'Exclude item'}
+        </button>
         <Link className="settings-link" to="/settings" aria-label="Open settings">
           <span aria-hidden="true">⚙</span>
         </Link>

--- a/frontend/src/pages/SettingsPage.jsx
+++ b/frontend/src/pages/SettingsPage.jsx
@@ -56,16 +56,23 @@ function SettingsPage() {
     refreshLibraries,
     setLibraryMappings,
     getLibraryMapping,
+    exclusions,
+    exclusionsLoading,
+    exclusionsError,
+    refreshExclusions,
+    includeItem,
   } = useTheme();
 
   const [status, setStatus] = useState(null);
   const [selectedLibraries, setSelectedLibraries] = useState([]);
   const [modalState, setModalState] = useState(initialModalState);
+  const [includingKeys, setIncludingKeys] = useState([]);
   const selectAllRef = useRef(null);
   const previousLoadingFlagsRef = useRef({
     loading,
     saving,
     librariesLoading,
+    exclusionsLoading,
   });
 
   const savedPlexUrl = savedSettings?.plexUrl || '';
@@ -85,6 +92,12 @@ function SettingsPage() {
       setStatus({ type: 'error', message: librariesError });
     }
   }, [librariesError]);
+
+  useEffect(() => {
+    if (exclusionsError) {
+      setStatus({ type: 'error', message: exclusionsError });
+    }
+  }, [exclusionsError]);
 
   const showInfoStatus = useCallback(
     (message) => {
@@ -117,11 +130,18 @@ function SettingsPage() {
   }, [librariesLoading, showInfoStatus]);
 
   useEffect(() => {
+    if (exclusionsLoading) {
+      showInfoStatus('Loading exclusions…');
+    }
+  }, [exclusionsLoading, showInfoStatus]);
+
+  useEffect(() => {
     const previous = previousLoadingFlagsRef.current;
     const infoMessages = [
       ['loading', loading, 'Loading settings…'],
       ['saving', saving, 'Saving settings…'],
       ['librariesLoading', librariesLoading, 'Loading Plex libraries…'],
+      ['exclusionsLoading', exclusionsLoading, 'Loading exclusions…'],
     ];
 
     const shouldClearInfo =
@@ -139,11 +159,14 @@ function SettingsPage() {
       loading,
       saving,
       librariesLoading,
+      exclusionsLoading,
     };
-  }, [loading, saving, librariesLoading, status]);
+  }, [loading, saving, librariesLoading, exclusionsLoading, status]);
 
   const busy = loading || saving;
   const combinedBusy = busy || librariesLoading;
+
+  const includingSet = useMemo(() => new Set(includingKeys), [includingKeys]);
 
   const libraryRows = useMemo(() => {
     if (!hasPlexCredentials) {
@@ -309,6 +332,31 @@ function SettingsPage() {
 
   const libraryRowMap = useMemo(() => new Map(libraryRows.map((row) => [row.name, row])), [libraryRows]);
 
+  const exclusionRows = useMemo(() => {
+    return (Array.isArray(exclusions) ? exclusions : []).map((entry) => {
+      const typeValue = typeof entry?.type === 'string' ? entry.type.toLowerCase() : '';
+      const typeLabel =
+        typeValue === 'movie' ? 'Movie' : typeValue === 'show' ? 'TV Show' : 'Collection';
+      const titleParts = [];
+      const titleText = typeof entry?.title === 'string' ? entry.title.trim() : '';
+      if (titleText) {
+        titleParts.push(titleText);
+      }
+      const yearNumber = entry?.year != null ? Number(entry.year) : null;
+      if (Number.isFinite(yearNumber) && yearNumber > 0) {
+        titleParts.push(`(${Math.trunc(yearNumber)})`);
+      }
+      const displayTitle = titleParts.length
+        ? titleParts.join(' ')
+        : titleText || entry?.ratingKey || 'Excluded item';
+      return {
+        ...entry,
+        typeLabel,
+        displayTitle,
+      };
+    });
+  }, [exclusions]);
+
   useEffect(() => {
     if (!selectAllRef.current) return;
     const total = libraryRows.length;
@@ -329,6 +377,13 @@ function SettingsPage() {
       return filtered;
     });
   }, [libraryRows]);
+
+  useEffect(() => {
+    const activeKeys = new Set(
+      exclusionRows.map((row) => `${row.library}:::${row.ratingKey}`)
+    );
+    setIncludingKeys((prev) => prev.filter((key) => activeKeys.has(key)));
+  }, [exclusionRows]);
 
   const mappingsDirty = useMemo(() => {
     if (libraryMappingsDirty != null) {
@@ -398,6 +453,22 @@ function SettingsPage() {
   const closeModal = () => {
     setModalState(initialModalState);
   };
+
+  const markIncluding = useCallback((key, active) => {
+    setIncludingKeys((prev) => {
+      if (active) {
+        if (prev.includes(key)) {
+          return prev;
+        }
+        return [...prev, key];
+      }
+      if (!prev.length) {
+        return prev;
+      }
+      const next = prev.filter((item) => item !== key);
+      return next.length === prev.length ? prev : next;
+    });
+  }, []);
 
   const openModal = (librariesList, intent, defaultTarget, options = {}) => {
     const uniqueNames = Array.from(new Set(librariesList.map((name) => normalizeText(name)).filter(Boolean)));
@@ -653,6 +724,42 @@ function SettingsPage() {
       setStatus({ type: 'error', message: err?.message || 'Failed to refresh libraries.' });
     }
   };
+
+  const handleRefreshExclusions = useCallback(async () => {
+    setStatus(null);
+    try {
+      await refreshExclusions();
+      setStatus({ type: 'success', message: 'Exclusions refreshed.' });
+    } catch (err) {
+      setStatus({
+        type: 'error',
+        message: err?.message || 'Failed to refresh exclusions.',
+      });
+    }
+  }, [refreshExclusions]);
+
+  const handleIncludeExclusion = useCallback(
+    async (entry) => {
+      if (!entry) return;
+      const key = `${entry.library}:::${entry.ratingKey}`;
+      markIncluding(key, true);
+      setStatus(null);
+      try {
+        await includeItem(entry.library, entry.ratingKey);
+        const label = entry.title || entry.displayTitle || entry.ratingKey;
+        setStatus({
+          type: 'success',
+          message: `${label} included again.`,
+        });
+      } catch (err) {
+        const message = err?.message || 'Failed to include item.';
+        setStatus({ type: 'error', message });
+      } finally {
+        markIncluding(key, false);
+      }
+    },
+    [includeItem, markIncluding]
+  );
 
   const performSave = useCallback(async () => {
     if (!isDirty) {
@@ -958,6 +1065,64 @@ function SettingsPage() {
               </table>
             ) : null}
           </div>
+        </section>
+
+        <section className="settings-card">
+          <h2>Exclusions</h2>
+          <p className="settings-description">
+            Items excluded from KAM appear here. Include them to show them again in library views.
+          </p>
+          <div className="settings-exclusions-toolbar">
+            <button
+              type="button"
+              onClick={handleRefreshExclusions}
+              disabled={exclusionsLoading}
+            >
+              {exclusionsLoading ? 'Refreshing…' : 'Refresh exclusions'}
+            </button>
+          </div>
+          {exclusionsLoading ? (
+            <div className="settings-exclusions-empty" role="status">
+              Loading exclusions…
+            </div>
+          ) : exclusionRows.length === 0 ? (
+            <div className="settings-exclusions-empty">
+              No items are currently excluded.
+            </div>
+          ) : (
+            <ul className="settings-exclusions-list">
+              {exclusionRows.map((row) => {
+                const key = `${row.library}:::${row.ratingKey}`;
+                const buttonBusy = includingSet.has(key);
+                return (
+                  <li key={key} className="settings-exclusion-row">
+                    <div className="settings-exclusion-meta">
+                      <div className="settings-exclusion-title">{row.displayTitle}</div>
+                      <div className="settings-exclusion-details">
+                        <span className="settings-exclusion-type">{row.typeLabel}</span>
+                        <span aria-hidden="true">•</span>
+                        <span>{row.library}</span>
+                        {row.year ? (
+                          <>
+                            <span aria-hidden="true">•</span>
+                            <span>{row.year}</span>
+                          </>
+                        ) : null}
+                      </div>
+                    </div>
+                    <button
+                      type="button"
+                      className="btn-secondary settings-exclusion-include"
+                      onClick={() => handleIncludeExclusion(row)}
+                      disabled={buttonBusy || exclusionsLoading}
+                    >
+                      {buttonBusy ? 'Including…' : 'Include'}
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
         </section>
 
         {status ? (

--- a/frontend/src/pages/ShowDetailPage.jsx
+++ b/frontend/src/pages/ShowDetailPage.jsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useParams, useSearchParams } from 'react-router-dom';
 import ArtworkCard from '../components/ArtworkCard.jsx';
 import { responseErrorMessage, safeJson } from '../utils/api.js';
+import { useTheme } from '../theme/ThemeProvider.jsx';
 
 const MISSING_FOLDER_MESSAGE = 'Create the Kometa asset folder first.';
 
@@ -23,6 +24,8 @@ function ShowDetailPage() {
   const library = rawLibrary ? String(rawLibrary) : '';
   const ratingKey = rawRatingKey ? String(rawRatingKey) : '';
 
+  const { excludeItem, includeItem, isItemExcluded, exclusionsLoading } = useTheme();
+
   const [detail, setDetail] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -32,6 +35,7 @@ function ShowDetailPage() {
     background: createOperation(),
     seasons: {},
   });
+  const [exclusionPending, setExclusionPending] = useState(false);
 
   const backgroundInputRef = useRef(null);
 
@@ -151,6 +155,21 @@ function ShowDetailPage() {
   const folderExists = Boolean(detail?.folderExists);
   const folderName = detail?.folderName || '';
   const effectiveRatingKey = detail?.ratingKey != null ? String(detail.ratingKey) : ratingKey;
+
+  const isExcluded = useMemo(() => {
+    if (detail?.excluded != null) {
+      return Boolean(detail.excluded);
+    }
+    if (!library || !effectiveRatingKey) {
+      return false;
+    }
+    return isItemExcluded(library, effectiveRatingKey);
+  }, [detail, isItemExcluded, library, effectiveRatingKey]);
+
+  const exclusionBusy = exclusionPending || exclusionsLoading;
+
+  const headerTitle = detail?.title || 'Show Details';
+  const headerYear = detail?.year;
 
   useEffect(() => {
     if (!folderExists && backgroundInputRef.current) {
@@ -441,10 +460,46 @@ function ShowDetailPage() {
     [folderExists, library, folderName, effectiveRatingKey, fetchDetails, updateSeasonOperation]
   );
 
+  const handleExclude = useCallback(async () => {
+    if (!library || !effectiveRatingKey) return;
+    setExclusionPending(true);
+    setStatusMessage('Excluding item…');
+    try {
+      await excludeItem({
+        library,
+        ratingKey: effectiveRatingKey,
+        type: 'show',
+        title: detail?.title || headerTitle,
+        year: detail?.year,
+      });
+      setDetail((prev) => (prev ? { ...prev, excluded: true } : prev));
+      setStatusMessage('Item excluded. Restore it from Settings → Exclusions.');
+    } catch (err) {
+      const message = err?.message || 'Failed to exclude item.';
+      setStatusMessage(message);
+    } finally {
+      setExclusionPending(false);
+    }
+  }, [library, effectiveRatingKey, excludeItem, detail, headerTitle]);
+
+  const handleInclude = useCallback(async () => {
+    if (!library || !effectiveRatingKey) return;
+    setExclusionPending(true);
+    setStatusMessage('Including item…');
+    try {
+      await includeItem(library, effectiveRatingKey);
+      setDetail((prev) => (prev ? { ...prev, excluded: false } : prev));
+      setStatusMessage('Item included again.');
+    } catch (err) {
+      const message = err?.message || 'Failed to include item.';
+      setStatusMessage(message);
+    } finally {
+      setExclusionPending(false);
+    }
+  }, [library, effectiveRatingKey, includeItem]);
+
   const backLink = library ? `/libraries?lib=${encodeURIComponent(library)}` : '/libraries';
   const folderDisplay = folderName || 'Not assigned';
-  const headerTitle = detail?.title || 'Show Details';
-  const headerYear = detail?.year;
 
   const handleBackgroundUploadClick = () => {
     if (!folderExists || backgroundBusy) return;
@@ -481,6 +536,22 @@ function ShowDetailPage() {
         <h1>{headerTitle}</h1>
         {headerYear ? <span className="detail-year">({headerYear})</span> : null}
         <span className="detail-header-gap" aria-hidden="true" />
+        <button
+          type="button"
+          className={`detail-action-button ${
+            isExcluded ? 'detail-action-button--include' : 'detail-action-button--exclude'
+          }`}
+          onClick={isExcluded ? handleInclude : handleExclude}
+          disabled={exclusionBusy || !library || !effectiveRatingKey}
+        >
+          {exclusionBusy
+            ? isExcluded
+              ? 'Including…'
+              : 'Excluding…'
+            : isExcluded
+            ? 'Include item'
+            : 'Exclude item'}
+        </button>
         <Link className="settings-link" to="/settings" aria-label="Open settings">
           <span aria-hidden="true">⚙</span>
         </Link>

--- a/frontend/src/pages/__tests__/SettingsPage.test.jsx
+++ b/frontend/src/pages/__tests__/SettingsPage.test.jsx
@@ -20,6 +20,7 @@ describe('SettingsPage', () => {
   it('renders plex libraries and enables bulk actions after selection', () => {
     const mockSave = vi.fn().mockResolvedValue({});
     const mockRefresh = vi.fn().mockResolvedValue([]);
+    const mockRefreshExclusions = vi.fn().mockResolvedValue([]);
     useTheme.mockReturnValue({
       theme: 'dark',
       savedTheme: 'dark',
@@ -49,6 +50,13 @@ describe('SettingsPage', () => {
       revertSettings: vi.fn(),
       refreshLibraries: mockRefresh,
       setLibraryMappings: vi.fn(),
+      exclusions: [],
+      exclusionsLoading: false,
+      exclusionsError: null,
+      refreshExclusions: mockRefreshExclusions,
+      includeItem: vi.fn(),
+      excludeItem: vi.fn(),
+      isItemExcluded: vi.fn(() => false),
     });
 
     render(
@@ -98,6 +106,13 @@ describe('SettingsPage', () => {
       revertSettings: vi.fn(),
       refreshLibraries: vi.fn(),
       setLibraryMappings: vi.fn(),
+      exclusions: [],
+      exclusionsLoading: false,
+      exclusionsError: null,
+      refreshExclusions: vi.fn(),
+      includeItem: vi.fn(),
+      excludeItem: vi.fn(),
+      isItemExcluded: vi.fn(() => false),
     });
 
     render(
@@ -111,6 +126,7 @@ describe('SettingsPage', () => {
 
   it('invokes refreshLibraries and reports success when refreshing', async () => {
     const mockRefresh = vi.fn().mockResolvedValue([]);
+    const mockRefreshExclusions = vi.fn().mockResolvedValue([]);
     useTheme.mockReturnValue({
       theme: 'dark',
       savedTheme: 'dark',
@@ -133,6 +149,13 @@ describe('SettingsPage', () => {
       revertSettings: vi.fn(),
       refreshLibraries: mockRefresh,
       setLibraryMappings: vi.fn(),
+      exclusions: [],
+      exclusionsLoading: false,
+      exclusionsError: null,
+      refreshExclusions: mockRefreshExclusions,
+      includeItem: vi.fn(),
+      excludeItem: vi.fn(),
+      isItemExcluded: vi.fn(() => false),
     });
 
     render(
@@ -150,6 +173,7 @@ describe('SettingsPage', () => {
 
   it('prevents refreshing libraries when Plex credentials are missing', async () => {
     const mockRefresh = vi.fn();
+    const mockRefreshExclusions = vi.fn();
     useTheme.mockReturnValue({
       theme: 'dark',
       savedTheme: 'dark',
@@ -174,6 +198,13 @@ describe('SettingsPage', () => {
       revertSettings: vi.fn(),
       refreshLibraries: mockRefresh,
       setLibraryMappings: vi.fn(),
+      exclusions: [],
+      exclusionsLoading: false,
+      exclusionsError: null,
+      refreshExclusions: mockRefreshExclusions,
+      includeItem: vi.fn(),
+      excludeItem: vi.fn(),
+      isItemExcluded: vi.fn(() => false),
     });
 
     render(
@@ -218,6 +249,13 @@ describe('SettingsPage', () => {
       revertSettings: vi.fn(),
       refreshLibraries: vi.fn(),
       setLibraryMappings: vi.fn(),
+      exclusions: [],
+      exclusionsLoading: false,
+      exclusionsError: null,
+      refreshExclusions: vi.fn(),
+      includeItem: vi.fn(),
+      excludeItem: vi.fn(),
+      isItemExcluded: vi.fn(() => false),
     });
 
     render(

--- a/frontend/src/theme/ThemeProvider.jsx
+++ b/frontend/src/theme/ThemeProvider.jsx
@@ -39,6 +39,9 @@ const ThemeContext = createContext({
   settingsDirty: false,
   libraryMappingsDirty: false,
   hasUnsavedChanges: false,
+  exclusions: [],
+  exclusionsLoading: false,
+  exclusionsError: null,
   applyTheme: () => {},
   updateSettings: () => {},
   saveSettings: async () => ({ theme: 'dark', plexUrl: '', plexToken: '' }),
@@ -53,6 +56,10 @@ const ThemeContext = createContext({
   getLibraryMapping: () => null,
   revertLibraryMapping: () => {},
   revertLibraryMappings: () => {},
+  refreshExclusions: async () => [],
+  excludeItem: async () => ({}),
+  includeItem: async () => {},
+  isItemExcluded: () => false,
 });
 
 const normalizeTheme = (value) => (value === 'light' ? 'light' : 'dark');
@@ -131,6 +138,71 @@ const sanitizeSettings = (raw = {}) => {
   };
 };
 
+const normalizeExclusionType = (value) => {
+  if (value == null) return null;
+  const text = String(value).trim().toLowerCase();
+  if (!text) return null;
+  if (['series', 'tv', 'tv show', 'television'].includes(text)) return 'show';
+  if (text.startsWith('collection')) return 'collection';
+  if (text === 'movie' || text === 'show' || text === 'collection') return text;
+  return null;
+};
+
+const normalizeExclusionText = (value) => {
+  if (value == null) return '';
+  const text = String(value).trim();
+  return text;
+};
+
+const normalizeExclusionYear = (value) => {
+  if (value == null) return null;
+  const num = Number(value);
+  if (!Number.isFinite(num)) return null;
+  const intVal = Math.trunc(num);
+  if (intVal <= 0) return null;
+  return intVal;
+};
+
+const sanitizeExclusionEntry = (entry) => {
+  if (!entry || typeof entry !== 'object') return null;
+  const library = normalizeExclusionText(entry.library);
+  const ratingKey = normalizeExclusionText(entry.ratingKey);
+  const type = normalizeExclusionType(entry.type);
+  if (!library || !ratingKey || !type) return null;
+  const title = normalizeExclusionText(entry.title);
+  const year = normalizeExclusionYear(entry.year);
+  const excludedAt = normalizeExclusionText(entry.excludedAt);
+  const result = {
+    library,
+    ratingKey,
+    type,
+  };
+  if (title) result.title = title;
+  if (year) result.year = year;
+  if (excludedAt) result.excludedAt = excludedAt;
+  return result;
+};
+
+const sanitizeExclusions = (raw) => {
+  if (!raw) return [];
+  const entries = Array.isArray(raw) ? raw : [];
+  const sanitized = entries
+    .map((entry) => sanitizeExclusionEntry(entry))
+    .filter(Boolean);
+  sanitized.sort((a, b) => {
+    const libraryCompare = a.library.localeCompare(b.library);
+    if (libraryCompare !== 0) return libraryCompare;
+    const typeCompare = a.type.localeCompare(b.type);
+    if (typeCompare !== 0) return typeCompare;
+    const titleA = a.title || '';
+    const titleB = b.title || '';
+    const titleCompare = titleA.localeCompare(titleB);
+    if (titleCompare !== 0) return titleCompare;
+    return a.ratingKey.localeCompare(b.ratingKey);
+  });
+  return sanitized;
+};
+
 export function ThemeProvider({ children }) {
   const [settings, setSettings] = useState(() => sanitizeSettings());
   const [savedSettings, setSavedSettings] = useState(() => sanitizeSettings());
@@ -140,7 +212,17 @@ export function ThemeProvider({ children }) {
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState(null);
+  const [exclusions, setExclusions] = useState(() => sanitizeExclusions());
+  const [exclusionsLoading, setExclusionsLoading] = useState(false);
+  const [exclusionsError, setExclusionsError] = useState(null);
   const isMountedRef = useRef(true);
+
+  const getExclusionKey = useCallback((libraryName, ratingKeyValue) => {
+    const libraryText = normalizeExclusionText(libraryName);
+    const ratingKeyText = normalizeExclusionText(ratingKeyValue);
+    if (!libraryText || !ratingKeyText) return '';
+    return `${libraryText}:::${ratingKeyText}`;
+  }, []);
 
   const applyLibraryMappingUpdates = useCallback((libraryNames, updates) => {
     const names = Array.isArray(libraryNames) ? libraryNames : [libraryNames];
@@ -199,6 +281,137 @@ export function ThemeProvider({ children }) {
       isMountedRef.current = false;
     };
   }, []);
+
+  const refreshExclusions = useCallback(async () => {
+    if (isMountedRef.current) {
+      setExclusionsLoading(true);
+      setExclusionsError(null);
+    }
+    try {
+      const response = await fetch('/api/exclusions');
+      const data = await safeJson(response);
+      if (!response.ok) {
+        throw new Error(responseErrorMessage(response, data));
+      }
+      const next = sanitizeExclusions(data);
+      if (isMountedRef.current) {
+        setExclusions(next);
+      }
+      return next;
+    } catch (err) {
+      const message = err?.message || 'Failed to load exclusions';
+      if (isMountedRef.current) {
+        setExclusions([]);
+        setExclusionsError(message);
+      }
+      throw new Error(message);
+    } finally {
+      if (isMountedRef.current) {
+        setExclusionsLoading(false);
+      }
+    }
+  }, []);
+
+  const excludeItem = useCallback(
+    async (payload) => {
+      const base = payload && typeof payload === 'object' ? payload : {};
+      const libraryName = normalizeExclusionText(base.library);
+      const ratingKeyValue = normalizeExclusionText(base.ratingKey);
+      const typeValue = normalizeExclusionType(base.type);
+      if (!libraryName || !ratingKeyValue || !typeValue) {
+        throw new Error('Library, rating key, and type are required to exclude an item.');
+      }
+      const body = {
+        library: libraryName,
+        ratingKey: ratingKeyValue,
+        type: typeValue,
+      };
+      const titleValue = normalizeExclusionText(base.title);
+      if (titleValue) {
+        body.title = titleValue;
+      }
+      const yearValue = normalizeExclusionYear(base.year);
+      if (yearValue) {
+        body.year = yearValue;
+      }
+
+      const response = await fetch('/api/exclusions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      const data = await safeJson(response);
+      if (!response.ok) {
+        throw new Error(responseErrorMessage(response, data));
+      }
+
+      const stored = sanitizeExclusionEntry(data) || {
+        library: libraryName,
+        ratingKey: ratingKeyValue,
+        type: typeValue,
+      };
+      if (isMountedRef.current) {
+        setExclusions((prev) => {
+          const list = Array.isArray(prev) ? [...prev] : [];
+          const key = getExclusionKey(libraryName, ratingKeyValue);
+          const index = list.findIndex(
+            (entry) => getExclusionKey(entry.library, entry.ratingKey) === key
+          );
+          if (index >= 0) {
+            list[index] = stored;
+          } else {
+            list.push(stored);
+          }
+          return sanitizeExclusions(list);
+        });
+        setExclusionsError(null);
+      }
+
+      return stored;
+    },
+    [getExclusionKey]
+  );
+
+  const includeItem = useCallback(
+    async (libraryName, ratingKeyValue) => {
+      const libraryText = normalizeExclusionText(libraryName);
+      const ratingKeyText = normalizeExclusionText(ratingKeyValue);
+      if (!libraryText || !ratingKeyText) {
+        throw new Error('Library and rating key are required to include an item.');
+      }
+      const url = `/api/exclusions/${encodeURIComponent(libraryText)}/${encodeURIComponent(
+        ratingKeyText
+      )}`;
+      const response = await fetch(url, { method: 'DELETE' });
+      const data = await safeJson(response);
+      if (!response.ok) {
+        throw new Error(responseErrorMessage(response, data));
+      }
+      if (isMountedRef.current) {
+        setExclusions((prev) => {
+          const list = Array.isArray(prev) ? prev : [];
+          const key = getExclusionKey(libraryText, ratingKeyText);
+          const next = list.filter(
+            (entry) => getExclusionKey(entry.library, entry.ratingKey) !== key
+          );
+          return sanitizeExclusions(next);
+        });
+        setExclusionsError(null);
+      }
+    },
+    [getExclusionKey]
+  );
+
+  const isItemExcluded = useCallback(
+    (libraryName, ratingKeyValue) => {
+      const key = getExclusionKey(libraryName, ratingKeyValue);
+      if (!key) return false;
+      return exclusions.some(
+        (entry) => getExclusionKey(entry.library, entry.ratingKey) === key
+      );
+    },
+    [exclusions, getExclusionKey]
+  );
 
   useEffect(() => {
     if (typeof document === 'undefined') return;
@@ -337,6 +550,10 @@ export function ThemeProvider({ children }) {
   useEffect(() => {
     refreshLibraries().catch(() => {});
   }, [refreshLibraries]);
+
+  useEffect(() => {
+    refreshExclusions().catch(() => {});
+  }, [refreshExclusions]);
 
   const revertSettings = useCallback(() => {
     if (!isMountedRef.current) return;
@@ -478,6 +695,9 @@ export function ThemeProvider({ children }) {
       settingsDirty,
       libraryMappingsDirty,
       hasUnsavedChanges,
+      exclusions,
+      exclusionsLoading,
+      exclusionsError,
       applyTheme,
       updateSettings,
       saveSettings,
@@ -492,6 +712,10 @@ export function ThemeProvider({ children }) {
       getLibraryMapping,
       revertLibraryMapping,
       revertLibraryMappings,
+      refreshExclusions,
+      excludeItem,
+      includeItem,
+      isItemExcluded,
     }),
     [
       settings,
@@ -505,6 +729,9 @@ export function ThemeProvider({ children }) {
       settingsDirty,
       libraryMappingsDirty,
       hasUnsavedChanges,
+      exclusions,
+      exclusionsLoading,
+      exclusionsError,
       applyTheme,
       updateSettings,
       saveSettings,
@@ -519,6 +746,10 @@ export function ThemeProvider({ children }) {
       getLibraryMapping,
       revertLibraryMapping,
       revertLibraryMappings,
+      refreshExclusions,
+      excludeItem,
+      includeItem,
+      isItemExcluded,
     ]
   );
 

--- a/tests/test_exclusions_route.py
+++ b/tests/test_exclusions_route.py
@@ -1,0 +1,54 @@
+import importlib
+
+from fastapi import HTTPException
+
+
+def _reload_modules(tmp_path, monkeypatch):
+    storage_path = tmp_path / "exclusions.json"
+    monkeypatch.setenv("KAM_EXCLUSIONS_PATH", str(storage_path))
+
+    service = importlib.reload(importlib.import_module("app.services.exclusions"))
+    service.set_storage_path(str(storage_path))
+    router = importlib.reload(importlib.import_module("app.routers.exclusions"))
+    return router, service
+
+
+def test_create_list_delete_exclusions(tmp_path, monkeypatch):
+    router, service = _reload_modules(tmp_path, monkeypatch)
+
+    assert router.get_exclusions() == []
+
+    payload = router.ExclusionPayload(
+        library="Movies",
+        ratingKey="500",
+        type="movie",
+        title="Sample Movie",
+        year=2020,
+    )
+
+    created = router.create_exclusion(payload)
+    assert created.library == "Movies"
+    assert created.ratingKey == "500"
+    assert created.type == "movie"
+    assert created.title == "Sample Movie"
+    assert created.year == 2020
+    assert created.excludedAt
+
+    listed = router.get_exclusions()
+    assert len(listed) == 1
+    assert listed[0].library == "Movies"
+
+    response = router.delete_exclusion("Movies", "500")
+    assert response.status_code == 204
+    assert service.list_exclusions() == []
+
+
+def test_delete_missing_exclusion_raises(tmp_path, monkeypatch):
+    router, _ = _reload_modules(tmp_path, monkeypatch)
+
+    try:
+        router.delete_exclusion("Movies", "999")
+    except HTTPException as exc:
+        assert exc.status_code == 404
+    else:
+        raise AssertionError("Expected HTTPException for missing exclusion")

--- a/tests/test_exclusions_service.py
+++ b/tests/test_exclusions_service.py
@@ -1,0 +1,55 @@
+import importlib
+
+
+def test_add_list_and_remove_exclusions(tmp_path, monkeypatch):
+    storage_path = tmp_path / "exclusions.json"
+    monkeypatch.setenv("KAM_EXCLUSIONS_PATH", str(storage_path))
+
+    service = importlib.reload(importlib.import_module("app.services.exclusions"))
+    service.set_storage_path(str(storage_path))
+
+    assert service.list_exclusions() == []
+
+    added = service.add_exclusion(
+        "Movies",
+        "101",
+        "movie",
+        title="Example",
+        year=2024,
+    )
+
+    assert added["library"] == "Movies"
+    assert added["ratingKey"] == "101"
+    assert added["type"] == "movie"
+    assert added["title"] == "Example"
+    assert added["year"] == 2024
+    assert "excludedAt" in added
+
+    again = service.add_exclusion("Movies", "101", "movie", title="Updated")
+    assert again["title"] == "Updated"
+    assert "year" not in again
+
+    listed = service.list_exclusions()
+    assert listed == [again]
+
+    assert service.is_excluded("Movies", "101") is True
+
+    removed = service.remove_exclusion("Movies", "101")
+    assert removed is True
+    assert service.list_exclusions() == []
+    assert service.is_excluded("Movies", "101") is False
+
+
+def test_invalid_exclusion_type_raises(tmp_path, monkeypatch):
+    storage_path = tmp_path / "exclusions.json"
+    monkeypatch.setenv("KAM_EXCLUSIONS_PATH", str(storage_path))
+
+    service = importlib.reload(importlib.import_module("app.services.exclusions"))
+    service.set_storage_path(str(storage_path))
+
+    try:
+        service.add_exclusion("Movies", "303", "invalid")
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("Expected ValueError for invalid exclusion type")

--- a/tests/test_items_route.py
+++ b/tests/test_items_route.py
@@ -1,5 +1,6 @@
 import importlib
 import importlib
+import importlib
 from types import SimpleNamespace
 
 import pytest
@@ -15,9 +16,11 @@ def items_env(tmp_path, monkeypatch):
     (folder / "poster.jpg").write_bytes(b"poster")
 
     overrides_path = tmp_path / "overrides.json"
+    exclusions_path = tmp_path / "exclusions.json"
 
     monkeypatch.setenv("KAM_ASSETS_ROOT", str(assets_root))
     monkeypatch.setenv("KAM_FOLDER_OVERRIDES_PATH", str(overrides_path))
+    monkeypatch.setenv("KAM_EXCLUSIONS_PATH", str(exclusions_path))
 
     settings_module = importlib.reload(importlib.import_module("app.services.settings"))
     settings_module.set_settings_path(str(tmp_path / "settings.json"))
@@ -43,6 +46,9 @@ def items_env(tmp_path, monkeypatch):
 
     folder_overrides = importlib.reload(importlib.import_module("app.services.folder_overrides"))
     folder_overrides.set_storage_path(str(overrides_path))
+
+    exclusions_module = importlib.reload(importlib.import_module("app.services.exclusions"))
+    exclusions_module.set_storage_path(str(exclusions_path))
 
     items_router = importlib.reload(importlib.import_module("app.routers.items"))
 
@@ -85,6 +91,7 @@ def items_env(tmp_path, monkeypatch):
         call=_call,
         folder_overrides=folder_overrides,
         folder=folder,
+        exclusions=exclusions_module,
     )
 
 
@@ -120,3 +127,12 @@ def test_items_route_reports_not_ready_count_and_filters(items_env):
     assert filtered["total_count"] == 1
     assert len(filtered["items"]) == 1
     assert filtered["items"][0]["ratingKey"] == "22"
+
+
+def test_items_route_omits_excluded_items(items_env):
+    items_env.exclusions.add_exclusion("Movies", "22", "movie", title="Needs Assets")
+
+    data = items_env.call()
+
+    keys = {it["ratingKey"] for it in data["items"]}
+    assert "22" not in keys


### PR DESCRIPTION
## Summary
- highlight the new ability to exclude items in the feature list
- document how to exclude and re-include items from the Settings → Exclusions screen

## Testing
- pytest
- npm install *(fails: registry. npmjs.org returns 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68f1325606e08330891ad311b168aa32