### PR TITLE
Persist UI settings to host-mounted config volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,12 +110,14 @@ docker pull ghcr.io/thedinz/kam:latest
 
 ### 2) Run (simple)
 
-Expose KAM on **7171** (mapped to the container's port **8000**) and map your assets:
+Expose KAM on **7171** (mapped to the container's port **8000**) and map your assets
+and configuration storage:
 
 ```bash
 docker run -d \
   --name kam \
   -p 7171:8000 \
+  -v /mnt/user/appdata/kam:/config \
   -v /mnt/user/media/assets:/assets \
   ghcr.io/thedinz/kam:latest
 ```
@@ -134,6 +136,7 @@ services:
     ports:
       - "7171:8000"
     volumes:
+      - /mnt/user/appdata/kam:/config
       - /mnt/user/media/assets:/assets
     restart: unless-stopped
 ```
@@ -161,6 +164,19 @@ COLLECTIONS_ROOT=/assets/Collections
 
 ---
 
+## Persistent configuration
+
+KAM stores UI settings—including Plex credentials, library mappings, and exclusion
+preferences—in `/config/settings.json` inside the container. Bind-mount `/config` to a
+directory on the host (for example, `/mnt/user/appdata/kam`) to persist these values
+across image updates, container recreation, and Unraid upgrades.
+
+> Upgrades from previous versions automatically reuse an existing
+> `/data/settings.json` file if it is present, so your saved settings are retained while
+> migrating to the new `/config` location.
+
+---
+
 ## Managing exclusions
 
 Sometimes you may want to temporarily hide a title from KAM—for example, if you are
@@ -177,7 +193,9 @@ from another browser tab.
 
 ## Unraid setup
 
-Kometa Asset Manager can now be found in the Unraid app store. Simply mount your Kometa asset directory and edit the other easy to understand template variables and GO!
+Kometa Asset Manager can now be found in the Unraid app store. Mount both your Kometa
+asset directory **and** a persistent config directory (e.g., `/mnt/user/appdata/kam ->
+/config`), edit the template variables, and GO!
 
 ---
 

--- a/app/services/settings.py
+++ b/app/services/settings.py
@@ -20,14 +20,47 @@ _DEFAULT_SETTINGS: Dict[str, Any] = {
     "libraryMappings": [],
 }
 
-_DEF_BASE = (
-    os.environ.get("KAM_STATE_ROOT")
-    or os.environ.get("KAM_CONFIG_ROOT")
-    or "/data"
-)
-_STORAGE_PATH = os.environ.get("KAM_SETTINGS_PATH") or os.path.join(
-    _DEF_BASE, "settings.json"
-)
+
+def _iter_default_base_candidates() -> List[str]:
+    """Return a prioritized list of storage roots to consider."""
+
+    raw_candidates = (
+        os.environ.get("KAM_STATE_ROOT"),
+        os.environ.get("KAM_CONFIG_ROOT"),
+        "/config",
+        "/data",
+    )
+    candidates: List[str] = []
+    for value in raw_candidates:
+        if not value:
+            continue
+        normalized = str(value).strip()
+        if normalized:
+            candidates.append(normalized)
+    if not candidates:
+        candidates.append("/config")
+    return candidates
+
+
+def _resolve_initial_storage_path() -> str:
+    """Determine the initial settings storage path with backwards compatibility."""
+
+    env_override = os.environ.get("KAM_SETTINGS_PATH")
+    if env_override and env_override.strip():
+        return env_override
+
+    candidates = _iter_default_base_candidates()
+    filename = "settings.json"
+
+    for base in candidates:
+        candidate_path = os.path.join(base, filename)
+        if os.path.isfile(candidate_path):
+            return candidate_path
+
+    return os.path.join(candidates[0], filename)
+
+
+_STORAGE_PATH = _resolve_initial_storage_path()
 
 _LOCK = threading.Lock()
 

--- a/docker-compose.sample.yml
+++ b/docker-compose.sample.yml
@@ -9,4 +9,5 @@ services:
     env_file:
       - .env
     volumes:
+      - /mnt/user/appdata/kam:/config:rw
       - /mnt/user/media/assets:/assets:rw

--- a/tests/test_settings_storage_path.py
+++ b/tests/test_settings_storage_path.py
@@ -1,0 +1,53 @@
+import importlib
+import os
+from pathlib import Path
+
+import pytest
+
+
+MODULE_NAME = "app.services.settings"
+
+
+@pytest.fixture
+def reload_settings(monkeypatch):
+    """Reload the settings module after mutating environment variables."""
+
+    def _reload():
+        module = importlib.import_module(MODULE_NAME)
+        return importlib.reload(module)
+
+    try:
+        yield _reload
+    finally:
+        module = importlib.import_module(MODULE_NAME)
+        importlib.reload(module)
+
+
+def _clear_env(monkeypatch):
+    for key in ("KAM_SETTINGS_PATH", "KAM_STATE_ROOT", "KAM_CONFIG_ROOT"):
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_default_path_prefers_config_directory(monkeypatch, reload_settings):
+    _clear_env(monkeypatch)
+
+    monkeypatch.setattr(os.path, "isfile", lambda _: False)
+
+    settings_module = reload_settings()
+
+    assert settings_module._get_storage_path() == Path("/config/settings.json")
+
+
+def test_existing_legacy_data_file_is_reused(monkeypatch, reload_settings):
+    _clear_env(monkeypatch)
+
+    monkeypatch.setattr(
+        os.path,
+        "isfile",
+        lambda candidate: Path(candidate) == Path("/data/settings.json"),
+    )
+
+    settings_module = reload_settings()
+
+    assert settings_module._get_storage_path() == Path("/data/settings.json")
+


### PR DESCRIPTION
## Summary
- prefer storing settings under a host-mounted /config directory and fall back to any existing legacy /data file
- add regression tests covering the new storage path selection logic
- document the required /config volume mapping in Docker and Unraid examples

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f13adbb5148330ba2f6fc55fbbb2aa