### PR TITLE
Persist assigned folders into library mappings

### DIFF
--- a/app/routers/assets.py
+++ b/app/routers/assets.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel
 
 from ..services import folder_overrides
 from ..services import library_mappings as library_mappings_service
+from ..services import settings as settings_service
 from ..services.resolve import ASSETS_ROOT, resolve_existing_dir_or_422
 
 router = APIRouter()
@@ -18,6 +19,67 @@ class AssignFolderPayload(BaseModel):
     library: str
     ratingKey: str
     folderName: str
+
+
+def _guess_library_root(library: str, folder_dir: Path) -> Path | None:
+    library_name = (library or "").strip()
+    if not library_name:
+        return None
+
+    library_lower = library_name.casefold()
+
+    try:
+        if folder_dir.name.casefold() == library_lower:
+            return folder_dir
+    except ValueError:
+        return None
+
+    for ancestor in folder_dir.parents:
+        if ancestor.name.casefold() == library_lower:
+            return ancestor
+
+    parent = folder_dir.parent
+    if parent != folder_dir:
+        return parent
+    return None
+
+
+def _ensure_library_mapping(library: str, folder_dir: Path) -> None:
+    if not library or not folder_dir:
+        return
+
+    if library_mappings_service.get_library_entry(library):
+        return
+
+    root = _guess_library_root(library, folder_dir)
+    if not root:
+        return
+
+    normalized = library_mappings_service.normalize_path(str(root))
+    if not normalized:
+        return
+
+    current_mappings = library_mappings_service.load_library_mappings()
+    updated: list[dict] = []
+    library_key = str(library).strip()
+    library_lower = library_key.casefold()
+    replaced = False
+
+    for entry in current_mappings:
+        name = str(entry.get("library") or "").strip()
+        if name.casefold() == library_lower:
+            next_entry = dict(entry)
+            next_entry["library"] = name or library_key
+            next_entry["assetPath"] = normalized
+            updated.append(next_entry)
+            replaced = True
+        else:
+            updated.append(dict(entry))
+
+    if not replaced:
+        updated.append({"library": library_key, "assetPath": normalized})
+
+    settings_service.save_library_mappings(updated)
 
 
 def _library_root(
@@ -226,6 +288,8 @@ def assign_folder(payload: AssignFolderPayload):
     folder_overrides.set_override(payload.library, payload.ratingKey, canonical_folder)
 
     folder_dir = Path(canonical_path)
+    _ensure_library_mapping(payload.library, folder_dir)
+
     poster_exists = (folder_dir / "poster.jpg").is_file()
     background_exists = (folder_dir / "background.jpg").is_file()
 

--- a/tests/test_folder_overrides.py
+++ b/tests/test_folder_overrides.py
@@ -1,9 +1,15 @@
 import importlib
 import json
+import sys
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 from fastapi import HTTPException
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
 
 
 @pytest.fixture
@@ -23,6 +29,9 @@ def overrides_env(tmp_path, monkeypatch):
     loose_dir = assets_root / "LooseAssets"
     loose_dir.mkdir()
     (loose_dir / "Clips").mkdir()
+
+    documentaries_dir = assets_root / "Documentaries"
+    documentaries_folder = documentaries_dir / "Nature Wonders"
 
     overrides_path = tmp_path / "overrides.json"
 
@@ -59,6 +68,9 @@ def overrides_env(tmp_path, monkeypatch):
         movies_dir=movies_dir,
         collections_dir=collections_dir,
         loose_dir=loose_dir,
+        documentaries_dir=documentaries_dir,
+        documentaries_folder=documentaries_folder,
+        settings_module=settings_module,
     )
 
 
@@ -92,6 +104,38 @@ def test_assign_folder_endpoint_persists_override(overrides_env):
     assert result["posterExists"] is True
     assert result["backgroundExists"] is True
     assert fo.get_override("Movies", "9") == overrides_env.movie_folder.name
+
+
+def test_assign_folder_creates_library_mapping_when_missing(overrides_env):
+    router = overrides_env.assets_router
+    settings_module = overrides_env.settings_module
+
+    overrides_env.documentaries_folder.mkdir(parents=True)
+
+    settings_module.save_settings(
+        {
+            "libraryMappings": [
+                {
+                    "library": "Movies",
+                    "assetPath": str(overrides_env.movies_dir),
+                    "collectionsPath": str(overrides_env.collections_dir),
+                }
+            ]
+        }
+    )
+
+    payload = router.AssignFolderPayload(
+        library="Documentaries",
+        ratingKey="55",
+        folderName=overrides_env.documentaries_folder.name,
+    )
+    router.assign_folder(payload)
+
+    stored = settings_module.load_settings()
+    mappings = stored.get("libraryMappings", [])
+    doc_entries = [entry for entry in mappings if entry.get("library") == "Documentaries"]
+    assert doc_entries
+    assert doc_entries[0]["assetPath"] == str(overrides_env.documentaries_dir)
 
 
 def test_list_asset_folders(overrides_env):


### PR DESCRIPTION
## Summary
- persist asset folder assignments by creating library mappings when none exist
- infer the library root from the chosen folder before saving settings
- extend folder override tests to cover mapping persistence

## Testing
- pytest tests/test_folder_overrides.py

------
https://chatgpt.com/codex/tasks/task_e_68f2ab25c6c08330a7ed1068d15b355e