### PR TITLE
Hide excluded collections from listings

### DIFF
--- a/app/routers/collections.py
+++ b/app/routers/collections.py
@@ -353,6 +353,12 @@ def collections(
                     ) = _local_poster_for_title(title, collections_base)
                     asset_ready = folder_exists
 
+                if rk is not None and library_name and exclusions.is_excluded(
+                    library_name, str(rk)
+                ):
+                    # Skip collections that have been explicitly excluded.
+                    continue
+
                 item = {
                     "ratingKey": rk,
                     "library": library_name,

--- a/tests/test_collections_route.py
+++ b/tests/test_collections_route.py
@@ -94,6 +94,10 @@ def collections_env(tmp_path, monkeypatch):
     folder_overrides = importlib.reload(importlib.import_module("app.services.folder_overrides"))
     folder_overrides.set_storage_path(str(overrides_path))
 
+    exclusions_module = importlib.reload(importlib.import_module("app.services.exclusions"))
+    exclusions_path = tmp_path / "exclusions.json"
+    exclusions_module.set_storage_path(str(exclusions_path))
+
     collections_router = importlib.reload(importlib.import_module("app.routers.collections"))
 
     sections = [_DummySection(
@@ -118,6 +122,7 @@ def collections_env(tmp_path, monkeypatch):
         folder_overrides=folder_overrides,
         override_folder=override_folder,
         collections_root=movies_section_root,
+        exclusions=exclusions_module,
     )
 
 
@@ -169,6 +174,10 @@ def collections_env_with_nested_root(tmp_path, monkeypatch):
     folder_overrides = importlib.reload(importlib.import_module("app.services.folder_overrides"))
     folder_overrides.set_storage_path(str(overrides_path))
 
+    exclusions_module = importlib.reload(importlib.import_module("app.services.exclusions"))
+    exclusions_path = tmp_path / "exclusions.json"
+    exclusions_module.set_storage_path(str(exclusions_path))
+
     collections_router = importlib.reload(importlib.import_module("app.routers.collections"))
 
     sections = [_DummySection(
@@ -193,6 +202,7 @@ def collections_env_with_nested_root(tmp_path, monkeypatch):
         folder_overrides=folder_overrides,
         override_folder=override_folder,
         collections_root=nested_root,
+        exclusions=exclusions_module,
     )
 
 
@@ -239,6 +249,10 @@ def collections_env_without_mapping(tmp_path, monkeypatch):
     folder_overrides = importlib.reload(importlib.import_module("app.services.folder_overrides"))
     folder_overrides.set_storage_path(str(overrides_path))
 
+    exclusions_module = importlib.reload(importlib.import_module("app.services.exclusions"))
+    exclusions_path = tmp_path / "exclusions.json"
+    exclusions_module.set_storage_path(str(exclusions_path))
+
     collections_router = importlib.reload(importlib.import_module("app.routers.collections"))
 
     sections = [_DummySection(
@@ -258,7 +272,7 @@ def collections_env_without_mapping(tmp_path, monkeypatch):
         params.update(kwargs)
         return collections_router.collections(**params)
 
-    return SimpleNamespace(call=_call)
+    return SimpleNamespace(call=_call, exclusions=exclusions_module)
 
 
 def test_collections_route_marks_asset_readiness(collections_env):
@@ -285,6 +299,18 @@ def test_collections_route_marks_asset_readiness(collections_env):
     assert yearless["folderName"] == "Franchise Collection"
     assert sanitized["folderName"] == "Mission Impossible Collection"
     assert sanitized["library"] == "Movies"
+
+
+def test_collections_route_omits_excluded_items(collections_env):
+    collections_env.exclusions.add_exclusion("Movies", "1", "collection")
+
+    data = collections_env.call()
+    titles = [item["title"] for item in data["items"]]
+
+    assert "My Cool Collection" not in titles
+    assert data["total_count"] == 3
+    # Not-ready counts should still reflect the remaining entries.
+    assert data["not_ready_count"] == 1
 
 
 def test_collections_route_handles_nested_collections_root(collections_env_with_nested_root):


### PR DESCRIPTION
## Summary
- skip excluded collections when building the collections listing
- ensure collection route fixtures isolate exclusion storage and cover the regression

## Testing
- pytest tests/test_collections_route.py

------
https://chatgpt.com/codex/tasks/task_e_68f78780f188833086b72a0759f6f05a