### PR TITLE
Fix collection exclusions to honor source library

### DIFF
--- a/app/routers/collections.py
+++ b/app/routers/collections.py
@@ -30,6 +30,48 @@ BACKGROUND_FILENAMES = (
     "art.jpg", "art.png", "art.webp", "fanart.jpg", "fanart.png"
 )
 
+
+def _candidate_exclusion_libraries(library: str | None) -> List[str]:
+    """Yield possible library names for exclusion lookups."""
+
+    candidates: List[str] = []
+    primary = (library or "").strip()
+
+    if primary:
+        candidates.append(primary)
+
+    # ``Collections`` used to be stored as the library name when excluding
+    # collection items from the Collections view. Continue checking that alias
+    # for backwards compatibility with existing exclusions.
+    if "Collections" not in candidates:
+        candidates.append("Collections")
+
+    # Preserve the original order for deterministic behaviour while removing
+    # duplicates.
+    deduped: List[str] = []
+    for name in candidates:
+        if name and name not in deduped:
+            deduped.append(name)
+
+    return deduped
+
+
+def _is_collection_excluded(library: str | None, rating_key: Any) -> bool:
+    """Return ``True`` if the given collection should be excluded."""
+
+    if rating_key in (None, ""):
+        return False
+
+    rating_text = str(rating_key).strip()
+    if not rating_text:
+        return False
+
+    for candidate in _candidate_exclusion_libraries(library):
+        if exclusions.is_excluded(candidate, rating_text):
+            return True
+
+    return False
+
 def _first_existing_poster(dir_path: Path) -> Path | None:
     """Return the first existing poster file in the given directory."""
     for name in LOCAL_FILENAMES:
@@ -206,6 +248,7 @@ def collection(
     year = getattr(item, "year", None)
 
     actual_library = sourceLibrary or source or getattr(item, "librarySectionTitle", None) or None
+    exclusion_library = actual_library or library
     collections_base = _collections_root_for_library(actual_library)
 
     poster_plex = None
@@ -275,7 +318,7 @@ def collection(
         "backgroundUrl": background_local,
         "backgroundUrlLocal": background_local,
         "backgroundUrlPlex": background_plex,
-        "excluded": exclusions.is_excluded(library, str(ratingKey)),
+        "excluded": _is_collection_excluded(exclusion_library, ratingKey),
     }
 
 
@@ -353,9 +396,7 @@ def collections(
                     ) = _local_poster_for_title(title, collections_base)
                     asset_ready = folder_exists
 
-                if rk is not None and library_name and exclusions.is_excluded(
-                    library_name, str(rk)
-                ):
+                if _is_collection_excluded(library_name, rk):
                     # Skip collections that have been explicitly excluded.
                     continue
 

--- a/frontend/src/pages/CollectionDetailPage.jsx
+++ b/frontend/src/pages/CollectionDetailPage.jsx
@@ -116,16 +116,22 @@ function CollectionDetailPage() {
   const folderExists = Boolean(detail?.folderExists);
   const folderName = detail?.folderName || '';
   const effectiveRatingKey = detail?.ratingKey != null ? String(detail.ratingKey) : ratingKey;
+  const detailSourceLibrary = detail?.sourceLibrary ? String(detail.sourceLibrary) : '';
+  const exclusionLibrary = useMemo(() => {
+    if (detailSourceLibrary) return detailSourceLibrary;
+    if (sourceLibrary) return sourceLibrary;
+    return library;
+  }, [detailSourceLibrary, sourceLibrary, library]);
 
   const isExcluded = useMemo(() => {
     if (detail?.excluded != null) {
       return Boolean(detail.excluded);
     }
-    if (!library || !effectiveRatingKey) {
+    if (!exclusionLibrary || !effectiveRatingKey) {
       return false;
     }
-    return isItemExcluded(library, effectiveRatingKey);
-  }, [detail, isItemExcluded, library, effectiveRatingKey]);
+    return isItemExcluded(exclusionLibrary, effectiveRatingKey);
+  }, [detail, isItemExcluded, exclusionLibrary, effectiveRatingKey]);
 
   const exclusionBusy = exclusionPending || exclusionsLoading;
 
@@ -259,12 +265,12 @@ function CollectionDetailPage() {
   );
 
   const handleExclude = useCallback(async () => {
-    if (!library || !effectiveRatingKey) return;
+    if (!exclusionLibrary || !effectiveRatingKey) return;
     setExclusionPending(true);
     setStatusMessage('Excluding item…');
     try {
       await excludeItem({
-        library,
+        library: exclusionLibrary,
         ratingKey: effectiveRatingKey,
         type: 'collection',
         title: detail?.title || headerTitle,
@@ -278,14 +284,14 @@ function CollectionDetailPage() {
     } finally {
       setExclusionPending(false);
     }
-  }, [library, effectiveRatingKey, excludeItem, detail, headerTitle]);
+  }, [exclusionLibrary, effectiveRatingKey, excludeItem, detail, headerTitle]);
 
   const handleInclude = useCallback(async () => {
-    if (!library || !effectiveRatingKey) return;
+    if (!exclusionLibrary || !effectiveRatingKey) return;
     setExclusionPending(true);
     setStatusMessage('Including item…');
     try {
-      await includeItem(library, effectiveRatingKey);
+      await includeItem(exclusionLibrary, effectiveRatingKey);
       setDetail((prev) => (prev ? { ...prev, excluded: false } : prev));
       setStatusMessage('Item included again.');
     } catch (err) {
@@ -294,7 +300,7 @@ function CollectionDetailPage() {
     } finally {
       setExclusionPending(false);
     }
-  }, [library, effectiveRatingKey, includeItem]);
+  }, [exclusionLibrary, effectiveRatingKey, includeItem]);
 
   const backLink = library ? `/libraries?lib=${encodeURIComponent(library)}` : '/libraries';
   const folderDisplay = folderName || 'Not assigned';
@@ -316,7 +322,7 @@ function CollectionDetailPage() {
             isExcluded ? 'detail-action-button--include' : 'detail-action-button--exclude'
           }`}
           onClick={isExcluded ? handleInclude : handleExclude}
-          disabled={exclusionBusy || !library || !effectiveRatingKey}
+          disabled={exclusionBusy || !exclusionLibrary || !effectiveRatingKey}
         >
           {exclusionBusy
             ? isExcluded

--- a/tests/test_collections_route.py
+++ b/tests/test_collections_route.py
@@ -2,6 +2,7 @@ import importlib
 import sys
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Optional
 
 import pytest
 
@@ -12,9 +13,20 @@ if str(ROOT) not in sys.path:
 
 
 class _DummyCollection:
-    def __init__(self, title: str, rating_key: int):
+    def __init__(
+        self,
+        title: str,
+        rating_key: int,
+        *,
+        library: Optional[str] = None,
+        year: Optional[int] = None,
+    ):
         self.title = title
         self.ratingKey = rating_key
+        if library is not None:
+            self.librarySectionTitle = library
+        if year is not None:
+            self.year = year
 
 
 class _DummySection:
@@ -37,6 +49,18 @@ class _DummyLibrary:
 class _DummyPlex:
     def __init__(self, sections):
         self.library = _DummyLibrary(sections)
+        self._items = {}
+        for section in sections:
+            for coll in section.collections():
+                try:
+                    key = int(coll.ratingKey)
+                except Exception:
+                    key = coll.ratingKey
+                self._items[key] = coll
+
+    def fetchItem(self, rating_key):
+        key = int(rating_key)
+        return self._items[key]
 
 
 @pytest.fixture
@@ -123,6 +147,7 @@ def collections_env(tmp_path, monkeypatch):
         override_folder=override_folder,
         collections_root=movies_section_root,
         exclusions=exclusions_module,
+        collection=collections_router.collection,
     )
 
 
@@ -311,6 +336,26 @@ def test_collections_route_omits_excluded_items(collections_env):
     assert data["total_count"] == 3
     # Not-ready counts should still reflect the remaining entries.
     assert data["not_ready_count"] == 1
+
+
+def test_collections_route_omits_collections_alias_entries(collections_env):
+    collections_env.exclusions.add_exclusion("Collections", "1", "collection")
+
+    data = collections_env.call()
+    titles = [item["title"] for item in data["items"]]
+
+    assert "My Cool Collection" not in titles
+
+
+def test_collection_detail_uses_source_library_for_exclusions(collections_env):
+    collections_env.exclusions.add_exclusion("Collections", "1", "collection")
+
+    detail = collections_env.collection(
+        library="Collections", ratingKey=1, sourceLibrary="Movies"
+    )
+
+    assert detail["excluded"] is True
+    assert detail["sourceLibrary"] == "Movies"
 
 
 def test_collections_route_handles_nested_collections_root(collections_env_with_nested_root):


### PR DESCRIPTION
## Summary
- ensure collection exclusions honor the source library while keeping compatibility with historic "Collections" entries
- update the Collection detail UI to exclude/include items using the correct source library
- cover the regression with additional collection route tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f78bfdc31c833085f6993af1460bb1