### PR TITLE
Add modal presentation for mass import errors

### DIFF
--- a/frontend/src/components/ImportStatusPanel.jsx
+++ b/frontend/src/components/ImportStatusPanel.jsx
@@ -1,3 +1,5 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
 function formatFailure(entry) {
   if (!entry) return 'Unknown issue';
   const parts = [];
@@ -11,11 +13,70 @@ function formatFailure(entry) {
 }
 
 function ImportStatusPanel({ active, percent, label, errors }) {
-  const hasErrors = Array.isArray(errors) && errors.length > 0;
+  const formattedErrors = useMemo(() => {
+    if (!Array.isArray(errors)) return [];
+    return errors
+      .map((entry) => formatFailure(entry))
+      .filter((text) => typeof text === 'string' && text.trim().length > 0);
+  }, [errors]);
+
+  const hasErrors = formattedErrors.length > 0;
   const clamped = Number.isFinite(percent) ? Math.max(0, Math.min(100, percent)) : 0;
   const classes = ['import-status'];
   if (active) classes.push('is-active');
   if (hasErrors) classes.push('has-errors');
+
+  const [isModalOpen, setModalOpen] = useState(false);
+  const closeButtonRef = useRef(null);
+  const modalId = 'importErrorsDialog';
+
+  const closeModal = useCallback(() => {
+    setModalOpen(false);
+  }, []);
+
+  const openModal = useCallback(() => {
+    if (hasErrors) {
+      setModalOpen(true);
+    }
+  }, [hasErrors]);
+
+  const handleBackdropClick = useCallback(
+    (event) => {
+      if (event.target === event.currentTarget) {
+        closeModal();
+      }
+    },
+    [closeModal],
+  );
+
+  useEffect(() => {
+    if (!hasErrors) {
+      closeModal();
+    }
+  }, [hasErrors, closeModal]);
+
+  useEffect(() => {
+    if (!isModalOpen) return undefined;
+    const handleKeyDown = (event) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        closeModal();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [isModalOpen, closeModal]);
+
+  useEffect(() => {
+    if (isModalOpen && closeButtonRef.current) {
+      closeButtonRef.current.focus();
+    }
+  }, [isModalOpen]);
+
+  const errorCountLabel = useMemo(() => {
+    const count = formattedErrors.length;
+    return `${count} import error${count === 1 ? '' : 's'}`;
+  }, [formattedErrors.length]);
 
   return (
     <div className={classes.join(' ')} aria-live="polite">
@@ -25,9 +86,55 @@ function ImportStatusPanel({ active, percent, label, errors }) {
         </div>
         <span className="progress-label">{label}</span>
       </div>
-      <ul className="error-list">
-        {hasErrors && errors.map((entry, index) => <li key={index}>{formatFailure(entry)}</li>)}
-      </ul>
+      {hasErrors ? (
+        <button
+          type="button"
+          className="error-trigger"
+          onClick={openModal}
+          aria-haspopup="dialog"
+          aria-expanded={isModalOpen}
+          aria-controls={modalId}
+        >
+          View {errorCountLabel}
+        </button>
+      ) : null}
+      {hasErrors && isModalOpen ? (
+        <div className="dialog-backdrop" role="presentation" onClick={handleBackdropClick}>
+          <div
+            className="dialog-panel error-dlg"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="importErrorsHeading"
+            id={modalId}
+          >
+            <div className="dialog-body">
+              <div className="dialog-heading">
+                <h2 id="importErrorsHeading">Import Errors</h2>
+                <button
+                  type="button"
+                  className="dialog-close"
+                  aria-label="Close import errors"
+                  onClick={closeModal}
+                  ref={closeButtonRef}
+                >
+                  ×
+                </button>
+              </div>
+              <p className="import-error-summary">{errorCountLabel}. Scroll to review each item.</p>
+              <ol className="import-error-list">
+                {formattedErrors.map((text, index) => (
+                  <li key={index}>{text}</li>
+                ))}
+              </ol>
+            </div>
+            <div className="actions">
+              <button type="button" onClick={closeModal}>
+                Close
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -222,17 +222,24 @@ a.btn:focus,
   line-height: 1.4;
 }
 
-.import-status .error-list {
-  margin: 0;
-  padding-left: 18px;
+.import-status .error-trigger {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 6px 10px;
+  background: var(--card);
+  color: #ff7a7a;
   font-size: 13px;
   line-height: 1.4;
-  color: #ff7a7a;
-  display: none;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease;
+  text-align: left;
 }
 
-.import-status.has-errors .error-list {
-  display: block;
+.import-status .error-trigger:hover,
+.import-status .error-trigger:focus-visible {
+  border-color: #ff7a7a;
+  background: rgba(255, 122, 122, 0.12);
+  outline: none;
 }
 
 .import-status.has-errors .progress-label {
@@ -507,6 +514,61 @@ main {
 
 .dialog-body {
   padding: 16px;
+}
+
+.dialog-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin: 0 0 12px;
+}
+
+.dialog-heading h2 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.dialog-close {
+  border: none;
+  background: none;
+  color: var(--muted);
+  font-size: 20px;
+  line-height: 1;
+  padding: 4px;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.dialog-close:hover,
+.dialog-close:focus-visible {
+  color: var(--fg);
+  background: var(--border);
+  outline: none;
+}
+
+.error-dlg {
+  max-width: 520px;
+}
+
+.import-error-summary {
+  margin: 0 0 12px;
+  font-size: 14px;
+  color: var(--muted);
+}
+
+.import-error-list {
+  margin: 0;
+  padding-left: 20px;
+  max-height: 320px;
+  overflow-y: auto;
+  font-size: 14px;
+  line-height: 1.45;
+  color: var(--fg);
+}
+
+.import-error-list li + li {
+  margin-top: 8px;
 }
 
 .folder-dlg h2 {


### PR DESCRIPTION
## Summary
- replace the inline import status error list with a button that opens a dialog
- add focus handling, keyboard dismissal, and backdrop click support for the error dialog
- style the dialog and trigger to present errors in a scrollable, closable modal

## Testing
- npm install *(fails: registry returned 403 for @testing-library/jest-dom)*

------
https://chatgpt.com/codex/tasks/task_e_68f7c1896d1c8330acb1a56520f519ea