### PR TITLE
Ensure folder overrides persist alongside exclusions

### DIFF
--- a/app/services/folder_overrides.py
+++ b/app/services/folder_overrides.py
@@ -14,14 +14,50 @@ logger = logging.getLogger(__name__)
 
 _LOCK = threading.Lock()
 
-_DEF_BASE = (
-    os.environ.get("KAM_STATE_ROOT")
-    or os.environ.get("KAM_CONFIG_ROOT")
-    or "/data"
-)
-_STORAGE_PATH = os.environ.get("KAM_FOLDER_OVERRIDES_PATH") or os.path.join(
-    _DEF_BASE, "folder_overrides.json"
-)
+
+def _iter_default_base_candidates() -> list[str]:
+    """Return a prioritized list of directories for storing overrides."""
+
+    raw_candidates = (
+        os.environ.get("KAM_STATE_ROOT"),
+        os.environ.get("KAM_CONFIG_ROOT"),
+        "/config",
+        "/data",
+    )
+
+    candidates: list[str] = []
+    for value in raw_candidates:
+        if not value:
+            continue
+        normalized = str(value).strip()
+        if normalized:
+            candidates.append(normalized)
+
+    if not candidates:
+        candidates.append("/config")
+
+    return candidates
+
+
+def _resolve_initial_storage_path() -> str:
+    """Determine the initial storage path, preferring existing files."""
+
+    env_override = os.environ.get("KAM_FOLDER_OVERRIDES_PATH")
+    if env_override and env_override.strip():
+        return env_override
+
+    filename = "folder_overrides.json"
+    candidates = _iter_default_base_candidates()
+
+    for base in candidates:
+        candidate_path = os.path.join(base, filename)
+        if os.path.isfile(candidate_path):
+            return candidate_path
+
+    return os.path.join(candidates[0], filename)
+
+
+_STORAGE_PATH = _resolve_initial_storage_path()
 
 
 def set_storage_path(path: str) -> None:

--- a/tests/test_folder_overrides.py
+++ b/tests/test_folder_overrides.py
@@ -12,6 +12,47 @@ if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
 
+def _reload_overrides_module():
+    return importlib.reload(importlib.import_module("app.services.folder_overrides"))
+
+
+def test_default_storage_path_prefers_existing_file(tmp_path, monkeypatch):
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    existing = config_dir / "folder_overrides.json"
+    existing.write_text("{}", encoding="utf-8")
+
+    monkeypatch.delenv("KAM_FOLDER_OVERRIDES_PATH", raising=False)
+    monkeypatch.setenv("KAM_STATE_ROOT", str(state_dir))
+    monkeypatch.setenv("KAM_CONFIG_ROOT", str(config_dir))
+
+    module = _reload_overrides_module()
+    assert module._get_storage_path() == existing
+
+
+def test_default_storage_path_defaults_to_first_candidate(tmp_path, monkeypatch):
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+
+    monkeypatch.delenv("KAM_FOLDER_OVERRIDES_PATH", raising=False)
+    monkeypatch.setenv("KAM_STATE_ROOT", str(state_dir))
+    monkeypatch.delenv("KAM_CONFIG_ROOT", raising=False)
+
+    module = _reload_overrides_module()
+    assert module._get_storage_path() == state_dir / "folder_overrides.json"
+
+
+def test_default_storage_path_falls_back_to_config(monkeypatch):
+    monkeypatch.delenv("KAM_FOLDER_OVERRIDES_PATH", raising=False)
+    monkeypatch.delenv("KAM_STATE_ROOT", raising=False)
+    monkeypatch.delenv("KAM_CONFIG_ROOT", raising=False)
+
+    module = _reload_overrides_module()
+    assert str(module._get_storage_path()) == "/config/folder_overrides.json"
+
+
 @pytest.fixture
 def overrides_env(tmp_path, monkeypatch):
     assets_root = tmp_path / "assets"


### PR DESCRIPTION
## Summary
- align the folder override storage path resolution with persistent config/state directories and reuse existing files when present
- add regression tests covering the new default path resolution behaviour

## Testing
- pytest tests/test_folder_overrides.py

------
https://chatgpt.com/codex/tasks/task_e_68f7de4c3e2c83309334976d2d9e8bb0