### PR TITLE
Tighten year-aware folder matching for movie sequels

### DIFF
--- a/app/routers/items.py
+++ b/app/routers/items.py
@@ -89,17 +89,24 @@ def _to_int(x) -> Optional[int]:
 # ---------- Local folder & poster helpers ----------
 
 def _try_existing_asset_folder(
-    library: str, title: Optional[str], year: Optional[int]
+    library: str,
+    title: Optional[str],
+    year: Optional[int],
+    item_type: Optional[str] = None,
 ) -> Tuple[Optional[str], Optional[str]]:
     """
     Use your resolver to find an actual, existing Kometa folder.
-    Try 'Title (Year)' first, then 'Title'. Never create anything.
+    Movies with a Plex year only try 'Title (Year)' automatically. If that
+    cannot be resolved, leave them unmatched instead of guessing from 'Title'.
     """
     if not title:
         return None, None
     candidates: List[str] = []
-    if year: candidates.append(f"{title} ({year})")
-    candidates.append(title)
+    if year:
+        candidates.append(f"{title} ({year})")
+    if not (year and (item_type or "").casefold() == "movie"):
+        candidates.append(title)
+    candidates = list(dict.fromkeys(candidates))
     for cand in candidates:
         try:
             full = resolve_existing_dir_or_422(library, cand)
@@ -193,7 +200,7 @@ def list_items(
         folder_name, folder_path = _resolve_override_folder(library, override)
         if not folder_path:
             auto_name, auto_path = _try_existing_asset_folder(
-                library, it["title"], it["year"]
+                library, it["title"], it["year"], it["type"]
             )
             if auto_name:
                 folder_name = folder_name or auto_name

--- a/app/services/resolve.py
+++ b/app/services/resolve.py
@@ -10,30 +10,50 @@ from . import library_mappings as library_mappings_service
 ASSETS_ROOT = os.environ.get("KAM_ASSETS_ROOT", "/assets")
 
 _ILLEGAL_CTRL = re.compile(r"[\u0000-\u001F]")
+_YEAR_SUFFIX_RE = re.compile(
+    r"^(?P<title>.*?)(?:\s*[\(\[\{]\s*(?P<bracket_year>(?:18|19|20|21)\d{2})\s*[\)\]\}]|\s+(?P<bare_year>(?:18|19|20|21)\d{2}))\s*$"
+)
 
 _STOPWORDS = {"the", "a", "an", "movie", "film"}
 
 
+def _extract_trailing_year(s: str) -> tuple[str, Optional[str]]:
+    """Split a folder/title into title text and a trailing release year."""
+
+    text = unicodedata.normalize("NFKC", str(s or ""))
+    text = _ILLEGAL_CTRL.sub("", text).strip()
+    if not text:
+        return "", None
+
+    match = _YEAR_SUFFIX_RE.match(text)
+    if not match:
+        return text, None
+
+    title = (match.group("title") or "").strip()
+    year = match.group("bracket_year") or match.group("bare_year")
+    if not title or not re.search(r"[0-9A-Za-z]", title):
+        return text, None
+    return title, year
+
+
 def _tokenize_title(s: str) -> tuple[list[str], Optional[str]]:
-    """Return normalized tokens and an optional trailing year."""
+    """Return normalized title tokens and an optional trailing year."""
     if not s:
         return [], None
 
-    normalized = unicodedata.normalize("NFKC", str(s))
-    normalized = _ILLEGAL_CTRL.sub("", normalized)
-    normalized = normalized.casefold()
+    title_part, year = _extract_trailing_year(s)
+    normalized = title_part.casefold()
 
-    tokens = [tok for tok in re.split(r"[^0-9a-z]+", normalized) if tok]
-    tokens = [tok for tok in tokens if tok not in _STOPWORDS]
+    raw_tokens = [tok for tok in re.split(r"[^0-9a-z]+", normalized) if tok]
+    filtered_tokens = [tok for tok in raw_tokens if tok not in _STOPWORDS]
 
-    year: Optional[str] = None
-
-    # Drop a single trailing year token such as "(2023)" so alternate title
-    # suffixes compare on the meaningful words only. Avoid stripping numeric
-    # titles like "1408" entirely by only removing the year when there are
-    # other tokens present.
-    if len(tokens) > 1 and re.fullmatch(r"\d{4}", tokens[-1]):
-        year = tokens.pop()
+    # Stop words help compare titles like "The Super Mario Bros. Movie" with
+    # "Super Mario Bros. (2023)", but they should never erase the whole title
+    # or leave only a sequel number behind.
+    if filtered_tokens and not all(tok.isdigit() for tok in filtered_tokens):
+        tokens = filtered_tokens
+    else:
+        tokens = raw_tokens
 
     return tokens, year
 
@@ -48,55 +68,83 @@ def _normalize(s: str) -> str:
     return "".join(tokens)
 
 
+def _comparison_parts(s: str) -> tuple[str, Optional[str], tuple[str, ...]]:
+    tokens, year = _tokenize_title(s)
+    return "".join(tokens), year, tuple(tokens)
+
+
 def _normalize_with_year(s: str) -> tuple[str, Optional[str]]:
     """Return the normalized comparison key and trailing year (if any)."""
 
-    tokens, year = _tokenize_title(s)
-    return "".join(tokens), year
+    normalized, year, _ = _comparison_parts(s)
+    return normalized, year
+
+
+def _sequel_tokens(tokens: tuple[str, ...]) -> tuple[str, ...]:
+    """Return numeric title tokens such as the 2 in a sequel title."""
+
+    return tuple(tok for tok in tokens if tok.isdigit())
+
+
+def _sequel_tokens_compatible(
+    want_tokens: tuple[str, ...], candidate_tokens: tuple[str, ...]
+) -> bool:
+    return _sequel_tokens(want_tokens) == _sequel_tokens(candidate_tokens)
+
+
+def _year_compatible(want_year: Optional[str], candidate_year: Optional[str]) -> bool:
+    if want_year:
+        return candidate_year == want_year
+    return True
+
 
 def _best_match(candidates, want: str) -> Optional[str]:
-    """Return the candidate whose normalized name equals the normalized target."""
-    want_key, want_year = _normalize_with_year(want)
+    """Return the safest existing folder match for a normalized target."""
+    want_key, want_year, want_tokens = _comparison_parts(want)
     if not want_key:
         return None
 
     normalized_candidates = [
-        (c, *_normalize_with_year(c)) for c in candidates if c
+        (c, *_comparison_parts(c)) for c in candidates if c
     ]
 
-    # 1) Exact normalized+year match first to prevent cross-year collisions.
-    if want_year:
-        for original, normalized, year in normalized_candidates:
-            if normalized == want_key and year and year == want_year:
-                return original
+    def usable(year: Optional[str], tokens: tuple[str, ...]) -> bool:
+        return _year_compatible(want_year, year) and _sequel_tokens_compatible(
+            want_tokens, tokens
+        )
 
-    # 2) Exact normalized match with compatible years.
-    for original, normalized, year in normalized_candidates:
-        if normalized != want_key:
-            continue
-        if want_year and year and year != want_year:
-            continue
-        return original
+    # 1) Exact normalized match, but only when the year and sequel markers are
+    # compatible. If a year-scoped Plex item cannot find the same year on disk,
+    # leave it unmatched instead of borrowing a sibling movie's folder.
+    exact_matches = [
+        original
+        for original, normalized, year, tokens in normalized_candidates
+        if normalized == want_key and usable(year, tokens)
+    ]
+    if len(exact_matches) == 1:
+        return exact_matches[0]
+    if len(exact_matches) > 1:
+        return None
 
-    # relaxed: startswith normalized (helps with extra year suffixes, etc.)
-    for original, normalized, year in normalized_candidates:
-        if not normalized:
-            continue
-        if not (normalized.startswith(want_key) or want_key.startswith(normalized)):
-            continue
-        if want_year and year and year != want_year:
-            continue
-        return original
+    # 2) Relaxed prefix match for legitimate suffixes such as "Extended
+    # Edition", still requiring compatible years and sequel numbers.
+    relaxed_matches = [
+        original
+        for original, normalized, year, tokens in normalized_candidates
+        if normalized
+        and (normalized.startswith(want_key) or want_key.startswith(normalized))
+        and usable(year, tokens)
+    ]
+    if len(relaxed_matches) == 1:
+        return relaxed_matches[0]
+    if len(relaxed_matches) > 1:
+        return None
 
-    # fallback: closest fuzzy match when the similarity is very high
-    best_score = 0.0
-    best_candidate = None
-    best_base_ratio = 0.0
-    best_lengths: tuple[int, int] = (0, 0)
-    for original, normalized, year in normalized_candidates:
-        if not normalized:
-            continue
-        if want_year and year and year != want_year:
+    # 3) Fallback: closest fuzzy match when the similarity is very high and
+    # there is a clear winner.
+    scored_matches: list[tuple[float, str, float, tuple[int, int]]] = []
+    for original, normalized, year, tokens in normalized_candidates:
+        if not normalized or not usable(year, tokens):
             continue
         matcher = SequenceMatcher(a=normalized, b=want_key)
         base_ratio = matcher.ratio()
@@ -117,33 +165,40 @@ def _best_match(candidates, want: str) -> Optional[str]:
             if shorter:
                 score = max(score, window_match.size / len(shorter))
 
-        if score > best_score:
-            best_score = score
-            best_candidate = original
-            best_base_ratio = base_ratio
-            best_lengths = (len_norm, len_want)
+        scored_matches.append((score, original, base_ratio, (len_norm, len_want)))
 
-    # require a conservative minimum similarity to avoid unrelated matches
-    if best_candidate and best_score >= 0.86:
-        len_norm, len_want = best_lengths
-        shorter = min(len_norm, len_want)
-        longer = max(len_norm, len_want)
+    scored_matches.sort(key=lambda item: item[0], reverse=True)
+    if not scored_matches:
+        return None
 
-        # Disallow fuzzy matches for extremely short titles or wildly
-        # different-length strings so "It" does not match
-        # "In association with Marvel".
-        if shorter < 4:
-            return None
-        if longer and shorter and (longer / shorter) > 2.5:
-            return None
+    best_score, best_candidate, best_base_ratio, best_lengths = scored_matches[0]
+    if best_score < 0.86:
+        return None
 
-        # Also require the overall ratio to be reasonably close; this ensures
-        # we only accept near-identical titles.
-        if best_base_ratio < 0.7:
-            return None
+    # Similar candidates mean the resolver is guessing. Surface the item as
+    # unmatched so the user can pair it manually.
+    if len(scored_matches) > 1 and scored_matches[1][0] >= best_score - 0.03:
+        return None
 
-        return best_candidate
-    return None
+    len_norm, len_want = best_lengths
+    shorter = min(len_norm, len_want)
+    longer = max(len_norm, len_want)
+
+    # Disallow fuzzy matches for extremely short titles or wildly
+    # different-length strings so "It" does not match
+    # "In association with Marvel".
+    if shorter < 4:
+        return None
+    if longer and shorter and (longer / shorter) > 2.5:
+        return None
+
+    # Also require the overall ratio to be reasonably close; this ensures
+    # we only accept near-identical titles.
+    if best_base_ratio < 0.7:
+        return None
+
+    return best_candidate
+
 
 def _candidate_bases(library: str) -> Iterable[str]:
     """Yield possible asset roots for *library* in priority order."""

--- a/tests/test_items_folder_matching.py
+++ b/tests/test_items_folder_matching.py
@@ -1,0 +1,49 @@
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app.routers import items
+
+
+def test_movie_with_year_does_not_try_bare_title_fallback(monkeypatch):
+    calls = []
+
+    def fake_resolve(library, folder_name):
+        calls.append((library, folder_name))
+        raise FileNotFoundError(folder_name)
+
+    monkeypatch.setattr(items, "resolve_existing_dir_or_422", fake_resolve)
+
+    folder_name, folder_path = items._try_existing_asset_folder(
+        "Movies", "Movie 2", 2015, "movie"
+    )
+
+    assert (folder_name, folder_path) == (None, None)
+    assert calls == [("Movies", "Movie 2 (2015)")]
+
+
+def test_show_with_year_can_still_try_title_folder(monkeypatch):
+    calls = []
+
+    def fake_resolve(library, folder_name):
+        calls.append((library, folder_name))
+        if folder_name == "Breaking Bad":
+            return "/assets/TV Shows/Breaking Bad"
+        raise FileNotFoundError(folder_name)
+
+    monkeypatch.setattr(items, "resolve_existing_dir_or_422", fake_resolve)
+
+    folder_name, folder_path = items._try_existing_asset_folder(
+        "TV Shows", "Breaking Bad", 2008, "show"
+    )
+
+    assert folder_name == "Breaking Bad"
+    assert folder_path == "/assets/TV Shows/Breaking Bad"
+    assert calls == [
+        ("TV Shows", "Breaking Bad (2008)"),
+        ("TV Shows", "Breaking Bad"),
+    ]

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -177,3 +177,92 @@ def test_resolve_does_not_cross_match_numeric_titles(tmp_path, monkeypatch):
 
     with pytest.raises(FileNotFoundError):
         resolve_module.resolve_existing_dir_or_422(library, target)
+
+
+def test_resolve_matches_sequel_to_same_year_folder(tmp_path, monkeypatch):
+    assets_root = tmp_path / "assets"
+    library = "Movies"
+    original = "Movie (2009)"
+    sequel = "Movie 2 (2015)"
+
+    library_path = assets_root / library
+    library_path.mkdir(parents=True)
+    (library_path / original).mkdir()
+    (library_path / sequel).mkdir()
+
+    monkeypatch.setenv("KAM_ASSETS_ROOT", str(assets_root))
+
+    settings_module = importlib.reload(importlib.import_module("app.services.settings"))
+    settings_module.set_settings_path(str(tmp_path / "settings.json"))
+    settings_module.save_library_mappings([])
+
+    resolve_module = _reload_with_assets_root(str(assets_root))
+
+    resolved = resolve_module.resolve_existing_dir_or_422(library, sequel)
+    assert os.path.basename(resolved) == sequel
+
+
+def test_resolve_does_not_match_sequel_to_original_year(tmp_path, monkeypatch):
+    assets_root = tmp_path / "assets"
+    library = "Movies"
+    target = "Movie 2 (2015)"
+    existing = "Movie (2009)"
+
+    library_path = assets_root / library
+    library_path.mkdir(parents=True)
+    (library_path / existing).mkdir()
+
+    monkeypatch.setenv("KAM_ASSETS_ROOT", str(assets_root))
+
+    settings_module = importlib.reload(importlib.import_module("app.services.settings"))
+    settings_module.set_settings_path(str(tmp_path / "settings.json"))
+    settings_module.save_library_mappings([])
+
+    resolve_module = _reload_with_assets_root(str(assets_root))
+
+    with pytest.raises(FileNotFoundError):
+        resolve_module.resolve_existing_dir_or_422(library, target)
+
+
+def test_resolve_does_not_match_original_to_sequel_year(tmp_path, monkeypatch):
+    assets_root = tmp_path / "assets"
+    library = "Movies"
+    target = "Movie (2009)"
+    existing = "Movie 2 (2015)"
+
+    library_path = assets_root / library
+    library_path.mkdir(parents=True)
+    (library_path / existing).mkdir()
+
+    monkeypatch.setenv("KAM_ASSETS_ROOT", str(assets_root))
+
+    settings_module = importlib.reload(importlib.import_module("app.services.settings"))
+    settings_module.set_settings_path(str(tmp_path / "settings.json"))
+    settings_module.save_library_mappings([])
+
+    resolve_module = _reload_with_assets_root(str(assets_root))
+
+    with pytest.raises(FileNotFoundError):
+        resolve_module.resolve_existing_dir_or_422(library, target)
+
+
+def test_resolve_does_not_match_year_scoped_movie_to_yearless_folder(tmp_path, monkeypatch):
+    assets_root = tmp_path / "assets"
+    library = "Movies"
+    target = "Movie 2 (2015)"
+    existing = "Movie 2"
+
+    library_path = assets_root / library
+    library_path.mkdir(parents=True)
+    (library_path / existing).mkdir()
+
+    monkeypatch.setenv("KAM_ASSETS_ROOT", str(assets_root))
+
+    settings_module = importlib.reload(importlib.import_module("app.services.settings"))
+    settings_module.set_settings_path(str(tmp_path / "settings.json"))
+    settings_module.save_library_mappings([])
+
+    resolve_module = _reload_with_assets_root(str(assets_root))
+
+    with pytest.raises(FileNotFoundError):
+        resolve_module.resolve_existing_dir_or_422(library, target)


### PR DESCRIPTION
## Summary
- require year-compatible normalized/fuzzy folder matches when the Plex item includes a year
- preserve numeric sequel markers during matching so originals and sequels do not cross-pair
- stop movie auto-pairing from falling back to bare title lookup when a year-specific folder is missing
- add regressions for original/sequel/year mismatch cases and movie/show fallback behavior

## Validation
- `python -m py_compile app/services/resolve.py app/routers/items.py tests/test_resolve.py tests/test_items_folder_matching.py`
- ran a no-dependency validation script covering the new sequel/year resolver cases and item auto-pair fallback behavior

Note: retargeted to `dev` per repo workflow. The local bundled Python did not include `pytest`, so I could not run the pytest command directly in this workspace.